### PR TITLE
feat(#165): Unknown Message

### DIFF
--- a/src/main/java/com/github/lombrozo/testnames/javaparser/AssertionOfHamcrest.java
+++ b/src/main/java/com/github/lombrozo/testnames/javaparser/AssertionOfHamcrest.java
@@ -38,17 +38,6 @@ import java.util.Set;
 public final class AssertionOfHamcrest implements ParsedAssertion {
 
     /**
-     * The explanation of the assertion.
-     * The message that can't be parsed. It could be either a constant, or a method call.
-     * @todo #160:30min UNKNOWN_MESSAGE constant duplication.
-     *  The UNKNOWN_MESSAGE constant is duplicated in AssertionOfJUnit and AssertionOfHamcrest.
-     *  It should be moved to the ParsedAssertion interface or to the separate class.
-     *  When it's done, remove this puzzle.
-     */
-    private static final String UNKNOWN_MESSAGE =
-        "Unknown message. The message will be known only in runtime";
-
-    /**
      * The method call.
      */
     private final MethodCallExpr method;
@@ -95,7 +84,7 @@ public final class AssertionOfHamcrest implements ParsedAssertion {
         if (expression.isStringLiteralExpr()) {
             result = Optional.of(expression.asStringLiteralExpr().getValue());
         } else if (expression.isNameExpr() || expression.isMethodCallExpr()) {
-            result = Optional.of(AssertionOfHamcrest.UNKNOWN_MESSAGE);
+            result = new UnknownMessage().message();
         } else {
             result = Optional.empty();
         }

--- a/src/main/java/com/github/lombrozo/testnames/javaparser/AssertionOfJUnit.java
+++ b/src/main/java/com/github/lombrozo/testnames/javaparser/AssertionOfJUnit.java
@@ -42,12 +42,6 @@ import org.junit.jupiter.api.Assertions;
 final class AssertionOfJUnit implements ParsedAssertion {
 
     /**
-     * The explanation of the assertion.
-     * The message that can't be parsed. It could be either a constant, or a method call.
-     */
-    private static final String UNKNOWN_MESSAGE = "Unknown message";
-
-    /**
      * Special assertions that we consider as assertions with messages.
      */
     private static final String[] SPECIAL = {"assertAll", "fail"};
@@ -93,7 +87,7 @@ final class AssertionOfJUnit implements ParsedAssertion {
         final Optional<Expression> last = args.getLast();
         final Integer min = this.allowed.get(this.call.getName().toString());
         if (Arrays.asList(AssertionOfJUnit.SPECIAL).contains(this.call.getName().toString())) {
-            result = Optional.of(AssertionOfJUnit.UNKNOWN_MESSAGE);
+            result = new UnknownMessage().message();
         } else if (min < args.size() && last.isPresent()) {
             result = AssertionOfJUnit.message(last.get());
         } else {
@@ -112,7 +106,7 @@ final class AssertionOfJUnit implements ParsedAssertion {
         if (expression.isStringLiteralExpr()) {
             result = Optional.of(expression.asStringLiteralExpr().asString());
         } else if (expression.isNameExpr()) {
-            result = Optional.of(AssertionOfJUnit.UNKNOWN_MESSAGE);
+            result = new UnknownMessage().message();
         } else {
             result = Optional.empty();
         }

--- a/src/main/java/com/github/lombrozo/testnames/javaparser/UnknownMessage.java
+++ b/src/main/java/com/github/lombrozo/testnames/javaparser/UnknownMessage.java
@@ -1,0 +1,21 @@
+package com.github.lombrozo.testnames.javaparser;
+
+import java.util.Optional;
+
+final class UnknownMessage {
+
+    private final String msg;
+
+    UnknownMessage() {
+        this("Unknown message. The message will be known only in runtime");
+    }
+
+    private UnknownMessage(final String message) {
+        this.msg = message;
+    }
+
+    Optional<String> message() {
+        return Optional.of(this.msg);
+    }
+
+}

--- a/src/main/java/com/github/lombrozo/testnames/javaparser/UnknownMessage.java
+++ b/src/main/java/com/github/lombrozo/testnames/javaparser/UnknownMessage.java
@@ -1,19 +1,61 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2022-2023 Volodya
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package com.github.lombrozo.testnames.javaparser;
 
 import java.util.Optional;
 
+/**
+ * Unknown message.
+ *
+ * @since 0.1.15
+ */
 final class UnknownMessage {
 
+    /**
+     * The message.
+     */
     private final String msg;
 
+    /**
+     * Constructor.
+     */
     UnknownMessage() {
         this("Unknown message. The message will be known only in runtime");
     }
 
+    /**
+     * Constructor.
+     * @param message The message.
+     */
     private UnknownMessage(final String message) {
         this.msg = message;
     }
 
+    /**
+     * Retrieves message as optional.
+     * @return Optional message.
+     */
     Optional<String> message() {
         return Optional.of(this.msg);
     }


### PR DESCRIPTION
Add Unknown Message class.

Closes: #165 

<!-- start pr-codex -->

---

## PR-Codex overview
This PR refactors duplicated code in `AssertionOfHamcrest` and `AssertionOfJUnit` by creating a new `UnknownMessage` class. It also adds a license header to `UnknownMessage` and improves its documentation.

### Detailed summary
- Refactors duplicated code in `AssertionOfHamcrest` and `AssertionOfJUnit`.
- Creates a new `UnknownMessage` class.
- Adds a license header to `UnknownMessage`.
- Improves the documentation of `UnknownMessage`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->