### PR TITLE
feat(#149): Add assertion of JUnit

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,9 +22,7 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.github.volodya-lombrozo</groupId>
   <artifactId>jtcop-maven-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,9 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.github.volodya-lombrozo</groupId>
   <artifactId>jtcop-maven-plugin</artifactId>
@@ -80,7 +82,9 @@ SOFTWARE.
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-api</artifactId>
       <version>5.9.3</version>
-      <scope>test</scope>
+      <!--The dependency required for obtaining
+      assertions during the parsing of Java tests-->
+      <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>org.cactoos</groupId>

--- a/src/main/java/com/github/lombrozo/testnames/javaparser/AssertionOfJUnit.java
+++ b/src/main/java/com/github/lombrozo/testnames/javaparser/AssertionOfJUnit.java
@@ -1,0 +1,65 @@
+package com.github.lombrozo.testnames.javaparser;
+
+import com.github.javaparser.ast.NodeList;
+import com.github.javaparser.ast.expr.Expression;
+import com.github.javaparser.ast.expr.MethodCallExpr;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.util.Arrays;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.Assertions;
+
+public class AssertionOfJUnit implements ParsedAssertion {
+
+    /**
+     * The method call.
+     */
+    private final MethodCallExpr call;
+
+    /**
+     * The allowed methods.
+     */
+    private final Set<String> allowed;
+
+    public AssertionOfJUnit(final MethodCallExpr call) {
+        this(call, AssertionOfJUnit.allowedJUnitNames());
+
+    }
+
+    private AssertionOfJUnit(final MethodCallExpr call, final Set<String> methods) {
+        this.call = call;
+        this.allowed = methods;
+    }
+
+    @Override
+    public boolean isAssertion() {
+        return this.call.getArguments().size() > 2
+            && this.allowed.contains(this.call.getName().toString());
+    }
+
+    @Override
+    public Optional<String> explanation() {
+        final Optional<String> result;
+        final NodeList<Expression> args = this.call.getArguments();
+        if (args.isEmpty() || args.size() < 3) {
+            result = Optional.empty();
+        } else {
+            result = Optional.ofNullable(args.get(2).asStringLiteralExpr().asString());
+        }
+        return result;
+    }
+
+    private static Set<String> allowedJUnitNames() {
+        return Arrays.stream(Assertions.class.getMethods())
+            .filter(AssertionOfJUnit::isAssertion)
+            .map(Method::getName)
+            .collect(Collectors.toSet());
+    }
+
+    private static boolean isAssertion(final Method method) {
+        final int modifiers = method.getModifiers();
+        return Modifier.isPublic(modifiers) && Modifier.isStatic(modifiers);
+    }
+}

--- a/src/main/java/com/github/lombrozo/testnames/javaparser/AssertionOfJUnit.java
+++ b/src/main/java/com/github/lombrozo/testnames/javaparser/AssertionOfJUnit.java
@@ -1,3 +1,26 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2022-2023 Volodya
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package com.github.lombrozo.testnames.javaparser;
 
 import com.github.javaparser.ast.NodeList;
@@ -11,7 +34,12 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import org.junit.jupiter.api.Assertions;
 
-public class AssertionOfJUnit implements ParsedAssertion {
+/**
+ * Assertion of JUnit.
+ *
+ * @since 0.1.15
+ */
+final class AssertionOfJUnit implements ParsedAssertion {
 
     /**
      * The method call.
@@ -23,13 +51,21 @@ public class AssertionOfJUnit implements ParsedAssertion {
      */
     private final Set<String> allowed;
 
-    public AssertionOfJUnit(final MethodCallExpr call) {
-        this(call, AssertionOfJUnit.allowedJUnitNames());
-
+    /**
+     * Constructor.
+     * @param method The method call.
+     */
+    AssertionOfJUnit(final MethodCallExpr method) {
+        this(method, AssertionOfJUnit.allowedJUnitNames());
     }
 
-    private AssertionOfJUnit(final MethodCallExpr call, final Set<String> methods) {
-        this.call = call;
+    /**
+     * Constructor.
+     * @param method The method call.
+     * @param methods The allowed methods.
+     */
+    private AssertionOfJUnit(final MethodCallExpr method, final Set<String> methods) {
+        this.call = method;
         this.allowed = methods;
     }
 
@@ -51,6 +87,10 @@ public class AssertionOfJUnit implements ParsedAssertion {
         return result;
     }
 
+    /**
+     * The allowed methods.
+     * @return The allowed JUnit methods.
+     */
     private static Set<String> allowedJUnitNames() {
         return Arrays.stream(Assertions.class.getMethods())
             .filter(AssertionOfJUnit::isAssertion)
@@ -58,6 +98,11 @@ public class AssertionOfJUnit implements ParsedAssertion {
             .collect(Collectors.toSet());
     }
 
+    /**
+     * Is JUnit assertion.
+     * @param method The method.
+     * @return True if JUnit assertion.
+     */
     private static boolean isAssertion(final Method method) {
         final int modifiers = method.getModifiers();
         return Modifier.isPublic(modifiers) && Modifier.isStatic(modifiers);

--- a/src/main/java/com/github/lombrozo/testnames/javaparser/AssertionOfJUnit.java
+++ b/src/main/java/com/github/lombrozo/testnames/javaparser/AssertionOfJUnit.java
@@ -38,6 +38,11 @@ import org.junit.jupiter.api.Assertions;
  * Assertion of JUnit.
  *
  * @since 0.1.15
+ * @todo #149:90min Implement more flexible mechanism of assertions parsing.
+ *  Currently, we are using a hardcoded list of allowed methods and number of arguments
+ *  to reason about junit assertions. This is not flexible enough and doesn't count all
+ *  cases. We have to add more tests for JUnit assertions and implement a more flexible
+ *  mechanism of parsing.
  */
 final class AssertionOfJUnit implements ParsedAssertion {
 

--- a/src/main/java/com/github/lombrozo/testnames/javaparser/AssertionOfJavaParser.java
+++ b/src/main/java/com/github/lombrozo/testnames/javaparser/AssertionOfJavaParser.java
@@ -24,7 +24,6 @@
 package com.github.lombrozo.testnames.javaparser;
 
 import com.github.javaparser.ast.expr.MethodCallExpr;
-import com.github.lombrozo.testnames.Assertion;
 import java.util.Optional;
 
 /**
@@ -32,7 +31,7 @@ import java.util.Optional;
  *
  * @since 0.1.15
  */
-public final class AssertionOfJavaParser implements Assertion {
+public final class AssertionOfJavaParser implements ParsedAssertion {
 
     /**
      * The method call.
@@ -57,5 +56,10 @@ public final class AssertionOfJavaParser implements Assertion {
             result = Optional.empty();
         }
         return result;
+    }
+
+    @Override
+    public boolean isAssertion() {
+        return new AssertionOfJUnit(this.call).isAssertion();
     }
 }

--- a/src/main/java/com/github/lombrozo/testnames/javaparser/AssertionOfJavaParser.java
+++ b/src/main/java/com/github/lombrozo/testnames/javaparser/AssertionOfJavaParser.java
@@ -23,8 +23,6 @@
  */
 package com.github.lombrozo.testnames.javaparser;
 
-import com.github.javaparser.ast.NodeList;
-import com.github.javaparser.ast.expr.Expression;
 import com.github.javaparser.ast.expr.MethodCallExpr;
 import com.github.lombrozo.testnames.Assertion;
 import java.util.Optional;
@@ -52,11 +50,11 @@ public final class AssertionOfJavaParser implements Assertion {
     @Override
     public Optional<String> explanation() {
         final Optional<String> result;
-        final NodeList<Expression> args = this.call.getArguments();
-        if (args.isEmpty() || args.size() < 3) {
-            result = Optional.empty();
+        final ParsedAssertion assertion = new AssertionOfJUnit(this.call);
+        if (assertion.isAssertion()) {
+            result = assertion.explanation();
         } else {
-            result = Optional.ofNullable(args.get(2).asStringLiteralExpr().asString());
+            result = Optional.empty();
         }
         return result;
     }

--- a/src/main/java/com/github/lombrozo/testnames/javaparser/ParsedAssertion.java
+++ b/src/main/java/com/github/lombrozo/testnames/javaparser/ParsedAssertion.java
@@ -29,6 +29,10 @@ import com.github.lombrozo.testnames.Assertion;
  * The assertion of the parsed test method.
  *
  * @since 0.1.15
+ * @todo #149:90min Add support of Hamcrest assertions.
+ *  For now we support only JUnit assertions, the next step would be to add Harcrest assertions.
+ *  We will have to change the library scope to 'compile' and parse it the same way as
+ *  {@link AssertionOfJUnit}.
  */
 interface ParsedAssertion extends Assertion {
 

--- a/src/main/java/com/github/lombrozo/testnames/javaparser/ParsedAssertion.java
+++ b/src/main/java/com/github/lombrozo/testnames/javaparser/ParsedAssertion.java
@@ -1,8 +1,40 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2022-2023 Volodya
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package com.github.lombrozo.testnames.javaparser;
 
 import com.github.lombrozo.testnames.Assertion;
 
-public interface ParsedAssertion extends Assertion {
+/**
+ * The assertion of the parsed test method.
+ *
+ * @since 0.1.15
+ */
+interface ParsedAssertion extends Assertion {
 
+    /**
+     * Is the method call an assertion?
+     * @return True if the method call is an assertion.
+     */
     boolean isAssertion();
 }

--- a/src/main/java/com/github/lombrozo/testnames/javaparser/ParsedAssertion.java
+++ b/src/main/java/com/github/lombrozo/testnames/javaparser/ParsedAssertion.java
@@ -1,0 +1,8 @@
+package com.github.lombrozo.testnames.javaparser;
+
+import com.github.lombrozo.testnames.Assertion;
+
+public interface ParsedAssertion extends Assertion {
+
+    boolean isAssertion();
+}

--- a/src/main/java/com/github/lombrozo/testnames/javaparser/TestCaseJavaParser.java
+++ b/src/main/java/com/github/lombrozo/testnames/javaparser/TestCaseJavaParser.java
@@ -51,9 +51,6 @@ import lombok.Data;
  *  The method should return a list of assertions from different libraries like
  *  Hamcrest, AssertJ, JUnit, etc. Also we have to have a list of tests that check new
  *  functionality.
- * @todo #146:90min Continue implementation of TestCaseJavaParser#suppressed.
- *  We have to refactor the method assertions() in TestCaseJavaParser.
- *  Now it looks ugly. Moreover, we have to handle more corner cases.
  */
 @Data
 final class TestCaseJavaParser implements TestCase {
@@ -123,8 +120,6 @@ final class TestCaseJavaParser implements TestCase {
                 .map(TestCaseJavaParser::toExpression)
                 .filter(Expression::isMethodCallExpr)
                 .map(MethodCallExpr.class::cast)
-                .filter(call -> call.getArguments().size() > 2)
-                .filter(call -> call.getName().toString().equals("assertEquals"))
                 .map(AssertionOfJavaParser::new)
                 .forEach(assertions::add)
         );

--- a/src/main/java/com/github/lombrozo/testnames/javaparser/TestCaseJavaParser.java
+++ b/src/main/java/com/github/lombrozo/testnames/javaparser/TestCaseJavaParser.java
@@ -121,6 +121,7 @@ final class TestCaseJavaParser implements TestCase {
                 .filter(Expression::isMethodCallExpr)
                 .map(MethodCallExpr.class::cast)
                 .map(AssertionOfJavaParser::new)
+                .filter(ParsedAssertion::isAssertion)
                 .forEach(assertions::add)
         );
         return Collections.unmodifiableCollection(assertions);


### PR DESCRIPTION
Add assertion of JUnit.

Closes: #149

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the `junit-jupiter-api` dependency and refactors the `TestCaseJavaParser` class to handle more corner cases. Notable changes include:

### Detailed summary
- Updated `junit-jupiter-api` dependency version to `5.9.3`.
- Changed the scope of the dependency to `compile`.
- Refactored `TestCaseJavaParser` class to handle more corner cases.
- Added `ParsedAssertion` interface to represent the assertion of the parsed test method.
- Implemented `AssertionOfJUnit` class to represent JUnit assertions.
- Added `isAssertion()` method to `ParsedAssertion` and `AssertionOfJUnit` classes to check if a method call is an assertion.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->