### PR TITLE
feat(#67): Assertions messages

### DIFF
--- a/src/main/java/com/github/lombrozo/testnames/Assertion.java
+++ b/src/main/java/com/github/lombrozo/testnames/Assertion.java
@@ -1,6 +1,7 @@
 package com.github.lombrozo.testnames;
 
 import java.util.Optional;
+import java.util.UUID;
 
 /**
  * The assertion of the test method.
@@ -12,5 +13,42 @@ public interface Assertion {
      * @return The assertion message explanation.
      */
     Optional<String> explanation();
+
+
+    /**
+     * Fake assertion.
+     *
+     * @since 0.1.15
+     */
+    class Fake implements Assertion {
+
+        private final String message;
+
+        public Fake() {
+            this(UUID.randomUUID().toString());
+        }
+
+        public Fake(final String msg) {
+            this.message = msg;
+        }
+
+        @Override
+        public Optional<String> explanation() {
+            return Optional.ofNullable(this.message);
+        }
+    }
+
+    /**
+     * Empty assertion.
+     *
+     * @since 0.1.15
+     */
+    class Empty implements Assertion {
+
+        @Override
+        public Optional<String> explanation() {
+            return Optional.empty();
+        }
+    }
 
 }

--- a/src/main/java/com/github/lombrozo/testnames/Assertion.java
+++ b/src/main/java/com/github/lombrozo/testnames/Assertion.java
@@ -1,3 +1,26 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2022-2023 Volodya
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package com.github.lombrozo.testnames;
 
 import java.util.Optional;
