### PR TITLE
feat(#170): fix the bug related to junit messages

### DIFF
--- a/src/main/java/com/github/lombrozo/testnames/javaparser/AssertionOfJUnit.java
+++ b/src/main/java/com/github/lombrozo/testnames/javaparser/AssertionOfJUnit.java
@@ -100,12 +100,17 @@ final class AssertionOfJUnit implements ParsedAssertion {
      * The expression message.
      * @param expression The expression.
      * @return The message.
+     * @todo #170:30min Code duplication between AssertionOfJUnit and AssertionOfHamcrest.
+     *  We have the same code in both classes in the 'message' method. We need to:
+     *  Extract the common code to a new class. The new class should be used by both
+     *  AssertionOfJUnit and AssertionOfHamcrest.
+     *  After that, we should remove the puzzle.
      */
     private static Optional<String> message(final Expression expression) {
         final Optional<String> result;
         if (expression.isStringLiteralExpr()) {
             result = Optional.of(expression.asStringLiteralExpr().asString());
-        } else if (expression.isNameExpr()) {
+        } else if (expression.isNameExpr() || expression.isMethodCallExpr()) {
             result = new UnknownMessage().message();
         } else {
             result = Optional.empty();

--- a/src/test/java/com/github/lombrozo/testnames/javaparser/AssertionOfJUnitTest.java
+++ b/src/test/java/com/github/lombrozo/testnames/javaparser/AssertionOfJUnitTest.java
@@ -56,7 +56,7 @@ class AssertionOfJUnitTest {
 
     @Test
     void parsesJUnitAssertionsAllPresent() {
-        final int expected = 34;
+        final int expected = 36;
         final int actual = AssertionOfJUnitTest.method(AssertionOfJUnitTest.WITH_MESSAGES)
             .assertions().size();
         MatcherAssert.assertThat(

--- a/src/test/java/com/github/lombrozo/testnames/javaparser/AssertionOfJavaParserTest.java
+++ b/src/test/java/com/github/lombrozo/testnames/javaparser/AssertionOfJavaParserTest.java
@@ -30,17 +30,12 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 /**
  * Test for {@link AssertionOfJavaParser}.
  *
  * @since 0.1.15
- * @todo #164:30min Enable AssertionOfJavaParserTest#extractMessagesFromAllAssertions test.
- *  This test is disabled because it fails. Apparently, we have the bug in the parser of JUnit
- *  assertions. We need to fix it. After that, we should enable this test:
- *  {@link AssertionOfJavaParserTest#extractsMessagesFromAllAssertions()}
  */
 class AssertionOfJavaParserTest {
 
@@ -94,7 +89,6 @@ class AssertionOfJavaParserTest {
     }
 
     @Test
-    @Disabled
     void extractsMessagesFromAllAssertions() {
         final List<AssertionOfJavaParser> all = AssertionOfJavaParserTest
             .method("severalFrameworks")

--- a/src/test/resources/TestWithJUnitAssertions.java
+++ b/src/test/resources/TestWithJUnitAssertions.java
@@ -48,6 +48,8 @@ class TestWithJUnitAssertions {
         Assertions.assertEquals("1", "1", DEFAULT_SUPPLIER);
         Assertions.assertTrue(true, DEFAULT_EXPLANATION);
         Assertions.assertTrue(true, DEFAULT_SUPPLIER);
+        Assertions.assertTrue(true, "JUnit explanation");
+        Assertions.assertTrue(true, String.format("JUnit %s", "explanation"));
         Assertions.assertFalse(false, DEFAULT_EXPLANATION);
         Assertions.assertFalse(false, DEFAULT_SUPPLIER);
         Assertions.assertNotEquals("1", "2", DEFAULT_EXPLANATION);


### PR DESCRIPTION
Fix the bug related to junit messages.

Closes: #170 

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds JUnit assertion messages to the test suite, increases the expected size of the assertions list, and makes a minor change to `AssertionOfJUnit`. Additionally, it proposes to extract common code to a new class and fix a bug in `AssertionOfJavaParserTest`.

### Detailed summary
- `AssertionOfJUnitTest` now has two additional assertions with messages.
- The expected size of assertions in `AssertionOfJUnitTest` is increased.
- `AssertionOfJUnit` has a minor change that includes `isMethodCallExpr()` in `message()`.
- Proposes to extract common code to a new class in `AssertionOfJUnit`.
- Proposes to fix a bug in `AssertionOfJavaParserTest`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->