### PR TITLE
feat(#152): junit assertions

### DIFF
--- a/src/main/java/com/github/lombrozo/testnames/javaparser/AssertionOfJUnit.java
+++ b/src/main/java/com/github/lombrozo/testnames/javaparser/AssertionOfJUnit.java
@@ -26,7 +26,6 @@ package com.github.lombrozo.testnames.javaparser;
 import com.github.javaparser.ast.NodeList;
 import com.github.javaparser.ast.expr.Expression;
 import com.github.javaparser.ast.expr.MethodCallExpr;
-import com.github.javaparser.ast.expr.NameExpr;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.util.Arrays;
@@ -62,7 +61,6 @@ final class AssertionOfJUnit implements ParsedAssertion {
      * The allowed methods.
      */
     private final Set<String> allowed;
-
 
     /**
      * Constructor.
@@ -101,6 +99,11 @@ final class AssertionOfJUnit implements ParsedAssertion {
         return result;
     }
 
+    /**
+     * The expression message.
+     * @param expression The expression.
+     * @return The message.
+     */
     private static Optional<String> message(final Expression expression) {
         final Optional<String> result;
         if (expression.isStringLiteralExpr()) {

--- a/src/main/java/com/github/lombrozo/testnames/javaparser/AssertionOfJUnit.java
+++ b/src/main/java/com/github/lombrozo/testnames/javaparser/AssertionOfJUnit.java
@@ -38,11 +38,10 @@ import org.junit.jupiter.api.Assertions;
  * Assertion of JUnit.
  *
  * @since 0.1.15
- * @todo #149:90min Implement more flexible mechanism of assertions parsing.
- *  Currently, we are using a hardcoded list of allowed methods and number of arguments
- *  to reason about junit assertions. This is not flexible enough and doesn't count all
- *  cases. We have to add more tests for JUnit assertions and implement a more flexible
- *  mechanism of parsing.
+ * @todo #152:90min Continue with implementing more flexible mechanism of assertions parsing.
+ *  We have added approximate implementation of JUnit assertions parsing.
+ *  However, it is not enough. I believe we have to check all tests and cases one more time.
+ *  Also it would be nice to add integration test for JUnit assertions.
  */
 final class AssertionOfJUnit implements ParsedAssertion {
 

--- a/src/main/java/com/github/lombrozo/testnames/javaparser/AssertionOfJUnit.java
+++ b/src/main/java/com/github/lombrozo/testnames/javaparser/AssertionOfJUnit.java
@@ -84,10 +84,21 @@ final class AssertionOfJUnit implements ParsedAssertion {
     public Optional<String> explanation() {
         final Optional<String> result;
         final NodeList<Expression> args = this.call.getArguments();
-        if (args.isEmpty() || args.size() < 3) {
-            result = Optional.empty();
+        final Optional<Expression> last = args.getLast();
+        if (last.isPresent()) {
+            result = AssertionOfJUnit.message(last.get());
         } else {
-            result = Optional.ofNullable(args.get(2).asStringLiteralExpr().asString());
+            result = Optional.empty();
+        }
+        return result;
+    }
+
+    private static Optional<String> message(final Expression expression) {
+        final Optional<String> result;
+        if (expression.isStringLiteralExpr()) {
+            result = Optional.of(expression.asStringLiteralExpr().asString());
+        } else {
+            result = Optional.empty();
         }
         return result;
     }

--- a/src/main/java/com/github/lombrozo/testnames/javaparser/AssertionOfJUnit.java
+++ b/src/main/java/com/github/lombrozo/testnames/javaparser/AssertionOfJUnit.java
@@ -26,6 +26,7 @@ package com.github.lombrozo.testnames.javaparser;
 import com.github.javaparser.ast.NodeList;
 import com.github.javaparser.ast.expr.Expression;
 import com.github.javaparser.ast.expr.MethodCallExpr;
+import com.github.javaparser.ast.expr.NameExpr;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.util.Arrays;
@@ -47,6 +48,12 @@ import org.junit.jupiter.api.Assertions;
 final class AssertionOfJUnit implements ParsedAssertion {
 
     /**
+     * The explanation of the assertion.
+     * The message that can't be parsed. It could be either a constant, or a method call.
+     */
+    private static final String UNKNOWN_MESSAGE = "Unknown message";
+
+    /**
      * The method call.
      */
     private final MethodCallExpr call;
@@ -55,6 +62,7 @@ final class AssertionOfJUnit implements ParsedAssertion {
      * The allowed methods.
      */
     private final Set<String> allowed;
+
 
     /**
      * Constructor.
@@ -97,6 +105,8 @@ final class AssertionOfJUnit implements ParsedAssertion {
         final Optional<String> result;
         if (expression.isStringLiteralExpr()) {
             result = Optional.of(expression.asStringLiteralExpr().asString());
+        } else if (expression.isNameExpr()) {
+            result = Optional.of(AssertionOfJUnit.UNKNOWN_MESSAGE);
         } else {
             result = Optional.empty();
         }

--- a/src/main/java/com/github/lombrozo/testnames/javaparser/AssertionOfJavaParser.java
+++ b/src/main/java/com/github/lombrozo/testnames/javaparser/AssertionOfJavaParser.java
@@ -25,12 +25,14 @@ package com.github.lombrozo.testnames.javaparser;
 
 import com.github.javaparser.ast.expr.MethodCallExpr;
 import java.util.Optional;
+import lombok.ToString;
 
 /**
  * The assertion of the test method.
  *
  * @since 0.1.15
  */
+@ToString
 public final class AssertionOfJavaParser implements ParsedAssertion {
 
     /**

--- a/src/test/java/com/github/lombrozo/testnames/javaparser/AssertionOfJUnitTest.java
+++ b/src/test/java/com/github/lombrozo/testnames/javaparser/AssertionOfJUnitTest.java
@@ -1,0 +1,54 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2022-2023 Volodya
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.github.lombrozo.testnames.javaparser;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test case for {@link AssertionOfJUnit}.
+ *
+ * @since 0.1.15
+ */
+class AssertionOfJUnitTest {
+
+    @Test
+    void parsesOrdinaryAssertions() {
+
+    }
+
+    @Test
+    void parsesAssertionsWithMessageSupplier() {
+
+    }
+
+    @Test
+    void parsesAssertionsWithoutMessage() {
+
+    }
+
+    @Test
+    void ignoresFailAssertion() {
+
+    }
+}

--- a/src/test/java/com/github/lombrozo/testnames/javaparser/AssertionOfJUnitTest.java
+++ b/src/test/java/com/github/lombrozo/testnames/javaparser/AssertionOfJUnitTest.java
@@ -23,6 +23,13 @@
  */
 package com.github.lombrozo.testnames.javaparser;
 
+import com.github.lombrozo.testnames.Assertion;
+import com.github.lombrozo.testnames.TestCase;
+import java.util.Collection;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -34,21 +41,73 @@ class AssertionOfJUnitTest {
 
     @Test
     void parsesOrdinaryAssertions() {
-
-    }
-
-    @Test
-    void parsesAssertionsWithMessageSupplier() {
-
+        final Collection<Assertion> assertions = AssertionOfJUnitTest.method("withMessages")
+            .assertions();
+        MatcherAssert.assertThat(
+            String.format(
+                "All assertions should have explanation assertions without messages %s",
+                assertions.stream()
+                    .filter(opt -> !opt.explanation().isPresent())
+                    .collect(Collectors.toList())
+            ),
+            assertions
+                .stream()
+                .map(Assertion::explanation)
+                .allMatch(Optional::isPresent),
+            Matchers.is(true)
+        );
+        MatcherAssert.assertThat(
+            "All assertions should have JUnit explanation text",
+            assertions.stream()
+                .map(Assertion::explanation)
+                .filter(Optional::isPresent)
+                .map(Optional::get)
+                .noneMatch(String::isEmpty),
+            Matchers.is(true)
+        );
     }
 
     @Test
     void parsesAssertionsWithoutMessage() {
-
+        MatcherAssert.assertThat(
+            "All assertions should be without assertion message",
+            AssertionOfJUnitTest.method("withoutMessages")
+                .assertions()
+                .stream()
+                .map(Assertion::explanation)
+                .noneMatch(Optional::isPresent),
+            Matchers.is(true)
+        );
     }
 
     @Test
     void ignoresFailAssertion() {
+        MatcherAssert.assertThat(
+            "We should add fake explanations for some assertions",
+            AssertionOfJUnitTest.method("ingoresSomeAssertionMessages")
+                .assertions()
+                .stream()
+                .map(Assertion::explanation)
+                .allMatch(Optional::isPresent),
+            Matchers.is(true)
+        );
+    }
 
+
+    /**
+     * Returns test case by name.
+     * @param name Name of test case.
+     * @return Test case.
+     */
+    private static TestCase method(final String name) {
+        return JavaTestClasses.TEST_WITH_JUNIT_ASSERTIONS
+            .javaParserClass().all().stream()
+            .filter(method -> name.equals(method.name()))
+            .findFirst()
+            .orElseThrow(
+                () -> {
+                    throw new IllegalStateException(String.format("Method not found: %s", name));
+                }
+            );
     }
 }

--- a/src/test/java/com/github/lombrozo/testnames/javaparser/AssertionOfJUnitTest.java
+++ b/src/test/java/com/github/lombrozo/testnames/javaparser/AssertionOfJUnitTest.java
@@ -40,6 +40,7 @@ import org.junit.jupiter.api.Test;
 class AssertionOfJUnitTest {
 
     @Test
+    @SuppressWarnings("PMD.JUnitTestContainsTooManyAsserts")
     void parsesOrdinaryAssertions() {
         final Collection<Assertion> assertions = AssertionOfJUnitTest.method("withMessages")
             .assertions();
@@ -92,7 +93,6 @@ class AssertionOfJUnitTest {
             Matchers.is(true)
         );
     }
-
 
     /**
      * Returns test case by name.

--- a/src/test/java/com/github/lombrozo/testnames/javaparser/JavaTestClasses.java
+++ b/src/test/java/com/github/lombrozo/testnames/javaparser/JavaTestClasses.java
@@ -82,6 +82,11 @@ enum JavaTestClasses {
     TEST_WITH_ASSERTIONS("TestWithAssertions.java"),
 
     /**
+     * Test class with JUnit assertions.
+     */
+    TEST_WITH_JUNIT_ASSERTIONS("TestWithJUnitAssertions.java"),
+
+    /**
      * Test class with mistakes in test names.
      */
     WRONG_NAME("TestWrongName.java");

--- a/src/test/resources/TestWithJUnitAssertions.java
+++ b/src/test/resources/TestWithJUnitAssertions.java
@@ -44,7 +44,107 @@ class TestWithJUnitAssertions {
     @Test
     void withMessages() {
         Assertions.assertEquals("1", "1", DEFAULT_EXPLANATION);
-        Assertions.assertTrue(true, TestWithJUnitAssertions.DEFAULT_EXPLANATION);
+        Assertions.assertEquals("1", "1", DEFAULT_SUPPLIER);
+        Assertions.assertTrue(true, DEFAULT_EXPLANATION);
+        Assertions.assertTrue(true, DEFAULT_SUPPLIER);
+        Assertions.assertFalse(false, DEFAULT_EXPLANATION);
+        Assertions.assertFalse(false, DEFAULT_SUPPLIER);
+        Assertions.assertNotEquals("1", "2", DEFAULT_EXPLANATION);
+        Assertions.assertNotEquals("1", "2", DEFAULT_SUPPLIER);
+        Assertions.assertArrayEquals(new int[]{1, 2, 3}, new int[]{1, 2, 3}, DEFAULT_EXPLANATION);
+        Assertions.assertArrayEquals(new int[]{1, 2, 3}, new int[]{1, 2, 3}, DEFAULT_SUPPLIER);
+        Assertions.assertLinesMatch(
+            Collections.EMPTY_LIST,
+            Collections.EMPTY_LIST,
+            DEFAULT_EXPLANATION
+        );
+        Assertions.assertLinesMatch(
+            Collections.EMPTY_LIST,
+            Collections.EMPTY_LIST,
+            DEFAULT_SUPPLIER
+        );
+        Assertions.assertInstanceOf(Integer.class, 1, DEFAULT_SUPPLIER);
+        Assertions.assertInstanceOf(Integer.class, 1, DEFAULT_EXPLANATION);
+        Assertions.assertNotSame(new Object(), new Object(), DEFAULT_EXPLANATION);
+        Assertions.assertNotSame(new Object(), new Object(), DEFAULT_SUPPLIER);
+        Assertions.assertSame(1, 1, DEFAULT_EXPLANATION);
+        Assertions.assertSame(1, 1, DEFAULT_SUPPLIER);
+        Assertions.assertNull(null, DEFAULT_EXPLANATION);
+        Assertions.assertNull(null, DEFAULT_SUPPLIER);
+        Assertions.assertNotNull(new Object(), DEFAULT_EXPLANATION);
+        Assertions.assertNotNull(new Object(), DEFAULT_SUPPLIER);
+        Assertions.assertTimeout(
+            Duration.ZERO,
+            () -> {
+            },
+            DEFAULT_EXPLANATION
+        );
+        Assertions.assertTimeout(
+            Duration.ZERO,
+            () -> {
+            },
+            DEFAULT_SUPPLIER
+        );
+        Assertions.assertTimeoutPreemptively(
+            Duration.ZERO,
+            () -> {
+            },
+            DEFAULT_EXPLANATION
+        );
+        Assertions.assertTimeoutPreemptively(
+            Duration.ZERO,
+            () -> {
+            },
+            DEFAULT_SUPPLIER
+        );
+        Assertions.assertThrowsExactly(
+            IllegalStateException.class,
+            () -> {
+                throw new IllegalStateException();
+            },
+            DEFAULT_EXPLANATION
+        );
+        Assertions.assertThrowsExactly(
+            IllegalStateException.class,
+            () -> {
+                throw new IllegalStateException();
+            },
+            DEFAULT_SUPPLIER
+        );
+        Assertions.assertIterableEquals(
+            new int[]{1, 2, 3},
+            new int[]{1, 2, 3},
+            DEFAULT_EXPLANATION
+        );
+        Assertions.assertIterableEquals(
+            new int[]{1, 2, 3},
+            new int[]{1, 2, 3},
+            DEFAULT_SUPPLIER
+        );
+        Assertions.assertDoesNotThrow(
+            () -> {
+            },
+            DEFAULT_SUPPLIER
+        );
+        Assertions.assertDoesNotThrow(
+            () -> {
+            },
+            DEFAULT_EXPLANATION
+        );
+        Assertions.assertThrows(
+            IllegalStateException.class,
+            () -> {
+                throw new IllegalStateException();
+            },
+            DEFAULT_EXPLANATION
+        );
+        Assertions.assertThrows(
+            IllegalStateException.class,
+            () -> {
+                throw new IllegalStateException();
+            },
+            DEFAULT_SUPPLIER
+        );
     }
 
     @Test

--- a/src/test/resources/TestWithJUnitAssertions.java
+++ b/src/test/resources/TestWithJUnitAssertions.java
@@ -1,0 +1,107 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2022-2023 Volodya
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.github.lombrozo.testnames;
+
+import java.time.Duration;
+import java.util.Collections;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class TestWithJUnitAssertions {
+
+    /**
+     * Default explanation for assertions.
+     */
+    private final static String DEFAULT_EXPLANATION = "JUnit explanation";
+
+    /**
+     * Default supplier for assertions.
+     */
+    private final static String DEFAULT_SUPPLIER = () -> TestWithJUnitAssertions.DEFAULT_EXPLANATION;
+
+    @Test
+    void withMessages() {
+        Assertions.assertEquals("1", "1", DEFAULT_EXPLANATION);
+        Assertions.assertTrue(true, TestWithJUnitAssertions.DEFAULT_EXPLANATION);
+    }
+
+    @Test
+    void withoutMessages() {
+        Assertions.assertEquals("1", "1");
+        Assertions.assertTrue(true);
+        Assertions.assertFalse(false);
+        Assertions.assertNotEquals("1", "2");
+        Assertions.assertArrayEquals(new int[]{1, 2, 3}, new int[]{1, 2, 3});
+        Assertions.assertLinesMatch(Collections.EMPTY_LIST, Collections.EMPTY_LIST);
+        Assertions.assertInstanceOf(Integer.class, 1);
+        Assertions.assertNotSame(new Object(), new Object());
+        Assertions.assertSame(1, 1);
+        Assertions.assertNull(null);
+        Assertions.assertNotNull(new Object());
+        Assertions.assertTimeout(
+            Duration.ZERO,
+            () -> {
+            }
+        );
+        Assertions.assertTimeoutPreemptively(
+            Duration.ZERO,
+            () -> {
+            }
+        );
+        Assertions.assertThrowsExactly(
+            IllegalStateException.class,
+            () -> {
+                throw new IllegalStateException();
+            }
+        );
+        Assertions.assertIterableEquals(
+            new int[]{1, 2, 3},
+            new int[]{1, 2, 3}
+        );
+        Assertions.assertDoesNotThrow(
+            () -> {
+            }
+        );
+        Assertions.assertThrows(
+            IllegalStateException.class,
+            () -> {
+                throw new IllegalStateException();
+            }
+        );
+    }
+
+    @Test
+    void ingoresSomeAssertionMessages() {
+        Assertions.fail("JUnit explanation");
+        Assertions.fail(new IllegalStateException());
+        Assertions.fail();
+        Assertions.fail("JUnit explanation", new IllegalStateException());
+        Assertions.fail(() -> "JUnit explanation");
+        Assertions.assertAll(
+            () -> {
+            }
+        );
+    }
+}


### PR DESCRIPTION
First draft of JUnit assertions parsing.

Closes: #152 

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds a new test class and implements a more flexible mechanism of assertions parsing.

### Detailed summary
- Added a new test class with JUnit assertions.
- Implemented a more flexible mechanism of assertions parsing in AssertionOfJUnit.
- Added a new field in AssertionOfJUnit to represent the message that can't be parsed.
- Added a new test case for AssertionOfJUnit.

> The following files were skipped due to too many changes: `src/test/resources/TestWithJUnitAssertions.java`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->