### PR TITLE
feat(#136): Add integration test for exclusions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -141,12 +141,6 @@ SOFTWARE.
       <version>3.9.0</version>
       <scope>provided</scope>
     </dependency>
-    <dependency>
-      <groupId>org.cactoos</groupId>
-      <artifactId>cactoos</artifactId>
-      <version>0.55.0</version>
-      <scope>compile</scope>
-    </dependency>
   </dependencies>
   <build>
     <pluginManagement>

--- a/src/it/exclusions/pom.xml
+++ b/src/it/exclusions/pom.xml
@@ -22,9 +22,7 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.github.volodya-lombrozo</groupId>
   <artifactId>jtcop-it</artifactId>

--- a/src/it/exclusions/pom.xml
+++ b/src/it/exclusions/pom.xml
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+MIT License
+
+Copyright (c) 2022-2023 Volodya
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.github.volodya-lombrozo</groupId>
+  <artifactId>jtcop-it</artifactId>
+  <version>@project.version@</version>
+  <packaging>jar</packaging>
+  <description>Integration test</description>
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
+  </properties>
+  <dependencies>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <version>5.9.3</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
+      <version>5.9.3</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>com.github.volodya-lombrozo</groupId>
+        <artifactId>jtcop-maven-plugin</artifactId>
+        <version>@project.version@</version>
+        <executions>
+          <execution>
+            <id>integration-test</id>
+            <goals>
+              <goal>check</goal>
+            </goals>
+            <configuration>
+              <exclusions>
+                <exclusion>
+                  JTCOP.RuleAllTestsHaveProductionClass
+                </exclusion>
+              </exclusions>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/src/it/exclusions/src/test/java/TestDoesntHaveProductionClass.java
+++ b/src/it/exclusions/src/test/java/TestDoesntHaveProductionClass.java
@@ -1,0 +1,32 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2022-2023 Volodya
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+import org.junit.jupiter.api.Test;
+
+class TestDoesntHaveProductionClass {
+    @Test
+    void creates() {
+    }
+
+}

--- a/src/it/exclusions/verify.groovy
+++ b/src/it/exclusions/verify.groovy
@@ -1,0 +1,26 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2022-2023 Volodya
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+String log = new File(basedir, 'build.log').text;
+log.contains("BUILD SUCCESS")
+true

--- a/src/main/java/com/github/lombrozo/testnames/RuleName.java
+++ b/src/main/java/com/github/lombrozo/testnames/RuleName.java
@@ -1,26 +1,73 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2022-2023 Volodya
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package com.github.lombrozo.testnames;
 
 import java.util.Locale;
 
+/**
+ * Rule name that understands prefix.
+ * @since 0.1.14
+ */
 public class RuleName {
 
+    /**
+     * Prefix for the rule name.
+     */
     private static final String PREFIX = "JTCOP";
 
+    /**
+     * The origin rule name.
+     */
     private final String name;
 
-    public RuleName(String name) {
+    /**
+     * Ctor.
+     * @param name The origin rule name.
+     */
+    public RuleName(final String name) {
         this.name = name;
     }
 
+    /**
+     * Checks if the rule name has prefix.
+     * @return True if the rule name has prefix.
+     */
     public boolean hasPrefix() {
         return this.name.toUpperCase(Locale.ROOT).startsWith(RuleName.PREFIX);
     }
 
+    /**
+     * Retrieves rule name without prefix.
+     * @return Rule name without prefix.
+     */
     public String withoutPrefix() {
+        final String result;
         if (this.hasPrefix()) {
-            return this.name.substring(RuleName.PREFIX.length() + 1);
+            result = this.name.substring(RuleName.PREFIX.length() + 1);
         } else {
-            return this.name;
+            result = this.name;
         }
+        return result;
     }
 }

--- a/src/main/java/com/github/lombrozo/testnames/RuleName.java
+++ b/src/main/java/com/github/lombrozo/testnames/RuleName.java
@@ -1,0 +1,26 @@
+package com.github.lombrozo.testnames;
+
+import java.util.Locale;
+
+public class RuleName {
+
+    private static final String PREFIX = "JTCOP";
+
+    private final String name;
+
+    public RuleName(String name) {
+        this.name = name;
+    }
+
+    public boolean hasPrefix() {
+        return this.name.toUpperCase(Locale.ROOT).startsWith(RuleName.PREFIX);
+    }
+
+    public String withoutPrefix() {
+        if (this.hasPrefix()) {
+            return this.name.substring(RuleName.PREFIX.length() + 1);
+        } else {
+            return this.name;
+        }
+    }
+}

--- a/src/main/java/com/github/lombrozo/testnames/ValidateMojo.java
+++ b/src/main/java/com/github/lombrozo/testnames/ValidateMojo.java
@@ -29,6 +29,7 @@ import com.github.lombrozo.testnames.javaparser.ProjectJavaParser;
 import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.stream.Collectors;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
@@ -74,7 +75,10 @@ public final class ValidateMojo extends AbstractMojo {
             new ProjectJavaParser(
                 Paths.get(this.project.getCompileSourceRoots().get(0)),
                 Paths.get(this.project.getTestCompileSourceRoots().get(0)),
-                Arrays.asList(this.exclusions)
+                Arrays.stream(this.exclusions)
+                    .map(RuleName::new)
+                    .map(RuleName::withoutPrefix)
+                    .collect(Collectors.toSet())
             )
         ).inspection();
         if (!complaints.isEmpty() && this.failOnError) {

--- a/src/main/java/com/github/lombrozo/testnames/ValidateMojo.java
+++ b/src/main/java/com/github/lombrozo/testnames/ValidateMojo.java
@@ -62,9 +62,6 @@ public final class ValidateMojo extends AbstractMojo {
 
     /**
      * The rules that have to be excluded from execution.
-     * @todo #129:90min Add integration tests for ValidateMojo exclusions.
-     *  We have to add integration tests for ValidateMojo exclusions. The integration test
-     *  will check that we don't apply rules that are excluded.
      */
     @Parameter(property = "exclusions")
     private String[] exclusions;

--- a/src/main/java/com/github/lombrozo/testnames/javaparser/SuppressedAnnotations.java
+++ b/src/main/java/com/github/lombrozo/testnames/javaparser/SuppressedAnnotations.java
@@ -29,7 +29,6 @@ import com.github.javaparser.ast.expr.SingleMemberAnnotationExpr;
 import com.github.javaparser.ast.expr.StringLiteralExpr;
 import com.github.javaparser.ast.nodeTypes.NodeWithAnnotations;
 import com.github.lombrozo.testnames.RuleName;
-import java.util.Locale;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -95,14 +94,5 @@ final class SuppressedAnnotations {
             result = Stream.empty();
         }
         return result;
-    }
-
-    /**
-     * Checks whether annotation is related to Jtcop.
-     * @param value Annotation value.
-     * @return True if Jtcop annotation.
-     */
-    private static boolean isJtcopAnnotation(final String value) {
-        return value.toUpperCase(Locale.ROOT).startsWith("JTCOP.");
     }
 }

--- a/src/main/java/com/github/lombrozo/testnames/javaparser/SuppressedAnnotations.java
+++ b/src/main/java/com/github/lombrozo/testnames/javaparser/SuppressedAnnotations.java
@@ -28,6 +28,7 @@ import com.github.javaparser.ast.expr.Expression;
 import com.github.javaparser.ast.expr.SingleMemberAnnotationExpr;
 import com.github.javaparser.ast.expr.StringLiteralExpr;
 import com.github.javaparser.ast.nodeTypes.NodeWithAnnotations;
+import com.github.lombrozo.testnames.RuleName;
 import java.util.Locale;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -64,8 +65,9 @@ final class SuppressedAnnotations {
                 .filter(Expression::isSingleMemberAnnotationExpr)
                 .map(Expression::asSingleMemberAnnotationExpr)
                 .flatMap(SuppressedAnnotations::annotationValue)
-                .filter(SuppressedAnnotations::isJtcopAnnotation)
-                .map(ann -> ann.substring(6))
+                .map(RuleName::new)
+                .filter(RuleName::hasPrefix)
+                .map(RuleName::withoutPrefix)
                 .collect(Collectors.toList()).stream();
         } else {
             result = Stream.empty();


### PR DESCRIPTION
Closes: #136

<!-- start pr-codex -->

---

## PR-Codex overview
This PR removes a dependency on `org.cactoos` and introduces a new `RuleName` class that handles prefixing. It also adds a new `exclusions` parameter to the `ValidateMojo` class and a new integration test module.

### Detailed summary
- Removed dependency on `org.cactoos`
- Added `RuleName` class to handle prefixing
- Added `exclusions` parameter to `ValidateMojo` class
- Added new integration test module.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->