### PR TITLE
fix: disable clint during javadoc attachment

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -345,6 +345,9 @@ SOFTWARE.
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-javadoc-plugin</artifactId>
             <version>3.5.0</version>
+            <configuration>
+              <doclint>none</doclint>
+            </configuration>
             <executions>
               <execution>
                 <id>attach-javadocs</id>


### PR DESCRIPTION
fix: disable `clint` during javadoc attachment