### PR TITLE
feat(#157): junit assertions - fix mistakes and enable tests

### DIFF
--- a/src/main/java/com/github/lombrozo/testnames/javaparser/AssertionOfJUnit.java
+++ b/src/main/java/com/github/lombrozo/testnames/javaparser/AssertionOfJUnit.java
@@ -31,7 +31,6 @@ import java.lang.reflect.Modifier;
 import java.util.Arrays;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
 import java.util.stream.Collectors;
 import org.junit.jupiter.api.Assertions;
 
@@ -49,20 +48,20 @@ final class AssertionOfJUnit implements ParsedAssertion {
     private static final String UNKNOWN_MESSAGE = "Unknown message";
 
     /**
+     * Special assertions that we consider as assertions with messages.
+     */
+    private static final String[] SPECIAL = {"assertAll", "fail"};
+
+    /**
      * The method call.
      */
     private final MethodCallExpr call;
 
     /**
      * The allowed methods.
+     * The key is the method name, the value is the minimum number of arguments.
      */
     private final Map<String, Integer> allowed;
-
-    /**
-     * Special assertions that we consider as assertions with messages.
-     */
-    private final String[] special = {"assertAll", "fail"};
-
 
     /**
      * Constructor.
@@ -93,7 +92,7 @@ final class AssertionOfJUnit implements ParsedAssertion {
         final NodeList<Expression> args = this.call.getArguments();
         final Optional<Expression> last = args.getLast();
         final Integer min = this.allowed.get(this.call.getName().toString());
-        if(Arrays.asList(this.special).contains(this.call.getName().toString())) {
+        if (Arrays.asList(this.SPECIAL).contains(this.call.getName().toString())) {
             result = Optional.of(AssertionOfJUnit.UNKNOWN_MESSAGE);
         } else if (min < args.size() && last.isPresent()) {
             result = AssertionOfJUnit.message(last.get());

--- a/src/main/java/com/github/lombrozo/testnames/javaparser/AssertionOfJUnit.java
+++ b/src/main/java/com/github/lombrozo/testnames/javaparser/AssertionOfJUnit.java
@@ -29,7 +29,6 @@ import com.github.javaparser.ast.expr.MethodCallExpr;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.util.Arrays;
-import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -60,6 +59,12 @@ final class AssertionOfJUnit implements ParsedAssertion {
     private final Map<String, Integer> allowed;
 
     /**
+     * Special assertions that we consider as assertions with messages.
+     */
+    private final String[] special = {"assertAll", "fail"};
+
+
+    /**
      * Constructor.
      * @param method The method call.
      */
@@ -88,7 +93,9 @@ final class AssertionOfJUnit implements ParsedAssertion {
         final NodeList<Expression> args = this.call.getArguments();
         final Optional<Expression> last = args.getLast();
         final Integer min = this.allowed.get(this.call.getName().toString());
-        if (min < this.call.getArguments().size() && last.isPresent()) {
+        if(Arrays.asList(this.special).contains(this.call.getName().toString())) {
+            result = Optional.of(AssertionOfJUnit.UNKNOWN_MESSAGE);
+        } else if (min < args.size() && last.isPresent()) {
             result = AssertionOfJUnit.message(last.get());
         } else {
             result = Optional.empty();

--- a/src/test/java/com/github/lombrozo/testnames/javaparser/AssertionOfJUnitTest.java
+++ b/src/test/java/com/github/lombrozo/testnames/javaparser/AssertionOfJUnitTest.java
@@ -28,16 +28,12 @@ import com.github.lombrozo.testnames.TestCase;
 import java.util.Optional;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 /**
  * Test case for {@link AssertionOfJUnit}.
  *
  * @since 0.1.15
- * @todo #155:90min Enable all tests in AssertionOfJUnitTest and fix all related problems.
- *  Currently, some tests are disabled because of the problems with parsing of JUnit assertions.
- *  We need to fix all problems and enable all tests. After that, we can remove this puzzle.
  */
 class AssertionOfJUnitTest {
 
@@ -57,7 +53,6 @@ class AssertionOfJUnitTest {
     private static final String SPECIAL_MESSAGES = "specialAssertions";
 
     @Test
-    @Disabled
     void parsesJUnitAssertionsAllPresent() {
         final int expected = 34;
         final int actual = AssertionOfJUnitTest.method(AssertionOfJUnitTest.WITH_MESSAGES)
@@ -97,7 +92,6 @@ class AssertionOfJUnitTest {
     }
 
     @Test
-    @Disabled
     void parsesAssertionsWithoutMessagesAllAreParsed() {
         final int expected = 17;
         final int actual = AssertionOfJUnitTest.method(AssertionOfJUnitTest.WITHOUT_MESSAGES)
@@ -123,7 +117,6 @@ class AssertionOfJUnitTest {
     }
 
     @Test
-    @Disabled
     void parsesAllSpecialAssertionsAllAreParsed() {
         final int expected = 6;
         final int actual = AssertionOfJUnitTest.method(AssertionOfJUnitTest.SPECIAL_MESSAGES)

--- a/src/test/java/com/github/lombrozo/testnames/javaparser/AssertionOfJUnitTest.java
+++ b/src/test/java/com/github/lombrozo/testnames/javaparser/AssertionOfJUnitTest.java
@@ -142,10 +142,15 @@ class AssertionOfJUnitTest {
 
     @Test
     void ignoresFailAssertion() {
+        final Collection<Assertion> assertions = AssertionOfJUnitTest.method(
+                AssertionOfJUnitTest.SPECIAL_MESSAGES)
+            .assertions();
         MatcherAssert.assertThat(
-            "We should add fake explanations for some assertions",
-            AssertionOfJUnitTest.method(AssertionOfJUnitTest.SPECIAL_MESSAGES)
-                .assertions()
+            String.format(
+                "We should accept special assertions as assertions with explanation, but was %s",
+                assertions
+            ),
+            assertions
                 .stream()
                 .map(Assertion::explanation)
                 .allMatch(Optional::isPresent),

--- a/src/test/java/com/github/lombrozo/testnames/javaparser/AssertionOfJUnitTest.java
+++ b/src/test/java/com/github/lombrozo/testnames/javaparser/AssertionOfJUnitTest.java
@@ -107,21 +107,19 @@ class AssertionOfJUnitTest {
 
     @Test
     void parsesAssertionsWithoutMessage() {
-        final Collection<Assertion> assertions = AssertionOfJUnitTest.method(
-                AssertionOfJUnitTest.WITHOUT_MESSAGES)
-            .assertions();
+        final Collection<Assertion> all = AssertionOfJUnitTest.method(
+            AssertionOfJUnitTest.WITHOUT_MESSAGES
+        ).assertions();
         MatcherAssert.assertThat(
             String.format(
                 "All assertions should be without assertion message, but was: %s",
-                assertions
-                    .stream()
+                all.stream()
                     .map(Assertion::explanation)
                     .filter(Optional::isPresent)
                     .map(Optional::get)
                     .collect(Collectors.toList())
             ),
-            assertions
-                .stream()
+            all.stream()
                 .map(Assertion::explanation)
                 .noneMatch(Optional::isPresent),
             Matchers.is(true)
@@ -142,16 +140,15 @@ class AssertionOfJUnitTest {
 
     @Test
     void ignoresFailAssertion() {
-        final Collection<Assertion> assertions = AssertionOfJUnitTest.method(
-                AssertionOfJUnitTest.SPECIAL_MESSAGES)
-            .assertions();
+        final Collection<Assertion> all = AssertionOfJUnitTest.method(
+            AssertionOfJUnitTest.SPECIAL_MESSAGES
+        ).assertions();
         MatcherAssert.assertThat(
             String.format(
                 "We should accept special assertions as assertions with explanation, but was %s",
-                assertions
+                all
             ),
-            assertions
-                .stream()
+            all.stream()
                 .map(Assertion::explanation)
                 .allMatch(Optional::isPresent),
             Matchers.is(true)

--- a/src/test/java/com/github/lombrozo/testnames/javaparser/AssertionOfJUnitTest.java
+++ b/src/test/java/com/github/lombrozo/testnames/javaparser/AssertionOfJUnitTest.java
@@ -25,7 +25,9 @@ package com.github.lombrozo.testnames.javaparser;
 
 import com.github.lombrozo.testnames.Assertion;
 import com.github.lombrozo.testnames.TestCase;
+import java.util.Collection;
 import java.util.Optional;
+import java.util.stream.Collectors;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
@@ -105,10 +107,20 @@ class AssertionOfJUnitTest {
 
     @Test
     void parsesAssertionsWithoutMessage() {
+        final Collection<Assertion> assertions = AssertionOfJUnitTest.method(
+                AssertionOfJUnitTest.WITHOUT_MESSAGES)
+            .assertions();
         MatcherAssert.assertThat(
-            "All assertions should be without assertion message",
-            AssertionOfJUnitTest.method(AssertionOfJUnitTest.WITHOUT_MESSAGES)
-                .assertions()
+            String.format(
+                "All assertions should be without assertion message, but was: %s",
+                assertions
+                    .stream()
+                    .map(Assertion::explanation)
+                    .filter(Optional::isPresent)
+                    .map(Optional::get)
+                    .collect(Collectors.toList())
+            ),
+            assertions
                 .stream()
                 .map(Assertion::explanation)
                 .noneMatch(Optional::isPresent),


### PR DESCRIPTION
junit assertions - fix mistakes and enable tests.

Closes: #157 

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds new special assertions and changes the allowed methods from a Set to a Map. It also refactors the code to simplify some methods and improve the readability of the tests.

### Detailed summary
- Adds new special assertions.
- Changes the allowed methods from a Set to a Map.
- Refactors the code to simplify methods and improve test readability.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->