### PR TITLE
JTCOP.RuleAllTestsHaveProductionClass warning

### DIFF
--- a/docs/rules/all-have-production-class.md
+++ b/docs/rules/all-have-production-class.md
@@ -15,8 +15,8 @@ name. If this instruction does not provide the necessary information,
 frustration can ensue, particularly if the project is not one's own. Ultimately,
 the name of the test class is the last hope for obtaining this information.
 
-Exceptions: Annotations, Interfaces, `@SuppressedWarnings("
-RuleAllTestsHaveProductionClass")`.
+Exceptions: Annotations, Interfaces, 
+`@SuppressedWarnings("JTCOP.RuleAllTestsHaveProductionClass")`.
 
 You can read more about that
 rule [here](https://www.yegor256.com/2023/01/19/layout-of-tests.html#test-classes).


### PR DESCRIPTION
added JTCOP prefix, since according to the documentation not clear why just `RuleAllTestsHaveProductionClass` doesn't work

@volodya-lombrozo please take a look


<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the `all-have-production-class.md` documentation file to reflect changes in the `@SuppressedWarnings` annotation.

### Detailed summary
- Updated `@SuppressedWarnings` annotation to `@SuppressedWarnings("JTCOP.RuleAllTestsHaveProductionClass")`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->