### PR TITLE
feat(#151): Start implementing of hamcrest assertions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -85,6 +85,14 @@ SOFTWARE.
       <scope>compile</scope>
     </dependency>
     <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest</artifactId>
+      <version>2.2</version>
+      <!--The dependency required for obtaining
+      assertions during the parsing of Java tests-->
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
       <groupId>org.cactoos</groupId>
       <artifactId>cactoos</artifactId>
       <version>0.55.0</version>
@@ -105,12 +113,6 @@ SOFTWARE.
       <groupId>com.jcabi</groupId>
       <artifactId>jcabi-matchers</artifactId>
       <version>1.6.0</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.hamcrest</groupId>
-      <artifactId>hamcrest</artifactId>
-      <version>2.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/src/main/java/com/github/lombrozo/testnames/javaparser/AssertionOfHamcrest.java
+++ b/src/main/java/com/github/lombrozo/testnames/javaparser/AssertionOfHamcrest.java
@@ -1,0 +1,59 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2022-2023 Volodya
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.github.lombrozo.testnames.javaparser;
+
+import com.github.javaparser.ast.expr.MethodCallExpr;
+import java.util.Optional;
+
+/**
+ * Assertion of Hamcrest.
+ *
+ * @since 0.1.15
+ */
+public class AssertionOfHamcrest implements ParsedAssertion {
+
+    /**
+     * The method call.
+     */
+    private final MethodCallExpr method;
+
+    /**
+     * Ctor.
+     * @param call The method call.
+     */
+    public AssertionOfHamcrest(final MethodCallExpr call) {
+        this.method = call;
+    }
+
+
+    @Override
+    public Optional<String> explanation() {
+        return Optional.empty();
+    }
+
+    @Override
+    public boolean isAssertion() {
+        return false;
+    }
+}

--- a/src/main/java/com/github/lombrozo/testnames/javaparser/AssertionOfHamcrest.java
+++ b/src/main/java/com/github/lombrozo/testnames/javaparser/AssertionOfHamcrest.java
@@ -31,7 +31,7 @@ import java.util.Optional;
  *
  * @since 0.1.15
  */
-public class AssertionOfHamcrest implements ParsedAssertion {
+public final class AssertionOfHamcrest implements ParsedAssertion {
 
     /**
      * The method call.
@@ -46,7 +46,6 @@ public class AssertionOfHamcrest implements ParsedAssertion {
         this.method = call;
     }
 
-
     @Override
     public Optional<String> explanation() {
         return Optional.empty();
@@ -54,6 +53,6 @@ public class AssertionOfHamcrest implements ParsedAssertion {
 
     @Override
     public boolean isAssertion() {
-        return false;
+        return "mock".equals(this.method.getName().toString());
     }
 }

--- a/src/main/java/com/github/lombrozo/testnames/javaparser/AssertionOfJUnit.java
+++ b/src/main/java/com/github/lombrozo/testnames/javaparser/AssertionOfJUnit.java
@@ -92,7 +92,7 @@ final class AssertionOfJUnit implements ParsedAssertion {
         final NodeList<Expression> args = this.call.getArguments();
         final Optional<Expression> last = args.getLast();
         final Integer min = this.allowed.get(this.call.getName().toString());
-        if (Arrays.asList(this.SPECIAL).contains(this.call.getName().toString())) {
+        if (Arrays.asList(AssertionOfJUnit.SPECIAL).contains(this.call.getName().toString())) {
             result = Optional.of(AssertionOfJUnit.UNKNOWN_MESSAGE);
         } else if (min < args.size() && last.isPresent()) {
             result = AssertionOfJUnit.message(last.get());

--- a/src/main/java/com/github/lombrozo/testnames/javaparser/AssertionOfJavaParser.java
+++ b/src/main/java/com/github/lombrozo/testnames/javaparser/AssertionOfJavaParser.java
@@ -51,9 +51,12 @@ public final class AssertionOfJavaParser implements ParsedAssertion {
     @Override
     public Optional<String> explanation() {
         final Optional<String> result;
-        final ParsedAssertion assertion = new AssertionOfJUnit(this.call);
-        if (assertion.isAssertion()) {
-            result = assertion.explanation();
+        final ParsedAssertion junit = new AssertionOfJUnit(this.call);
+        final ParsedAssertion hamcrest = new AssertionOfHamcrest(this.call);
+        if (junit.isAssertion()) {
+            result = junit.explanation();
+        } else if (hamcrest.isAssertion()) {
+            result = hamcrest.explanation();
         } else {
             result = Optional.empty();
         }

--- a/src/test/java/com/github/lombrozo/testnames/javaparser/AssertionOfHamcrestTest.java
+++ b/src/test/java/com/github/lombrozo/testnames/javaparser/AssertionOfHamcrestTest.java
@@ -1,0 +1,35 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2022-2023 Volodya
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.github.lombrozo.testnames.javaparser;
+
+/**
+ * Test for {@link AssertionOfHamcrest}.
+ *
+ * @since 0.1.15
+ */
+class AssertionOfHamcrestTest {
+
+
+
+}

--- a/src/test/java/com/github/lombrozo/testnames/javaparser/AssertionOfHamcrestTest.java
+++ b/src/test/java/com/github/lombrozo/testnames/javaparser/AssertionOfHamcrestTest.java
@@ -23,13 +23,143 @@
  */
 package com.github.lombrozo.testnames.javaparser;
 
+import com.github.lombrozo.testnames.Assertion;
+import com.github.lombrozo.testnames.TestCase;
+import java.util.Collection;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+
 /**
  * Test for {@link AssertionOfHamcrest}.
  *
  * @since 0.1.15
+ * @todo #151:90min Continue Implementation of the AssertionOfHamcrest methods.
+ *  AssertionOfHamcrest should parse all hamcrest assertions and messages.
+ *  Now it is not implemented. When it is done, remove @Disabled annotation from all
+ *  tests in this class.
  */
 class AssertionOfHamcrestTest {
 
+    @Test
+    @Disabled
+    void parsesAllHamcrestAssertions() {
+        final int expected = 3;
+        final Collection<Assertion> assertions = AssertionOfHamcrestTest.method(
+            "withMessages"
+        ).assertions();
+        MatcherAssert.assertThat(
+            String.format(
+                "We expect %d assertions in the test case, but was %d",
+                expected,
+                assertions.size()
+            ),
+            assertions,
+            Matchers.hasSize(expected)
+        );
+    }
 
+    @Test
+    @Disabled
+    void parsesAllHamcrestMessages() {
+        final Collection<Assertion> assertions = AssertionOfHamcrestTest.method(
+            "withMessages"
+        ).assertions();
+        final String expected = "Hamcrest message";
+        MatcherAssert.assertThat(
+            String.format(
+                "We expect all assertions to have messages, but was %s",
+                assertions.stream()
+                    .map(Assertion::explanation)
+                    .filter(Optional::isPresent)
+                    .map(Optional::get)
+                    .collect(Collectors.toList())
+            ),
+            assertions.stream()
+                .map(Assertion::explanation)
+                .filter(Optional::isPresent)
+                .allMatch(message -> message.equals(expected)),
+            Matchers.is(true)
+        );
+    }
 
+    @Test
+    @Disabled
+    void ignoresJUnitAssertions() {
+        final Collection<Assertion> assertions = AssertionOfHamcrestTest.method(
+            "junitAssertions"
+        ).assertions();
+        MatcherAssert.assertThat(
+            String.format(
+                "We expect empty assertion list, but was %d",
+                assertions
+            ),
+            assertions,
+            Matchers.empty()
+        );
+    }
+
+    @Test
+    @Disabled
+    void parsesAllHamcrestAssertionsWithoutMessages() {
+        final int expected = 4;
+        final Collection<Assertion> assertions = AssertionOfHamcrestTest.method(
+            "withoutMessages"
+        ).assertions();
+        MatcherAssert.assertThat(
+            String.format(
+                "We expect %d assertions in the test case, but was %d",
+                expected,
+                assertions.size()
+            ),
+            assertions,
+            Matchers.hasSize(expected)
+        );
+    }
+
+    @Test
+    @Disabled
+    void checksIfAllHamcrestAssertionsAreActuallyWithoutMessages() {
+        final Collection<Assertion> assertions = AssertionOfHamcrestTest.method(
+            "withoutMessages"
+        ).assertions();
+        MatcherAssert.assertThat(
+            String.format(
+                "We expect all assertions to have no messages, but was %s",
+                assertions.stream()
+                    .map(Assertion::explanation)
+                    .filter(Optional::isPresent)
+                    .map(Optional::get)
+                    .collect(Collectors.toList())
+            ),
+            assertions.stream()
+                .map(Assertion::explanation)
+                .noneMatch(Optional::isPresent),
+            Matchers.is(true)
+        );
+    }
+
+    /**
+     * Returns test case by name.
+     * @param name Name of test case.
+     * @return Test case.
+     * @todo #151:30min The method AssertionOfHamcrestTest#method is duplicated.
+     *  The method AssertionOfHamcrestTest#method is duplicated in the class AssertionOfJUnitTest.
+     *  It's better to move it to the separate class and use it from both classes.
+     *  When it's done, remove this puzzle.
+     */
+    private static TestCase method(final String name) {
+        return JavaTestClasses.TEST_WITH_HAMCREST_ASSERTIONS
+            .javaParserClass().all().stream()
+            .filter(method -> name.equals(method.name()))
+            .findFirst()
+            .orElseThrow(
+                () -> {
+                    throw new IllegalStateException(String.format("Method not found: %s", name));
+                }
+            );
+    }
 }

--- a/src/test/java/com/github/lombrozo/testnames/javaparser/AssertionOfHamcrestTest.java
+++ b/src/test/java/com/github/lombrozo/testnames/javaparser/AssertionOfHamcrestTest.java
@@ -48,16 +48,16 @@ class AssertionOfHamcrestTest {
     @Disabled
     void parsesAllHamcrestAssertions() {
         final int expected = 3;
-        final Collection<Assertion> assertions = AssertionOfHamcrestTest.method(
+        final Collection<Assertion> all = AssertionOfHamcrestTest.method(
             "withMessages"
         ).assertions();
         MatcherAssert.assertThat(
             String.format(
                 "We expect %d assertions in the test case, but was %d",
                 expected,
-                assertions.size()
+                all.size()
             ),
-            assertions,
+            all,
             Matchers.hasSize(expected)
         );
     }
@@ -65,20 +65,20 @@ class AssertionOfHamcrestTest {
     @Test
     @Disabled
     void parsesAllHamcrestMessages() {
-        final Collection<Assertion> assertions = AssertionOfHamcrestTest.method(
+        final Collection<Assertion> all = AssertionOfHamcrestTest.method(
             "withMessages"
         ).assertions();
         final String expected = "Hamcrest message";
         MatcherAssert.assertThat(
             String.format(
                 "We expect all assertions to have messages, but was %s",
-                assertions.stream()
+                all.stream()
                     .map(Assertion::explanation)
                     .filter(Optional::isPresent)
                     .map(Optional::get)
                     .collect(Collectors.toList())
             ),
-            assertions.stream()
+            all.stream()
                 .map(Assertion::explanation)
                 .filter(Optional::isPresent)
                 .allMatch(message -> message.equals(expected)),
@@ -89,15 +89,12 @@ class AssertionOfHamcrestTest {
     @Test
     @Disabled
     void ignoresJUnitAssertions() {
-        final Collection<Assertion> assertions = AssertionOfHamcrestTest.method(
+        final Collection<Assertion> all = AssertionOfHamcrestTest.method(
             "junitAssertions"
         ).assertions();
         MatcherAssert.assertThat(
-            String.format(
-                "We expect empty assertion list, but was %d",
-                assertions
-            ),
-            assertions,
+            String.format("We expect empty assertion list, but was %s", all),
+            all,
             Matchers.empty()
         );
     }
@@ -106,16 +103,16 @@ class AssertionOfHamcrestTest {
     @Disabled
     void parsesAllHamcrestAssertionsWithoutMessages() {
         final int expected = 4;
-        final Collection<Assertion> assertions = AssertionOfHamcrestTest.method(
+        final Collection<Assertion> all = AssertionOfHamcrestTest.method(
             "withoutMessages"
         ).assertions();
         MatcherAssert.assertThat(
             String.format(
                 "We expect %d assertions in the test case, but was %d",
                 expected,
-                assertions.size()
+                all.size()
             ),
-            assertions,
+            all,
             Matchers.hasSize(expected)
         );
     }
@@ -123,19 +120,19 @@ class AssertionOfHamcrestTest {
     @Test
     @Disabled
     void checksIfAllHamcrestAssertionsAreActuallyWithoutMessages() {
-        final Collection<Assertion> assertions = AssertionOfHamcrestTest.method(
+        final Collection<Assertion> all = AssertionOfHamcrestTest.method(
             "withoutMessages"
         ).assertions();
         MatcherAssert.assertThat(
             String.format(
                 "We expect all assertions to have no messages, but was %s",
-                assertions.stream()
+                all.stream()
                     .map(Assertion::explanation)
                     .filter(Optional::isPresent)
                     .map(Optional::get)
                     .collect(Collectors.toList())
             ),
-            assertions.stream()
+            all.stream()
                 .map(Assertion::explanation)
                 .noneMatch(Optional::isPresent),
             Matchers.is(true)

--- a/src/test/java/com/github/lombrozo/testnames/javaparser/JavaTestClasses.java
+++ b/src/test/java/com/github/lombrozo/testnames/javaparser/JavaTestClasses.java
@@ -87,6 +87,11 @@ enum JavaTestClasses {
     TEST_WITH_JUNIT_ASSERTIONS("TestWithJUnitAssertions.java"),
 
     /**
+     * Test class with Hamcrest assertions.
+     */
+    TEST_WITH_HAMCREST_ASSERTIONS("TestWithHamcrestAssertions.java"),
+
+    /**
      * Test class with mistakes in test names.
      */
     WRONG_NAME("TestWrongName.java");

--- a/src/test/resources/TestWithHamcrestAssertions.java
+++ b/src/test/resources/TestWithHamcrestAssertions.java
@@ -1,0 +1,84 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2022-2023 Volodya
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.github.lombrozo.testnames;
+
+import java.util.function.Supplier;
+import org.hamcrest.MatcherAssert;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class TestWithHamcrestAssertions {
+
+    /**
+     * Default explanation for assertions.
+     */
+    private final static String DEFAULT_EXPLANATION = "Hamcrest explanation";
+
+    /**
+     * Default supplier for assertions.
+     */
+    private final static Supplier<String> DEFAULT_SUPPLIER = () -> TestWithJUnitAssertions.DEFAULT_EXPLANATION;
+
+    @Test
+    void withMessages() {
+        MatcherAssert.assertThat(
+            DEFAULT_EXPLANATION,
+            "1",
+            org.hamcrest.Matchers.equalTo("1")
+        );
+        MatcherAssert.assertThat(
+            DEFAULT_SUPPLIER.get(),
+            "1",
+            org.hamcrest.Matchers.equalTo("1")
+        );
+        MatcherAssert.assertThat(
+            "Hamcrest explanation",
+            true,
+            org.hamcrest.Matchers.is(true)
+        );
+    }
+
+    @Test
+    void withoutMessages() {
+        MatcherAssert.assertThat("1", org.hamcrest.Matchers.equalTo("1"));
+        MatcherAssert.assertThat(1, org.hamcrest.Matchers.equalTo(1));
+        MatcherAssert.assertThat(1L, org.hamcrest.Matchers.equalTo(1L));
+        MatcherAssert.assertThat(1.0, org.hamcrest.Matchers.is(1.0));
+    }
+
+    @Test
+    void junitAssertions() {
+        Assertions.assertEquals("1", "1", "JUnit explanation");
+        Assertions.assertTrue(true, "JUnit explanation");
+        Assertions.assertFalse(true, "JUnit explanation");
+        Assertions.assertThrows(
+            RuntimeException.class,
+            () -> {
+                throw new RuntimeException("JUnit explanation");
+            },
+            "JUnit explanation"
+        );
+    }
+}

--- a/src/test/resources/TestWithJUnitAssertions.java
+++ b/src/test/resources/TestWithJUnitAssertions.java
@@ -26,6 +26,7 @@ package com.github.lombrozo.testnames;
 
 import java.time.Duration;
 import java.util.Collections;
+import java.util.function.Supplier;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -39,7 +40,7 @@ class TestWithJUnitAssertions {
     /**
      * Default supplier for assertions.
      */
-    private final static String DEFAULT_SUPPLIER = () -> TestWithJUnitAssertions.DEFAULT_EXPLANATION;
+    private final static Supplier<String> DEFAULT_SUPPLIER = () -> TestWithJUnitAssertions.DEFAULT_EXPLANATION;
 
     @Test
     void withMessages() {


### PR DESCRIPTION
Start implementing of hamcrest assertions.

Closes: #151 

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds support for parsing Hamcrest assertions in Java tests to the `testnames` library. Here are the notable changes:

### Detailed summary
- Added `AssertionOfHamcrest` class for parsing Hamcrest assertions.
- Added `TestWithHamcrestAssertions` and `TestWithHamcrestAssertions.java` for testing Hamcrest assertions.
- Added `hamcrest` dependency to `pom.xml`.
- Added tests for `AssertionOfHamcrest`.

> The following files were skipped due to too many changes: `src/test/java/com/github/lombrozo/testnames/javaparser/AssertionOfHamcrestTest.java`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->