### PR TITLE
chore: release latest releases by default

### DIFF
--- a/.rultor.yml
+++ b/.rultor.yml
@@ -5,6 +5,7 @@ docker:
 merge:
   script: mvn clean install -Pqulice --errors --batch-mode
 release:
+  pre: false
   script: |-
     [[ "${tag}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || exit -1
     mvn versions:set "-DnewVersion=${tag}" "-DprocessPlugins=false"


### PR DESCRIPTION
Rultor releases latest releases by default