### PR TITLE
feat(#166): Introduce JavaParser supplementary classes for tests

### DIFF
--- a/src/main/java/com/github/lombrozo/testnames/javaparser/ByName.java
+++ b/src/main/java/com/github/lombrozo/testnames/javaparser/ByName.java
@@ -1,0 +1,18 @@
+package com.github.lombrozo.testnames.javaparser;
+
+import com.github.javaparser.ast.body.MethodDeclaration;
+import java.util.function.Predicate;
+
+public class ByName implements Predicate<MethodDeclaration> {
+
+    private final String name;
+
+    public ByName(final String method) {
+        this.name = method;
+    }
+
+    @Override
+    public boolean test(final MethodDeclaration t) {
+        return this.name.equals(t.getNameAsString());
+    }
+}

--- a/src/main/java/com/github/lombrozo/testnames/javaparser/ByName.java
+++ b/src/main/java/com/github/lombrozo/testnames/javaparser/ByName.java
@@ -1,18 +1,54 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2022-2023 Volodya
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package com.github.lombrozo.testnames.javaparser;
 
 import com.github.javaparser.ast.body.MethodDeclaration;
 import java.util.function.Predicate;
 
-public class ByName implements Predicate<MethodDeclaration> {
+/**
+ * By name predicate.
+ * The predicate for filtering methods by name.
+ *
+ * @since 0.1.15
+ */
+final class ByName implements Predicate<MethodDeclaration> {
 
+    /**
+     * Method name.
+     */
     private final String name;
 
-    public ByName(final String method) {
+    /**
+     * Ctor.
+     * @param method Method name
+     */
+    ByName(final String method) {
         this.name = method;
     }
 
     @Override
-    public boolean test(final MethodDeclaration t) {
-        return this.name.equals(t.getNameAsString());
+    public boolean test(final MethodDeclaration declaration) {
+        return this.name.equals(declaration.getNameAsString());
     }
 }

--- a/src/main/java/com/github/lombrozo/testnames/javaparser/JavaParserClass.java
+++ b/src/main/java/com/github/lombrozo/testnames/javaparser/JavaParserClass.java
@@ -1,3 +1,26 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2022-2023 Volodya
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package com.github.lombrozo.testnames.javaparser;
 
 import com.github.javaparser.StaticJavaParser;
@@ -13,38 +36,78 @@ import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+/**
+ * JavaParser class.
+ * The utility class for working with JavaParser library.
+ *
+ * @since 0.1.15
+ */
 final class JavaParserClass {
 
-    private final NodeWithMembers<TypeDeclaration<?>> unit;
+    /**
+     * Parsed Java class.
+     */
+    private final NodeWithMembers<TypeDeclaration<?>> klass;
 
+    /**
+     * Ctor.
+     * @param stream Input stream with java class.
+     */
     JavaParserClass(final InputStream stream) {
         this(StaticJavaParser.parse(stream));
     }
 
+    /**
+     * Ctor.
+     * @param unit Compilation unit.
+     */
     JavaParserClass(final CompilationUnit unit) {
         this(JavaParserClass.fromCompilation(unit));
     }
 
+    /**
+     * Ctor.
+     * @param node Node with class.
+     */
     @SuppressWarnings("unchecked")
     private JavaParserClass(final Node node) {
         this((NodeWithMembers<TypeDeclaration<?>>) node);
     }
 
+    /**
+     * Ctor.
+     * @param unit Compilation unit.
+     */
     private JavaParserClass(final NodeWithMembers<TypeDeclaration<?>> unit) {
-        this.unit = unit;
+        this.klass = unit;
     }
 
+    /**
+     * Annotations of class.
+     * @return Annotations of class.
+     */
     SuppressedAnnotations annotations() {
-        return new SuppressedAnnotations((Node) this.unit);
+        return new SuppressedAnnotations((Node) this.klass);
     }
 
-    Stream<JavaParserMethod> methods(final Predicate<MethodDeclaration>... filters) {
-        return this.unit.getMethods()
+    /**
+     * Methods of class.
+     * @param filters Filters for methods.
+     * @return Methods of class.
+     */
+    @SafeVarargs
+    final Stream<JavaParserMethod> methods(final Predicate<MethodDeclaration>... filters) {
+        return this.klass.getMethods()
             .stream()
             .filter(method -> Stream.of(filters).allMatch(filter -> filter.test(method)))
             .map(JavaParserMethod::new);
     }
 
+    /**
+     * Prestructor of class.
+     * @param unit Compilation unit.
+     * @return Node with class.
+     */
     private static Node fromCompilation(final CompilationUnit unit) {
         final Queue<Node> all = unit.getChildNodes()
             .stream()

--- a/src/main/java/com/github/lombrozo/testnames/javaparser/JavaParserClass.java
+++ b/src/main/java/com/github/lombrozo/testnames/javaparser/JavaParserClass.java
@@ -1,10 +1,12 @@
 package com.github.lombrozo.testnames.javaparser;
 
+import com.github.javaparser.StaticJavaParser;
 import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.Node;
 import com.github.javaparser.ast.body.MethodDeclaration;
 import com.github.javaparser.ast.body.TypeDeclaration;
 import com.github.javaparser.ast.nodeTypes.NodeWithMembers;
+import java.io.InputStream;
 import java.util.LinkedList;
 import java.util.Queue;
 import java.util.function.Predicate;
@@ -14,6 +16,10 @@ import java.util.stream.Stream;
 final class JavaParserClass {
 
     private final NodeWithMembers<TypeDeclaration<?>> unit;
+
+    JavaParserClass(final InputStream stream) {
+        this(StaticJavaParser.parse(stream));
+    }
 
     JavaParserClass(final CompilationUnit unit) {
         this(JavaParserClass.fromCompilation(unit));
@@ -32,10 +38,11 @@ final class JavaParserClass {
         return new SuppressedAnnotations((Node) this.unit);
     }
 
-    Stream<MethodDeclaration> methods(Predicate<MethodDeclaration>... filters) {
+    Stream<JavaParserMethod> methods(final Predicate<MethodDeclaration>... filters) {
         return this.unit.getMethods()
             .stream()
-            .filter(method -> Stream.of(filters).allMatch(filter -> filter.test(method)));
+            .filter(method -> Stream.of(filters).allMatch(filter -> filter.test(method)))
+            .map(JavaParserMethod::new);
     }
 
     private static Node fromCompilation(final CompilationUnit unit) {

--- a/src/main/java/com/github/lombrozo/testnames/javaparser/JavaParserClass.java
+++ b/src/main/java/com/github/lombrozo/testnames/javaparser/JavaParserClass.java
@@ -1,0 +1,52 @@
+package com.github.lombrozo.testnames.javaparser;
+
+import com.github.javaparser.ast.CompilationUnit;
+import com.github.javaparser.ast.Node;
+import com.github.javaparser.ast.body.MethodDeclaration;
+import com.github.javaparser.ast.body.TypeDeclaration;
+import com.github.javaparser.ast.nodeTypes.NodeWithMembers;
+import java.util.LinkedList;
+import java.util.Queue;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+final class JavaParserClass {
+
+    private final NodeWithMembers<TypeDeclaration<?>> unit;
+
+    JavaParserClass(final CompilationUnit unit) {
+        this(JavaParserClass.fromCompilation(unit));
+    }
+
+    @SuppressWarnings("unchecked")
+    private JavaParserClass(final Node node) {
+        this((NodeWithMembers<TypeDeclaration<?>>) node);
+    }
+
+    private JavaParserClass(final NodeWithMembers<TypeDeclaration<?>> unit) {
+        this.unit = unit;
+    }
+
+    SuppressedAnnotations annotations() {
+        return new SuppressedAnnotations((Node) this.unit);
+    }
+
+    Stream<MethodDeclaration> methods(Predicate<MethodDeclaration>... filters) {
+        return this.unit.getMethods()
+            .stream()
+            .filter(method -> Stream.of(filters).allMatch(filter -> filter.test(method)));
+    }
+
+    private static Node fromCompilation(final CompilationUnit unit) {
+        final Queue<Node> all = unit.getChildNodes()
+            .stream()
+            .filter(node -> node instanceof TypeDeclaration<?>)
+            .collect(Collectors.toCollection(LinkedList::new));
+        if (all.isEmpty()) {
+            throw new IllegalStateException("Compilation unit has contain at least one class");
+        }
+        return all.element();
+    }
+
+}

--- a/src/main/java/com/github/lombrozo/testnames/javaparser/JavaParserMethod.java
+++ b/src/main/java/com/github/lombrozo/testnames/javaparser/JavaParserMethod.java
@@ -1,0 +1,59 @@
+package com.github.lombrozo.testnames.javaparser;
+
+import com.github.javaparser.ast.body.MethodDeclaration;
+import com.github.javaparser.ast.expr.Expression;
+import com.github.javaparser.ast.expr.MethodCallExpr;
+import com.github.javaparser.ast.stmt.BlockStmt;
+import com.github.javaparser.ast.stmt.Statement;
+import java.util.stream.Stream;
+
+final class JavaParserMethod {
+
+    private final MethodDeclaration method;
+
+    JavaParserMethod(final MethodDeclaration declaration) {
+        this.method = declaration;
+    }
+
+
+    String name() {
+        return this.method.getNameAsString();
+    }
+
+    MethodDeclaration asMethodDeclaration() {
+        return this.method;
+    }
+
+    Stream<MethodCallExpr> statements() {
+        return this.body().getStatements().stream()
+            .filter(Statement::isExpressionStmt)
+            .map(JavaParserMethod::toExpression)
+            .filter(Expression::isMethodCallExpr)
+            .map(MethodCallExpr.class::cast);
+    }
+
+    private BlockStmt body() {
+        return this.method.getBody().orElseThrow(
+            () -> new IllegalStateException(
+                String.format(
+                    "The method %s has to have body, otherwise it is not a method",
+                    this.method.getNameAsString()
+                )
+            )
+        );
+    }
+
+    /**
+     * Convert statement to expression.
+     * @param statement Statement
+     * @return Expression
+     */
+    private static Expression toExpression(final Statement statement) {
+        return statement.toExpressionStmt()
+            .orElseThrow(
+                () -> {
+                    throw new IllegalStateException("Statement is not expression");
+                }
+            ).getExpression();
+    }
+}

--- a/src/main/java/com/github/lombrozo/testnames/javaparser/JavaParserMethod.java
+++ b/src/main/java/com/github/lombrozo/testnames/javaparser/JavaParserMethod.java
@@ -1,3 +1,26 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2022-2023 Volodya
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package com.github.lombrozo.testnames.javaparser;
 
 import com.github.javaparser.ast.body.MethodDeclaration;
@@ -7,23 +30,47 @@ import com.github.javaparser.ast.stmt.BlockStmt;
 import com.github.javaparser.ast.stmt.Statement;
 import java.util.stream.Stream;
 
+/**
+ * JavaParser method.
+ * Utility class for working with JavaParser library.
+ *
+ * @since 0.1.15
+ */
 final class JavaParserMethod {
 
+    /**
+     * The method declaration.
+     */
     private final MethodDeclaration method;
 
+    /**
+     * Ctor.
+     * @param declaration Method declaration.
+     */
     JavaParserMethod(final MethodDeclaration declaration) {
         this.method = declaration;
     }
 
-
+    /**
+     * Get method name.
+     * @return Method name.
+     */
     String name() {
         return this.method.getNameAsString();
     }
 
+    /**
+     * Get method declaration.
+     * @return Method declaration.
+     */
     MethodDeclaration asMethodDeclaration() {
         return this.method;
     }
 
+    /**
+     * Get all method statements.
+     * @return Method statements.
+     */
     Stream<MethodCallExpr> statements() {
         return this.body().getStatements().stream()
             .filter(Statement::isExpressionStmt)
@@ -32,6 +79,10 @@ final class JavaParserMethod {
             .map(MethodCallExpr.class::cast);
     }
 
+    /**
+     * Get method body.
+     * @return Method body.
+     */
     private BlockStmt body() {
         return this.method.getBody().orElseThrow(
             () -> new IllegalStateException(

--- a/src/main/java/com/github/lombrozo/testnames/javaparser/JavaParserMethod.java
+++ b/src/main/java/com/github/lombrozo/testnames/javaparser/JavaParserMethod.java
@@ -29,6 +29,8 @@ import com.github.javaparser.ast.expr.MethodCallExpr;
 import com.github.javaparser.ast.stmt.BlockStmt;
 import com.github.javaparser.ast.stmt.Statement;
 import java.util.stream.Stream;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 /**
  * JavaParser method.
@@ -36,6 +38,8 @@ import java.util.stream.Stream;
  *
  * @since 0.1.15
  */
+@ToString
+@EqualsAndHashCode
 final class JavaParserMethod {
 
     /**

--- a/src/main/java/com/github/lombrozo/testnames/javaparser/TestCaseJavaParser.java
+++ b/src/main/java/com/github/lombrozo/testnames/javaparser/TestCaseJavaParser.java
@@ -80,7 +80,7 @@ final class TestCaseJavaParser implements TestCase {
      * @param method Java method
      * @checkstyle ParameterNameCheck (6 lines)
      */
-    TestCaseJavaParser(final MethodDeclaration method) {
+    private TestCaseJavaParser(final MethodDeclaration method) {
         this(method, new TestClass.Fake());
     }
 

--- a/src/main/java/com/github/lombrozo/testnames/javaparser/TestClassJavaParser.java
+++ b/src/main/java/com/github/lombrozo/testnames/javaparser/TestClassJavaParser.java
@@ -27,7 +27,6 @@ package com.github.lombrozo.testnames.javaparser;
 import com.github.javaparser.ParseProblemException;
 import com.github.javaparser.StaticJavaParser;
 import com.github.javaparser.ast.CompilationUnit;
-import com.github.javaparser.ast.body.MethodDeclaration;
 import com.github.lombrozo.testnames.TestCase;
 import com.github.lombrozo.testnames.TestClass;
 import java.io.InputStream;
@@ -144,8 +143,7 @@ public final class TestClassJavaParser implements TestClass {
     public Collection<TestCase> all() {
         try {
             return this.unit.value()
-                .methods()
-                .filter(TestClassJavaParser::isTest)
+                .methods(new TestsOnly())
                 .map(method -> new TestCaseJavaParser(method, this))
                 .collect(Collectors.toSet());
         } catch (final UncheckedIOException | ParseProblemException ex) {
@@ -169,14 +167,4 @@ public final class TestClassJavaParser implements TestClass {
         ).collect(Collectors.toSet());
     }
 
-    /**
-     * Check if method test or parameterized test.
-     *
-     * @param method To check
-     * @return Result as boolean
-     */
-    private static boolean isTest(final MethodDeclaration method) {
-        return !method.isPrivate() && (method.isAnnotationPresent("Test")
-            || method.isAnnotationPresent("ParameterizedTest"));
-    }
 }

--- a/src/main/java/com/github/lombrozo/testnames/javaparser/TestsOnly.java
+++ b/src/main/java/com/github/lombrozo/testnames/javaparser/TestsOnly.java
@@ -1,13 +1,47 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2022-2023 Volodya
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package com.github.lombrozo.testnames.javaparser;
 
 import com.github.javaparser.ast.body.MethodDeclaration;
 import java.util.function.Predicate;
 
-class TestsOnly implements Predicate<MethodDeclaration> {
+/**
+ * Tests only predicate.
+ * The predicate for filtering only test methods.
+ *
+ * @since 0.1.15
+ */
+@SuppressWarnings("PMD.JUnit4TestShouldUseTestAnnotation")
+final class TestsOnly implements Predicate<MethodDeclaration> {
 
     @Override
-    public boolean test(final MethodDeclaration t) {
-        return !t.isPrivate() && (t.isAnnotationPresent("Test")
-            || t.isAnnotationPresent("ParameterizedTest"));
+    public boolean test(final MethodDeclaration declaration) {
+        return !declaration.isPrivate()
+            &&
+            (
+                declaration.isAnnotationPresent("Test")
+                    || declaration.isAnnotationPresent("ParameterizedTest")
+            );
     }
 }

--- a/src/main/java/com/github/lombrozo/testnames/javaparser/TestsOnly.java
+++ b/src/main/java/com/github/lombrozo/testnames/javaparser/TestsOnly.java
@@ -1,0 +1,13 @@
+package com.github.lombrozo.testnames.javaparser;
+
+import com.github.javaparser.ast.body.MethodDeclaration;
+import java.util.function.Predicate;
+
+class TestsOnly implements Predicate<MethodDeclaration> {
+
+    @Override
+    public boolean test(final MethodDeclaration t) {
+        return !t.isPrivate() && (t.isAnnotationPresent("Test")
+            || t.isAnnotationPresent("ParameterizedTest"));
+    }
+}

--- a/src/test/java/com/github/lombrozo/testnames/javaparser/AssertionOfHamcrestTest.java
+++ b/src/test/java/com/github/lombrozo/testnames/javaparser/AssertionOfHamcrestTest.java
@@ -160,8 +160,17 @@ class AssertionOfHamcrestTest {
             );
     }
 
-    private static class MethodNotFound extends IllegalStateException {
+    /**
+     * Exception thrown when method not found.
+     *
+     * @since 0.1.15
+     */
+    private static final class MethodNotFound extends IllegalStateException {
 
+        /**
+         * Ctor.
+         * @param name Name of method.
+         */
         MethodNotFound(final String name) {
             super(String.format("Method not found: %s", name));
         }

--- a/src/test/java/com/github/lombrozo/testnames/javaparser/AssertionOfHamcrestTest.java
+++ b/src/test/java/com/github/lombrozo/testnames/javaparser/AssertionOfHamcrestTest.java
@@ -37,10 +37,6 @@ import org.junit.jupiter.api.Test;
  * Test for {@link AssertionOfHamcrest}.
  *
  * @since 0.1.15
- * @todo #160:90min Enable AssertionOfHamcrestTest#ignoresJUnitAssertions test.
- *  For now it's really hard to prepare correct test environment for ignoresJUnitAssertions test.
- *  We have to create several supportive classes which will make it convenient.
- *  When we have done it, just enable the test and remove that puzzle.
  */
 class AssertionOfHamcrestTest {
 

--- a/src/test/java/com/github/lombrozo/testnames/javaparser/AssertionOfHamcrestTest.java
+++ b/src/test/java/com/github/lombrozo/testnames/javaparser/AssertionOfHamcrestTest.java
@@ -26,11 +26,11 @@ package com.github.lombrozo.testnames.javaparser;
 import com.github.lombrozo.testnames.Assertion;
 import com.github.lombrozo.testnames.TestCase;
 import java.util.Collection;
+import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -121,11 +121,17 @@ class AssertionOfHamcrestTest {
     }
 
     @Test
-    @Disabled
     void ignoresJUnitAssertions() {
-        final Collection<Assertion> all = AssertionOfHamcrestTest.method(
-            "junitAssertions"
-        ).assertions();
+        final String name = "junitAssertions";
+        final List<AssertionOfHamcrest> all = JavaTestClasses.TEST_WITH_HAMCREST_ASSERTIONS
+            .toJavaParserClass()
+            .methods(new ByName(name))
+            .findFirst()
+            .orElseThrow(() -> new MethodNotFound(name))
+            .statements()
+            .map(AssertionOfHamcrest::new)
+            .filter(AssertionOfHamcrest::isAssertion)
+            .collect(Collectors.toList());
         MatcherAssert.assertThat(
             String.format("We expect empty assertion list, but was %s", all),
             all,
@@ -144,7 +150,7 @@ class AssertionOfHamcrestTest {
      */
     private static TestCase method(final String name) {
         return JavaTestClasses.TEST_WITH_HAMCREST_ASSERTIONS
-            .javaParserClass().all().stream()
+            .toTestClass().all().stream()
             .filter(method -> name.equals(method.name()))
             .findFirst()
             .orElseThrow(
@@ -152,5 +158,12 @@ class AssertionOfHamcrestTest {
                     throw new IllegalStateException(String.format("Method not found: %s", name));
                 }
             );
+    }
+
+    private static class MethodNotFound extends IllegalStateException {
+
+        MethodNotFound(final String name) {
+            super(String.format("Method not found: %s", name));
+        }
     }
 }

--- a/src/test/java/com/github/lombrozo/testnames/javaparser/AssertionOfJUnitTest.java
+++ b/src/test/java/com/github/lombrozo/testnames/javaparser/AssertionOfJUnitTest.java
@@ -162,7 +162,7 @@ class AssertionOfJUnitTest {
      */
     private static TestCase method(final String name) {
         return JavaTestClasses.TEST_WITH_JUNIT_ASSERTIONS
-            .javaParserClass().all().stream()
+            .toTestClass().all().stream()
             .filter(method -> name.equals(method.name()))
             .findFirst()
             .orElseThrow(

--- a/src/test/java/com/github/lombrozo/testnames/javaparser/JavaTestClasses.java
+++ b/src/test/java/com/github/lombrozo/testnames/javaparser/JavaTestClasses.java
@@ -114,12 +114,16 @@ enum JavaTestClasses {
      * @param suppressed Rules excluded for entire project.
      * @return Concrete test class implementation - {@link TestClassJavaParser}.
      */
-    TestClassJavaParser javaParserClass(final String... suppressed) {
+    TestClassJavaParser toTestClass(final String... suppressed) {
         return new TestClassJavaParser(
             Paths.get("."),
             this.inputStream(),
             Arrays.asList(suppressed)
         );
+    }
+
+    JavaParserClass toJavaParserClass() {
+        return new JavaParserClass(this.inputStream());
     }
 
     /**

--- a/src/test/java/com/github/lombrozo/testnames/javaparser/JavaTestClasses.java
+++ b/src/test/java/com/github/lombrozo/testnames/javaparser/JavaTestClasses.java
@@ -122,6 +122,10 @@ enum JavaTestClasses {
         );
     }
 
+    /**
+     * Creates {@link JavaParserClass} for current class.
+     * @return Concrete test class implementation - {@link JavaParserClass}.
+     */
     JavaParserClass toJavaParserClass() {
         return new JavaParserClass(this.inputStream());
     }

--- a/src/test/java/com/github/lombrozo/testnames/javaparser/TestCaseJavaParserTest.java
+++ b/src/test/java/com/github/lombrozo/testnames/javaparser/TestCaseJavaParserTest.java
@@ -76,7 +76,7 @@ class TestCaseJavaParserTest {
     @Test
     void parsesSuppressedAnnotations() {
         final Collection<String> suppressed = JavaTestClasses.ONLY_METHODS_SUPPRESSED
-            .javaParserClass()
+            .toTestClass()
             .all()
             .stream()
             .filter(method -> method.name().equals("cheksTest"))
@@ -93,7 +93,7 @@ class TestCaseJavaParserTest {
     @Test
     void parsesSingleSuppressedAnnotation() {
         final Collection<String> suppressed = JavaTestClasses.ONLY_METHODS_SUPPRESSED
-            .javaParserClass()
+            .toTestClass()
             .all()
             .stream()
             .filter(method -> method.name().equals("checksSingle"))
@@ -110,7 +110,7 @@ class TestCaseJavaParserTest {
     @Test
     void parsesSuppressedAnnotationsForClassAndMethodTogether() {
         final Collection<String> suppressed = JavaTestClasses.MANY_SUPPRESSED
-            .javaParserClass()
+            .toTestClass()
             .all()
             .stream()
             .filter(method -> method.name().equals("cheksTest"))
@@ -133,7 +133,7 @@ class TestCaseJavaParserTest {
     @Test
     @SuppressWarnings("PMD.JUnitTestContainsTooManyAsserts")
     void parsesMethodsAssertionsForJUnit() {
-        final TestClassJavaParser parser = JavaTestClasses.TEST_WITH_ASSERTIONS.javaParserClass();
+        final TestClassJavaParser parser = JavaTestClasses.TEST_WITH_ASSERTIONS.toTestClass();
         final String method = "junit";
         final Optional<TestCase> tested = parser.all().stream()
             .filter(test -> method.equals(test.name()))

--- a/src/test/java/com/github/lombrozo/testnames/javaparser/TestClassJavaParserTest.java
+++ b/src/test/java/com/github/lombrozo/testnames/javaparser/TestClassJavaParserTest.java
@@ -48,7 +48,7 @@ final class TestClassJavaParserTest {
     @Test
     void getsNames() {
         MatcherAssert.assertThat(
-            JavaTestClasses.SIMPLE.javaParserClass()
+            JavaTestClasses.SIMPLE.toTestClass()
                 .all()
                 .stream()
                 .map(TestCase::name)
@@ -62,7 +62,7 @@ final class TestClassJavaParserTest {
     @Test
     void returnsEmptyListIfItDoesNotHaveAnyCases() {
         MatcherAssert.assertThat(
-            JavaTestClasses.WITHOUT_TESTS.javaParserClass().all(),
+            JavaTestClasses.WITHOUT_TESTS.toTestClass().all(),
             Matchers.empty()
         );
     }
@@ -71,7 +71,7 @@ final class TestClassJavaParserTest {
     void getsNamesFromParameterizedCase() {
         MatcherAssert.assertThat(
             JavaTestClasses.PARAMETERIZED
-                .javaParserClass()
+                .toTestClass()
                 .all()
                 .stream()
                 .map(TestCase::name)
@@ -99,7 +99,7 @@ final class TestClassJavaParserTest {
     @Test
     void returnsEmptyListOfSuppressedRules() {
         MatcherAssert.assertThat(
-            JavaTestClasses.SIMPLE.javaParserClass().suppressed(),
+            JavaTestClasses.SIMPLE.toTestClass().suppressed(),
             Matchers.empty()
         );
     }
@@ -107,7 +107,7 @@ final class TestClassJavaParserTest {
     @Test
     void returnsNonEmptyListOfSuppressedRules() {
         final Collection<String> all = JavaTestClasses.SUPPRESSED_CLASS
-            .javaParserClass()
+            .toTestClass()
             .suppressed();
         MatcherAssert.assertThat(all, Matchers.hasSize(1));
         MatcherAssert.assertThat(
@@ -119,7 +119,7 @@ final class TestClassJavaParserTest {
     @Test
     void parsesWithLotsOfSuppressingRules() {
         final Collection<String> all = JavaTestClasses.MANY_SUPPRESSED
-            .javaParserClass()
+            .toTestClass()
             .suppressed();
         MatcherAssert.assertThat(all, Matchers.hasSize(3));
         MatcherAssert.assertThat(
@@ -137,7 +137,7 @@ final class TestClassJavaParserTest {
         final String custom = "Custom";
         final String project = "Project";
         final Collection<String> all = JavaTestClasses.MANY_SUPPRESSED
-            .javaParserClass(custom, project)
+            .toTestClass(custom, project)
             .suppressed();
         MatcherAssert.assertThat(all, Matchers.hasSize(5));
         MatcherAssert.assertThat(
@@ -155,7 +155,7 @@ final class TestClassJavaParserTest {
     @Test
     void parsesAnnotationWithSuppressedRules() {
         final Collection<String> all = JavaTestClasses.SUPPRESSED_ANNOTATION
-            .javaParserClass()
+            .toTestClass()
             .suppressed();
         MatcherAssert.assertThat(all, Matchers.hasSize(1));
         MatcherAssert.assertThat(all, Matchers.hasItem(RuleAllTestsHaveProductionClass.NAME));
@@ -164,7 +164,7 @@ final class TestClassJavaParserTest {
     @Test
     void parsesInterfaceWithSuppressedRules() {
         final Collection<String> all = JavaTestClasses.SUPPRESSED_INTERFACE
-            .javaParserClass()
+            .toTestClass()
             .suppressed();
         MatcherAssert.assertThat(all, Matchers.hasSize(1));
         MatcherAssert.assertThat(all, Matchers.hasItem(RuleAllTestsHaveProductionClass.NAME));


### PR DESCRIPTION
Introduce JavaParser supplementary classes for tests and enable `ignoresJUnitAssertions` test

Closes: #166

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces changes to the JavaTestClasses and TestClassJavaParser classes. It adds new methods to the JavaTestClasses class and renames some methods in the TestClassJavaParser class. It also adds two new predicate classes for filtering methods by name and for filtering only test methods. 

### Detailed summary
- Renamed `javaParserClass` method to `toTestClass` in `JavaTestClasses` class.
- Added `toJavaParserClass` method to `JavaTestClasses` class.
- Added `ByName` predicate class for filtering methods by name.
- Added `TestsOnly` predicate class for filtering only test methods.
- Renamed `javaParserClass` method to `toTestClass` in `TestClassJavaParser` class.
- Updated `TestClassJavaParser` class to use the new `ByName` and `TestsOnly` predicate classes.

> The following files were skipped due to too many changes: `src/main/java/com/github/lombrozo/testnames/javaparser/TestClassJavaParser.java`, `src/main/java/com/github/lombrozo/testnames/javaparser/TestCaseJavaParser.java`, `src/main/java/com/github/lombrozo/testnames/javaparser/JavaParserMethod.java`, `src/main/java/com/github/lombrozo/testnames/javaparser/JavaParserClass.java`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->