### PR TITLE
feat(#173): introduce StringExpression class

### DIFF
--- a/src/main/java/com/github/lombrozo/testnames/javaparser/AssertionOfJUnit.java
+++ b/src/main/java/com/github/lombrozo/testnames/javaparser/AssertionOfJUnit.java
@@ -89,29 +89,7 @@ final class AssertionOfJUnit implements ParsedAssertion {
         if (Arrays.asList(AssertionOfJUnit.SPECIAL).contains(this.call.getName().toString())) {
             result = new UnknownMessage().message();
         } else if (min < args.size() && last.isPresent()) {
-            result = AssertionOfJUnit.message(last.get());
-        } else {
-            result = Optional.empty();
-        }
-        return result;
-    }
-
-    /**
-     * The expression message.
-     * @param expression The expression.
-     * @return The message.
-     * @todo #170:30min Code duplication between AssertionOfJUnit and AssertionOfHamcrest.
-     *  We have the same code in both classes in the 'message' method. We need to:
-     *  Extract the common code to a new class. The new class should be used by both
-     *  AssertionOfJUnit and AssertionOfHamcrest.
-     *  After that, we should remove the puzzle.
-     */
-    private static Optional<String> message(final Expression expression) {
-        final Optional<String> result;
-        if (expression.isStringLiteralExpr()) {
-            result = Optional.of(expression.asStringLiteralExpr().asString());
-        } else if (expression.isNameExpr() || expression.isMethodCallExpr()) {
-            result = new UnknownMessage().message();
+            result = new StingExpression(last.get()).asString();
         } else {
             result = Optional.empty();
         }

--- a/src/main/java/com/github/lombrozo/testnames/javaparser/StingExpression.java
+++ b/src/main/java/com/github/lombrozo/testnames/javaparser/StingExpression.java
@@ -23,51 +23,41 @@
  */
 package com.github.lombrozo.testnames.javaparser;
 
-import com.github.javaparser.ast.NodeList;
 import com.github.javaparser.ast.expr.Expression;
-import com.github.javaparser.ast.expr.MethodCallExpr;
-import java.util.Collections;
 import java.util.Optional;
-import java.util.Set;
 
 /**
- * Assertion of Hamcrest.
+ * Sting expression of Java Parser.
+ * Utility class for working with JavaParser library.
+ * Extracts string expression from JavaParser expression.
  *
  * @since 0.1.15
  */
-public final class AssertionOfHamcrest implements ParsedAssertion {
+class StingExpression {
 
     /**
-     * The method call.
+     * Java Parser expression.
      */
-    private final MethodCallExpr method;
+    private final Expression expr;
 
     /**
-     * The allowed method names.
+     * Constructor.
+     * @param expression Java Parser expression.
      */
-    private final Set<String> allowed;
-
-    /**
-     * Ctor.
-     * @param call The method call.
-     */
-    AssertionOfHamcrest(final MethodCallExpr call) {
-        this.method = call;
-        this.allowed = Collections.singleton("assertThat");
+    StingExpression(final Expression expression) {
+        this.expr = expression;
     }
 
-    @Override
-    public boolean isAssertion() {
-        return this.allowed.contains(this.method.getName().toString());
-    }
-
-    @Override
-    public Optional<String> explanation() {
+    /**
+     * Get string literal from Expression if possible.
+     * @return String expression.
+     */
+    Optional<String> asString() {
         final Optional<String> result;
-        final NodeList<Expression> arguments = this.method.getArguments();
-        final Optional<Expression> first = arguments.getFirst();
-        if (arguments.size() > 2 && first.isPresent()) {
-            result = new StingExpression(first.get()).asString();
+        if (this.expr.isStringLiteralExpr()) {
+            result = Optional.of(this.expr.asStringLiteralExpr().asString());
+        } else if (this.expr.isNameExpr() || this.expr.isMethodCallExpr()) {
+            result = new UnknownMessage().message();
         } else {
             result = Optional.empty();
         }


### PR DESCRIPTION
Add `StringExpression` class in order to remove code duplication.

Closes: #173 

<!-- start pr-codex -->

---

## PR-Codex overview
This PR refactors the `AssertionOfHamcrest` and `AssertionOfJUnit` classes to extract common code to a new `StingExpression` class. The new class extracts string expressions from JavaParser expressions. 

### Detailed summary
- The `AssertionOfHamcrest` and `AssertionOfJUnit` classes have been refactored to extract common code to a new `StingExpression` class.
- The `StingExpression` class extracts string expressions from JavaParser expressions.
- The `UnknownMessage` class is used when the expression is not a string literal or a name or method call expression.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->