### PR TITLE
feat(#155): JUnit Assertions - Add more tests.

### DIFF
--- a/src/main/java/com/github/lombrozo/testnames/javaparser/AssertionOfJUnit.java
+++ b/src/main/java/com/github/lombrozo/testnames/javaparser/AssertionOfJUnit.java
@@ -38,10 +38,6 @@ import org.junit.jupiter.api.Assertions;
  * Assertion of JUnit.
  *
  * @since 0.1.15
- * @todo #152:90min Continue with implementing more flexible mechanism of assertions parsing.
- *  We have added approximate implementation of JUnit assertions parsing.
- *  However, it is not enough. I believe we have to check all tests and cases one more time.
- *  Also it would be nice to add integration test for JUnit assertions.
  */
 final class AssertionOfJUnit implements ParsedAssertion {
 

--- a/src/test/java/com/github/lombrozo/testnames/javaparser/AssertionOfJUnitTest.java
+++ b/src/test/java/com/github/lombrozo/testnames/javaparser/AssertionOfJUnitTest.java
@@ -35,6 +35,9 @@ import org.junit.jupiter.api.Test;
  * Test case for {@link AssertionOfJUnit}.
  *
  * @since 0.1.15
+ * @todo #155:90min Enable all tests in AssertionOfJUnitTest and fix all related problems.
+ *  Currently, some tests are disabled because of the problems with parsing of JUnit assertions.
+ *  We need to fix all problems and enable all tests. After that, we can remove this puzzle.
  */
 class AssertionOfJUnitTest {
 

--- a/src/test/java/com/github/lombrozo/testnames/javaparser/AssertionOfJUnitTest.java
+++ b/src/test/java/com/github/lombrozo/testnames/javaparser/AssertionOfJUnitTest.java
@@ -38,9 +38,20 @@ import org.junit.jupiter.api.Test;
  */
 class AssertionOfJUnitTest {
 
+    /**
+     * Method name for test with messages.
+     */
     private static final String WITH_MESSAGES = "withMessages";
+
+    /**
+     * Method name for test without messages.
+     */
     private static final String WITHOUT_MESSAGES = "withoutMessages";
-    private static final String SPECIAL_ASSERTIONS = "specialAssertions";
+
+    /**
+     * Method name for test with special assertions.
+     */
+    private static final String SPECIAL_MESSAGES = "specialAssertions";
 
     @Test
     @Disabled
@@ -72,7 +83,7 @@ class AssertionOfJUnitTest {
     void parsesJUnitAssertionsNoneHasEmptyExplanation() {
         MatcherAssert.assertThat(
             "All assertions should have JUnit explanation text",
-            AssertionOfJUnitTest.method("withMessages")
+            AssertionOfJUnitTest.method(AssertionOfJUnitTest.WITH_MESSAGES)
                 .assertions().stream()
                 .map(Assertion::explanation)
                 .filter(Optional::isPresent)
@@ -112,7 +123,7 @@ class AssertionOfJUnitTest {
     @Disabled
     void parsesAllSpecialAssertionsAllAreParsed() {
         final int expected = 6;
-        final int actual = AssertionOfJUnitTest.method(AssertionOfJUnitTest.SPECIAL_ASSERTIONS)
+        final int actual = AssertionOfJUnitTest.method(AssertionOfJUnitTest.SPECIAL_MESSAGES)
             .assertions().size();
         MatcherAssert.assertThat(
             String.format("We expect to parse %d special assertions, but was %s", expected, actual),
@@ -121,12 +132,11 @@ class AssertionOfJUnitTest {
         );
     }
 
-
     @Test
     void ignoresFailAssertion() {
         MatcherAssert.assertThat(
             "We should add fake explanations for some assertions",
-            AssertionOfJUnitTest.method(AssertionOfJUnitTest.SPECIAL_ASSERTIONS)
+            AssertionOfJUnitTest.method(AssertionOfJUnitTest.SPECIAL_MESSAGES)
                 .assertions()
                 .stream()
                 .map(Assertion::explanation)

--- a/src/test/java/com/github/lombrozo/testnames/javaparser/AssertionOfJUnitTest.java
+++ b/src/test/java/com/github/lombrozo/testnames/javaparser/AssertionOfJUnitTest.java
@@ -25,11 +25,10 @@ package com.github.lombrozo.testnames.javaparser;
 
 import com.github.lombrozo.testnames.Assertion;
 import com.github.lombrozo.testnames.TestCase;
-import java.util.Collection;
 import java.util.Optional;
-import java.util.stream.Collectors;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -39,27 +38,42 @@ import org.junit.jupiter.api.Test;
  */
 class AssertionOfJUnitTest {
 
+    private static final String WITH_MESSAGES = "withMessages";
+    private static final String WITHOUT_MESSAGES = "withoutMessages";
+    private static final String SPECIAL_ASSERTIONS = "specialAssertions";
+
     @Test
-    @SuppressWarnings("PMD.JUnitTestContainsTooManyAsserts")
-    void parsesOrdinaryAssertions() {
-        final Collection<Assertion> assertions = AssertionOfJUnitTest.method("withMessages")
-            .assertions();
+    @Disabled
+    void parsesJUnitAssertionsAllPresent() {
+        final int expected = 34;
+        final int actual = AssertionOfJUnitTest.method(AssertionOfJUnitTest.WITH_MESSAGES)
+            .assertions().size();
         MatcherAssert.assertThat(
-            String.format(
-                "All assertions should have explanation assertions without messages %s",
-                assertions.stream()
-                    .filter(opt -> !opt.explanation().isPresent())
-                    .collect(Collectors.toList())
-            ),
-            assertions
+            String.format("We expect to parse %d assertions, but was %s", expected, actual),
+            actual,
+            Matchers.is(expected)
+        );
+    }
+
+    @Test
+    void parsesJUnitAssertionsAllHaveExplanation() {
+        MatcherAssert.assertThat(
+            "All assertions should have explanation assertions",
+            AssertionOfJUnitTest.method(AssertionOfJUnitTest.WITH_MESSAGES)
+                .assertions()
                 .stream()
                 .map(Assertion::explanation)
                 .allMatch(Optional::isPresent),
             Matchers.is(true)
         );
+    }
+
+    @Test
+    void parsesJUnitAssertionsNoneHasEmptyExplanation() {
         MatcherAssert.assertThat(
             "All assertions should have JUnit explanation text",
-            assertions.stream()
+            AssertionOfJUnitTest.method("withMessages")
+                .assertions().stream()
                 .map(Assertion::explanation)
                 .filter(Optional::isPresent)
                 .map(Optional::get)
@@ -69,10 +83,23 @@ class AssertionOfJUnitTest {
     }
 
     @Test
+    @Disabled
+    void parsesAssertionsWithoutMessagesAllAreParsed() {
+        final int expected = 17;
+        final int actual = AssertionOfJUnitTest.method(AssertionOfJUnitTest.WITHOUT_MESSAGES)
+            .assertions().size();
+        MatcherAssert.assertThat(
+            String.format("We expect to parse %d empty assertions, but was %s", expected, actual),
+            actual,
+            Matchers.is(expected)
+        );
+    }
+
+    @Test
     void parsesAssertionsWithoutMessage() {
         MatcherAssert.assertThat(
             "All assertions should be without assertion message",
-            AssertionOfJUnitTest.method("withoutMessages")
+            AssertionOfJUnitTest.method(AssertionOfJUnitTest.WITHOUT_MESSAGES)
                 .assertions()
                 .stream()
                 .map(Assertion::explanation)
@@ -82,10 +109,24 @@ class AssertionOfJUnitTest {
     }
 
     @Test
+    @Disabled
+    void parsesAllSpecialAssertionsAllAreParsed() {
+        final int expected = 6;
+        final int actual = AssertionOfJUnitTest.method(AssertionOfJUnitTest.SPECIAL_ASSERTIONS)
+            .assertions().size();
+        MatcherAssert.assertThat(
+            String.format("We expect to parse %d special assertions, but was %s", expected, actual),
+            actual,
+            Matchers.is(expected)
+        );
+    }
+
+
+    @Test
     void ignoresFailAssertion() {
         MatcherAssert.assertThat(
             "We should add fake explanations for some assertions",
-            AssertionOfJUnitTest.method("ingoresSomeAssertionMessages")
+            AssertionOfJUnitTest.method(AssertionOfJUnitTest.SPECIAL_ASSERTIONS)
                 .assertions()
                 .stream()
                 .map(Assertion::explanation)

--- a/src/test/resources/TestWithJUnitAssertions.java
+++ b/src/test/resources/TestWithJUnitAssertions.java
@@ -193,7 +193,7 @@ class TestWithJUnitAssertions {
     }
 
     @Test
-    void ingoresSomeAssertionMessages() {
+    void specialAssertions() {
         Assertions.fail("JUnit explanation");
         Assertions.fail(new IllegalStateException());
         Assertions.fail();


### PR DESCRIPTION
Add more tests for `AssertionOfJUnitTest` that reveal some problems with the implementation.

Closes: #155 

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds a new test method and modifies existing ones in `AssertionOfJUnitTest` class to fix parsing issues with JUnit assertions.

### Detailed summary
- Added `specialAssertions()` test method to test special JUnit assertions
- Modified `parsesJUnitAssertionsAllHaveExplanation()` test method to ensure all JUnit assertions have explanations
- Added `parsesJUnitAssertionsNoneHasEmptyExplanation()` test method to ensure no JUnit assertion has an empty explanation
- Added `parsesAssertionsWithoutMessagesAllAreParsed()` test method to ensure all empty assertions are parsed
- Modified `parsesAssertionsWithoutMessage()` test method to ensure all assertions without messages are parsed
- Added `parsesAllSpecialAssertionsAllAreParsed()` test method to ensure all special assertions are parsed
- Added `@Disabled` annotation to tests that are currently disabled

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->