@@ -5,6 +28,8 @@ import java.util.UUID;
 
 /**
  * The assertion of the test method.
+ *
+ * @since 0.1.15
  */
 public interface Assertion {
 
@@ -14,7 +39,6 @@ public interface Assertion {
      */
     Optional<String> explanation();
 
-
     /**
      * Fake assertion.
      *
@@ -22,12 +46,22 @@ public interface Assertion {
      */
     class Fake implements Assertion {
 
+        /**
+         * The message.
+         */
         private final String message;
 
+        /**
+         * Ctor.
+         */
         public Fake() {
             this(UUID.randomUUID().toString());
         }
 
+        /**
+         * Ctor.
+         * @param msg The message.
+         */
         public Fake(final String msg) {
             this.message = msg;
         }

--- a/src/main/java/com/github/lombrozo/testnames/Assertion.java
+++ b/src/main/java/com/github/lombrozo/testnames/Assertion.java
@@ -1,0 +1,16 @@
+package com.github.lombrozo.testnames;
+
+import java.util.Optional;
+
+/**
+ * The assertion of the test method.
+ */
+public interface Assertion {
+
+    /**
+     * The assertion message explanation.
+     * @return The assertion message explanation.
+     */
+    Optional<String> explanation();
+
+}

--- a/src/main/java/com/github/lombrozo/testnames/TestCase.java
+++ b/src/main/java/com/github/lombrozo/testnames/TestCase.java
@@ -49,6 +49,12 @@ public interface TestCase {
     Collection<String> suppressed();
 
     /**
+     * The method assertions.
+     * @return The list of assertions.
+     */
+    Collection<Assertion> assertions();
+
+    /**
      * The fake test case.
      *
      * @since 0.1.0
@@ -101,6 +107,11 @@ public interface TestCase {
         @Override
         public Collection<String> suppressed() {
             return Collections.unmodifiableCollection(this.suppressed);
+        }
+
+        @Override
+        public Collection<Assertion> assertions() {
+            return Collections.emptyList();
         }
     }
 }

--- a/src/main/java/com/github/lombrozo/testnames/TestCase.java
+++ b/src/main/java/com/github/lombrozo/testnames/TestCase.java
@@ -24,6 +24,7 @@
 
 package com.github.lombrozo.testnames;
 
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import lombok.Data;
@@ -63,6 +64,11 @@ public interface TestCase {
     final class Fake implements TestCase {
 
         /**
+         * The fake name.
+         */
+        private static final String FAKE_NAME = "FakeCase";
+
+        /**
          * The name of test.
          */
         private final String name;
@@ -72,11 +78,13 @@ public interface TestCase {
          */
         private final Collection<String> suppressed;
 
+        private final Collection<Assertion> assertions;
+
         /**
          * Ctor.
          */
         public Fake() {
-            this("FakeCase");
+            this(Fake.FAKE_NAME);
         }
 
         /**
@@ -91,12 +99,35 @@ public interface TestCase {
 
         /**
          * Ctor.
+         * @param asserts The method assertions.
+         */
+        public Fake(final Assertion... asserts) {
+            this(Fake.FAKE_NAME, Collections.emptyList(), Arrays.asList(asserts));
+        }
+
+        /**
+         * Ctor.
          * @param name The name of test case
          * @param suppressed The suppressed rules
          */
         public Fake(final String name, final Collection<String> suppressed) {
+            this(name, suppressed, Collections.emptyList());
+        }
+
+        /**
+         * Ctor.
+         * @param name The name of test case
+         * @param suppressed The suppressed rules
+         * @param assertions The method assertions
+         */
+        public Fake(
+            final String name,
+            final Collection<String> suppressed,
+            final Collection<Assertion> assertions
+        ) {
             this.name = name;
             this.suppressed = suppressed;
+            this.assertions = assertions;
         }
 
         @Override
@@ -111,7 +142,7 @@ public interface TestCase {
 
         @Override
         public Collection<Assertion> assertions() {
-            return Collections.emptyList();
+            return Collections.unmodifiableCollection(this.assertions);
         }
     }
 }

--- a/src/main/java/com/github/lombrozo/testnames/TestCase.java
+++ b/src/main/java/com/github/lombrozo/testnames/TestCase.java
@@ -78,6 +78,9 @@ public interface TestCase {
          */
         private final Collection<String> suppressed;
 
+        /**
+         * The method assertions.
+         */
         private final Collection<Assertion> assertions;
 
         /**

--- a/src/main/java/com/github/lombrozo/testnames/javaparser/TestCaseJavaParser.java
+++ b/src/main/java/com/github/lombrozo/testnames/javaparser/TestCaseJavaParser.java
@@ -27,9 +27,11 @@ package com.github.lombrozo.testnames.javaparser;
 import com.github.javaparser.ast.NodeList;
 import com.github.javaparser.ast.body.MethodDeclaration;
 import com.github.javaparser.ast.type.VarType;
+import com.github.lombrozo.testnames.Assertion;
 import com.github.lombrozo.testnames.TestCase;
 import com.github.lombrozo.testnames.TestClass;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import lombok.Data;
@@ -38,6 +40,11 @@ import lombok.Data;
  * Parser for test case.
  *
  * @since 0.1.0
+ * @todo #67:90min Continue implementation of TestCaseJavaParser#assertions.
+ *  We have to implement the method assertions() in TestCaseJavaParser.
+ *  The method should return a list of assertions from different libraries like
+ *  Hamcrest, AssertJ, JUnit, etc. Also we have to have a list of tests that check new
+ *  functionality.
  */
 @Data
 final class TestCaseJavaParser implements TestCase {
@@ -95,5 +102,10 @@ final class TestCaseJavaParser implements TestCase {
             this.parent.suppressed().stream(),
             new SuppressedAnnotations(this.method).suppressed()
         ).collect(Collectors.toSet());
+    }
+
+    @Override
+    public Collection<Assertion> assertions() {
+        return Collections.emptyList();
     }
 }

--- a/src/main/java/com/github/lombrozo/testnames/rules/RuleAssertionMessage.java
+++ b/src/main/java/com/github/lombrozo/testnames/rules/RuleAssertionMessage.java
@@ -1,0 +1,118 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2022-2023 Volodya
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.github.lombrozo.testnames.rules;
+
+import com.github.lombrozo.testnames.Assertion;
+import com.github.lombrozo.testnames.Complaint;
+import com.github.lombrozo.testnames.Rule;
+import com.github.lombrozo.testnames.TestCase;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Optional;
+
+/**
+ * The rule that checks that test method has assertion and the assertion message is not empty.
+ */
+class RuleAssertionMessage implements Rule {
+
+    private final TestCase method;
+
+    RuleAssertionMessage(final TestCase test) {
+        this.method = test;
+    }
+
+    @Override
+    public Collection<Complaint> complaints() {
+        final Collection<Assertion> assertions = this.method.assertions();
+        final Collection<Complaint> res = new ArrayList<>(1);
+        if (assertions.isEmpty()) {
+            res.add(new EmptyAssertions(this.method));
+        }
+        assertions.stream()
+            .filter(assertion -> !assertion.explanation().isPresent())
+            .map(assertion -> new EmptyAssertionMessage(this.method, assertion))
+            .forEach(res::add);
+        return Collections.unmodifiableCollection(res);
+    }
+
+
+    /**
+     * The complaint about empty assertions.
+     * @since 0.1.15
+     */
+    private static final class EmptyAssertions implements Complaint {
+
+        /**
+         * The test case.
+         */
+        private final TestCase method;
+
+        /**
+         * Ctor.
+         * @param test The test case.
+         */
+        EmptyAssertions(final TestCase test) {
+            this.method = test;
+        }
+
+        @Override
+        public String message() {
+            return String.format("Method %s doesn't have assertion statements", this.method.name());
+        }
+    }
+
+    private static final class EmptyAssertionMessage implements Complaint {
+
+        /**
+         * The test case.
+         */
+        private final TestCase method;
+
+        /**
+         * The assertion.
+         */
+        private final Assertion assertion;
+
+        /**
+         * Ctor.
+         * @param test The test case.
+         * @param check The assertion.
+         */
+        EmptyAssertionMessage(final TestCase test, final Assertion check) {
+            this.method = test;
+            this.assertion = check;
+        }
+
+        @Override
+        public String message() {
+            return String.format(
+                "Method %s has assertion without message: %s, please add the explanation message to make the test more readable",
+                this.method.name(),
+                this.assertion
+            );
+        }
+    }
+
+}

--- a/src/main/java/com/github/lombrozo/testnames/rules/RuleAssertionMessage.java
+++ b/src/main/java/com/github/lombrozo/testnames/rules/RuleAssertionMessage.java
@@ -35,6 +35,11 @@ import java.util.Collections;
  * The rule that checks that test method has assertion and the assertion message is not empty.
  *
  * @since 0.1.15
+ * @todo #67:90min Add RuleAssertionMessage to the Cop checking pipeline.
+ *  We have to add the RuleAssertionMessage rule to the Cop checking pipeline.
+ *  For now, it's just added to repository and doesn't work during the entire check.
+ *  I believe it makes sense to add this rule when it will work without any problems
+ *  and we will have integration tests that check it.
  */
 class RuleAssertionMessage implements Rule {
 

--- a/src/main/java/com/github/lombrozo/testnames/rules/RuleAssertionMessage.java
+++ b/src/main/java/com/github/lombrozo/testnames/rules/RuleAssertionMessage.java
@@ -30,15 +30,23 @@ import com.github.lombrozo.testnames.TestCase;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.Optional;
 
 /**
  * The rule that checks that test method has assertion and the assertion message is not empty.
+ *
+ * @since 0.1.15
  */
 class RuleAssertionMessage implements Rule {
 
+    /**
+     * The test case.
+     */
     private final TestCase method;
 
+    /**
+     * Ctor.
+     * @param test The test case.
+     */
     RuleAssertionMessage(final TestCase test) {
         this.method = test;
     }
@@ -56,7 +64,6 @@ class RuleAssertionMessage implements Rule {
             .forEach(res::add);
         return Collections.unmodifiableCollection(res);
     }
-
 
     /**
      * The complaint about empty assertions.
@@ -83,6 +90,11 @@ class RuleAssertionMessage implements Rule {
         }
     }
 
+    /**
+     * The complaint about empty assertion message.
+     *
+     * @since 0.1.15
+     */
     private static final class EmptyAssertionMessage implements Complaint {
 
         /**

--- a/src/main/java/com/github/lombrozo/testnames/rules/RuleAssertionMessage.java
+++ b/src/main/java/com/github/lombrozo/testnames/rules/RuleAssertionMessage.java
@@ -46,7 +46,7 @@ class RuleAssertionMessage implements Rule {
     @Override
     public Collection<Complaint> complaints() {
         final Collection<Assertion> assertions = this.method.assertions();
-        final Collection<Complaint> res = new ArrayList<>(1);
+        final Collection<Complaint> res = new ArrayList<>(0);
         if (assertions.isEmpty()) {
             res.add(new EmptyAssertions(this.method));
         }

--- a/src/test/java/com/github/lombrozo/testnames/rules/RuleAssertionMessageTest.java
+++ b/src/test/java/com/github/lombrozo/testnames/rules/RuleAssertionMessageTest.java
@@ -1,5 +1,6 @@
 package com.github.lombrozo.testnames.rules;
 
+import com.github.lombrozo.testnames.Assertion;
 import com.github.lombrozo.testnames.Complaint;
 import com.github.lombrozo.testnames.TestCase;
 import java.util.Collection;
@@ -17,7 +18,7 @@ class RuleAssertionMessageTest {
     @Test
     void checksAssertionMessageWithoutComplaints() {
         MatcherAssert.assertThat(
-            new RuleAssertionMessage(new TestCase.Fake()).complaints(),
+            new RuleAssertionMessage(new TestCase.Fake(new Assertion.Fake())).complaints(),
             Matchers.empty()
         );
     }
@@ -42,7 +43,7 @@ class RuleAssertionMessageTest {
     @Test
     void checksAssertionMessageOfTestCaseWithoutAssertionMessage() {
         final Collection<Complaint> complaints = new RuleAssertionMessage(
-            new TestCase.Fake()
+            new TestCase.Fake(new Assertion.Empty())
         ).complaints();
         MatcherAssert.assertThat(
             complaints,

--- a/src/test/java/com/github/lombrozo/testnames/rules/RuleAssertionMessageTest.java
+++ b/src/test/java/com/github/lombrozo/testnames/rules/RuleAssertionMessageTest.java
@@ -1,3 +1,26 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2022-2023 Volodya
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package com.github.lombrozo.testnames.rules;
 
 import com.github.lombrozo.testnames.Assertion;
@@ -37,7 +60,6 @@ class RuleAssertionMessageTest {
             next.message(),
             Matchers.containsString("doesn't have assertion statements")
         );
-
     }
 
     @Test
@@ -54,5 +76,4 @@ class RuleAssertionMessageTest {
             Matchers.containsString("has assertion without message")
         );
     }
-
 }

--- a/src/test/java/com/github/lombrozo/testnames/rules/RuleAssertionMessageTest.java
+++ b/src/test/java/com/github/lombrozo/testnames/rules/RuleAssertionMessageTest.java
@@ -1,0 +1,57 @@
+package com.github.lombrozo.testnames.rules;
+
+import com.github.lombrozo.testnames.Complaint;
+import com.github.lombrozo.testnames.TestCase;
+import java.util.Collection;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+
+/**
+ * The test case for {@link RuleAssertionMessage}.
+ *
+ * @since 0.1.15
+ */
+class RuleAssertionMessageTest {
+
+    @Test
+    void checksAssertionMessageWithoutComplaints() {
+        MatcherAssert.assertThat(
+            new RuleAssertionMessage(new TestCase.Fake()).complaints(),
+            Matchers.empty()
+        );
+    }
+
+    @Test
+    void checksAssertionMessageOfTestCaseWithoutAssertions() {
+        final Collection<Complaint> complaints = new RuleAssertionMessage(
+            new TestCase.Fake()
+        ).complaints();
+        MatcherAssert.assertThat(
+            complaints,
+            Matchers.hasSize(1)
+        );
+        final Complaint next = complaints.iterator().next();
+        MatcherAssert.assertThat(
+            next.message(),
+            Matchers.containsString("doesn't have assertion statements")
+        );
+
+    }
+
+    @Test
+    void checksAssertionMessageOfTestCaseWithoutAssertionMessage() {
+        final Collection<Complaint> complaints = new RuleAssertionMessage(
+            new TestCase.Fake()
+        ).complaints();
+        MatcherAssert.assertThat(
+            complaints,
+            Matchers.hasSize(1)
+        );
+        MatcherAssert.assertThat(
+            complaints.iterator().next().message(),
+            Matchers.containsString("has assertion without message")
+        );
+    }
+
+}

--- a/src/test/java/com/github/lombrozo/testnames/rules/RuleAssertionMessageTest.java
+++ b/src/test/java/com/github/lombrozo/testnames/rules/RuleAssertionMessageTest.java
@@ -47,7 +47,7 @@ class RuleAssertionMessageTest {
     }
 
     @Test
-    void checksAssertionMessageOfTestCaseWithoutAssertions() {
+    void checksAssertionMessageOfCaseWithoutAssertions() {
         final Collection<Complaint> complaints = new RuleAssertionMessage(
             new TestCase.Fake()
         ).complaints();
@@ -63,7 +63,7 @@ class RuleAssertionMessageTest {
     }
 
     @Test
-    void checksAssertionMessageOfTestCaseWithoutAssertionMessage() {
+    void checksAssertionMessageOfCaseWithoutAssertionMessage() {
         final Collection<Complaint> complaints = new RuleAssertionMessage(
             new TestCase.Fake(new Assertion.Empty())
         ).complaints();


### PR DESCRIPTION
`Assertion` and `RuleAssertionMessage` classes were added to the repo.
Also naive implementation was added to the `RuleAssertionMessage`. The entire issue isn't finished and we will have to continue with it, so I've added several puzzles for it.

Closes: #67 

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds a new rule to check that test methods have assertions with non-empty messages. It also adds a new interface `Assertion` and two implementations of it (`Fake` and `Empty`).

### Detailed summary
- Added `Assertion` interface and two implementations (`Fake` and `Empty`)
- Added `RuleAssertionMessage` to check that test methods have assertions with non-empty messages
- Updated `TestCase` interface and `Fake` implementation to include `assertions()` method

> The following files were skipped due to too many changes: `src/main/java/com/github/lombrozo/testnames/rules/RuleAssertionMessage.java`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->