### PR TITLE
feat(#112): Handle annotations correctly

### DIFF
--- a/src/it/all-have-production-class/src/test/java/SuppressedAnnotation.java
+++ b/src/it/all-have-production-class/src/test/java/SuppressedAnnotation.java
@@ -21,11 +21,13 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 
 @Target(ElementType.TYPE)
 @Retention(RetentionPolicy.RUNTIME)
-@ActiveProfiles("test")
-@SpringBootTest
 @SuppressWarnings("JTCOP.RuleAllTestsHaveProductionClass")
-public @interface TestWithSpringContext {
+public @interface SuppressedAnnotation {
 }

--- a/src/it/all-have-production-class/src/test/java/SuppressedInterface.java
+++ b/src/it/all-have-production-class/src/test/java/SuppressedInterface.java
@@ -21,13 +21,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-String log = new File(basedir, 'build.log').text;
-[
-  'Test CorrectTest.java doesn\'t have corresponding production class.',
-].each { assert log.contains(it): "Log doesn't contain ['$it']" }
-[
-  'SuppressedTest.java',
-  'SuppressedInterface.java',
-  'SuppressedAnnotation.java',
-].each { assert !log.contains(it): "Log contains ['$it']" }
-true
+
+@SuppressWarnings("JTCOP.RuleAllTestsHaveProductionClass")
+public interface SuppressedInterface {
+}

--- a/src/it/all-have-production-class/src/test/java/TestWithSpringContext.java
+++ b/src/it/all-have-production-class/src/test/java/TestWithSpringContext.java
@@ -21,12 +21,11 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-String log = new File(basedir, 'build.log').text;
-[
-  'Test CorrectTest.java doesn\'t have corresponding production class.',
-].each { assert log.contains(it): "Log doesn't contain ['$it']" }
-[
-  'SuppressedTest.java',
-  'TestWithSpringContext',
-].each { assert !log.contains(it): "Log contains ['$it']" }
-true
+
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@ActiveProfiles("test")
+@SpringBootTest
+@SuppressWarnings("JTCOP.RuleAllTestsHaveProductionClass")
+public @interface TestWithSpringContext {
+}

--- a/src/main/java/com/github/lombrozo/testnames/javaparser/TestClassJavaParser.java
+++ b/src/main/java/com/github/lombrozo/testnames/javaparser/TestClassJavaParser.java
@@ -28,8 +28,8 @@ import com.github.javaparser.ParseProblemException;
 import com.github.javaparser.StaticJavaParser;
 import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.Node;
-import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
 import com.github.javaparser.ast.body.MethodDeclaration;
+import com.github.javaparser.ast.body.TypeDeclaration;
 import com.github.javaparser.ast.expr.Expression;
 import com.github.javaparser.ast.expr.SingleMemberAnnotationExpr;
 import com.github.javaparser.ast.expr.StringLiteralExpr;
@@ -192,7 +192,7 @@ public final class TestClassJavaParser implements TestClass {
      * @return Stream of test cases.
      */
     private Stream<TestCaseJavaParser> testCases(final Node node) {
-        return ((NodeWithMembers<ClassOrInterfaceDeclaration>) node)
+        return ((NodeWithMembers<TypeDeclaration<?>>) node)
             .getMethods()
             .stream()
             .filter(TestClassJavaParser::isTest)
@@ -210,7 +210,7 @@ public final class TestClassJavaParser implements TestClass {
      * @return True if test class.
      */
     private static boolean isTestClass(final Node node) {
-        return node instanceof ClassOrInterfaceDeclaration;
+        return node instanceof TypeDeclaration<?>;
     }
 
     /**

--- a/src/test/java/com/github/lombrozo/testnames/javaparser/TestClassJavaParserTest.java
+++ b/src/test/java/com/github/lombrozo/testnames/javaparser/TestClassJavaParserTest.java
@@ -142,4 +142,24 @@ final class TestClassJavaParserTest {
         );
     }
 
+    @Test
+    void parsesAnnotationWithSuppressedRules(@TempDir final Path path) throws Exception {
+        final Collection<String> all = new TestClassJavaParser(
+            path,
+            new ResourceOf("SuppressedAnnotation.java").stream()
+        ).suppressed();
+        MatcherAssert.assertThat(all, Matchers.hasSize(1));
+        MatcherAssert.assertThat(all, Matchers.hasItem("RuleAllTestsHaveProductionClass"));
+    }
+
+    @Test
+    void parsesInterfaceWithSuppressedRules(@TempDir final Path path) throws Exception {
+        final Collection<String> all = new TestClassJavaParser(
+            path,
+            new ResourceOf("SuppressedInterface.java").stream()
+        ).suppressed();
+        MatcherAssert.assertThat(all, Matchers.hasSize(1));
+        MatcherAssert.assertThat(all, Matchers.hasItem("RuleAllTestsHaveProductionClass"));
+    }
+
 }

--- a/src/test/resources/SuppressedAnnotation.java
+++ b/src/test/resources/SuppressedAnnotation.java
@@ -22,10 +22,13 @@
  * SOFTWARE.
  */
 
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
 @Target(ElementType.TYPE)
 @Retention(RetentionPolicy.RUNTIME)
-@ActiveProfiles("test")
-@SpringBootTest
 @SuppressWarnings("JTCOP.RuleAllTestsHaveProductionClass")
 public @interface SuppressedAnnotation {
 }

--- a/src/test/resources/SuppressedAnnotation.java
+++ b/src/test/resources/SuppressedAnnotation.java
@@ -21,12 +21,11 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-String log = new File(basedir, 'build.log').text;
-[
-  'Test CorrectTest.java doesn\'t have corresponding production class.',
-].each { assert log.contains(it): "Log doesn't contain ['$it']" }
-[
-  'SuppressedTest.java',
-  'TestWithSpringContext',
-].each { assert !log.contains(it): "Log contains ['$it']" }
-true
+
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@ActiveProfiles("test")
+@SpringBootTest
+@SuppressWarnings("JTCOP.RuleAllTestsHaveProductionClass")
+public @interface SuppressedAnnotation {
+}

--- a/src/test/resources/SuppressedInterface.java
+++ b/src/test/resources/SuppressedInterface.java
@@ -21,13 +21,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-String log = new File(basedir, 'build.log').text;
-[
-  'Test CorrectTest.java doesn\'t have corresponding production class.',
-].each { assert log.contains(it): "Log doesn't contain ['$it']" }
-[
-  'SuppressedTest.java',
-  'SuppressedInterface.java',
-  'SuppressedAnnotation.java',
-].each { assert !log.contains(it): "Log contains ['$it']" }
-true
+
+@SuppressWarnings("JTCOP.RuleAllTestsHaveProductionClass")
+public interface SuppressedInterface {
+}


### PR DESCRIPTION
We skipped annotations during parsing `java` code. Now we handle them the same way as usual classes.

Issue related: #112 