### PR TITLE
feat(#161): Removes method duplication between classes

### DIFF
--- a/src/test/java/com/github/lombrozo/testnames/javaparser/AssertionOfHamcrestTest.java
+++ b/src/test/java/com/github/lombrozo/testnames/javaparser/AssertionOfHamcrestTest.java
@@ -24,7 +24,6 @@
 package com.github.lombrozo.testnames.javaparser;
 
 import com.github.lombrozo.testnames.Assertion;
-import com.github.lombrozo.testnames.TestCase;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
@@ -43,9 +42,8 @@ class AssertionOfHamcrestTest {
     @Test
     void parsesAllHamcrestAssertions() {
         final int expected = 3;
-        final Collection<Assertion> all = AssertionOfHamcrestTest.method(
-            "withMessages"
-        ).assertions();
+        final Collection<Assertion> all = JavaTestClasses.TEST_WITH_HAMCREST_ASSERTIONS
+            .testCase("withMessages").assertions();
         MatcherAssert.assertThat(
             String.format(
                 "We expect %d assertions in the test case, but was %d",
@@ -59,9 +57,8 @@ class AssertionOfHamcrestTest {
 
     @Test
     void parsesAllHamcrestMessages() {
-        final Collection<Assertion> all = AssertionOfHamcrestTest.method(
-            "withMessages"
-        ).assertions();
+        final Collection<Assertion> all = JavaTestClasses.TEST_WITH_HAMCREST_ASSERTIONS
+            .testCase("withMessages").assertions();
         MatcherAssert.assertThat(
             String.format(
                 "We expect all assertions to have messages, but was %s",
@@ -81,9 +78,8 @@ class AssertionOfHamcrestTest {
     @Test
     void parsesAllHamcrestAssertionsWithoutMessages() {
         final int expected = 4;
-        final Collection<Assertion> all = AssertionOfHamcrestTest.method(
-            "withoutMessages"
-        ).assertions();
+        final Collection<Assertion> all = JavaTestClasses.TEST_WITH_HAMCREST_ASSERTIONS
+            .testCase("withoutMessages").assertions();
         MatcherAssert.assertThat(
             String.format(
                 "We expect %d assertions in the test case, but was %d",
@@ -97,9 +93,8 @@ class AssertionOfHamcrestTest {
 
     @Test
     void checksIfAllHamcrestAssertionsAreActuallyWithoutMessages() {
-        final Collection<Assertion> all = AssertionOfHamcrestTest.method(
-            "withoutMessages"
-        ).assertions();
+        final Collection<Assertion> all = JavaTestClasses.TEST_WITH_HAMCREST_ASSERTIONS
+            .testCase("withoutMessages").assertions();
         MatcherAssert.assertThat(
             String.format(
                 "We expect all assertions to have no messages, but was %s",
@@ -134,26 +129,4 @@ class AssertionOfHamcrestTest {
             Matchers.empty()
         );
     }
-
-    /**
-     * Returns test case by name.
-     * @param name Name of test case.
-     * @return Test case.
-     * @todo #151:30min The method AssertionOfHamcrestTest#method is duplicated.
-     *  The method AssertionOfHamcrestTest#method is duplicated in the class AssertionOfJUnitTest.
-     *  It's better to move it to the separate class and use it from both classes.
-     *  When it's done, remove this puzzle.
-     */
-    private static TestCase method(final String name) {
-        return JavaTestClasses.TEST_WITH_HAMCREST_ASSERTIONS
-            .toTestClass().all().stream()
-            .filter(method -> name.equals(method.name()))
-            .findFirst()
-            .orElseThrow(
-                () -> {
-                    throw new IllegalStateException(String.format("Method not found: %s", name));
-                }
-            );
-    }
-
 }

--- a/src/test/java/com/github/lombrozo/testnames/javaparser/AssertionOfHamcrestTest.java
+++ b/src/test/java/com/github/lombrozo/testnames/javaparser/AssertionOfHamcrestTest.java
@@ -113,12 +113,8 @@ class AssertionOfHamcrestTest {
 
     @Test
     void ignoresJUnitAssertions() {
-        final String name = "junitAssertions";
         final List<AssertionOfHamcrest> all = JavaTestClasses.TEST_WITH_HAMCREST_ASSERTIONS
-            .toJavaParserClass()
-            .methods(new ByName(name))
-            .findFirst()
-            .orElseThrow(() -> new MethodNotFound(name))
+            .method("junitAssertions")
             .statements()
             .map(AssertionOfHamcrest::new)
             .filter(AssertionOfHamcrest::isAssertion)

--- a/src/test/java/com/github/lombrozo/testnames/javaparser/AssertionOfJUnitTest.java
+++ b/src/test/java/com/github/lombrozo/testnames/javaparser/AssertionOfJUnitTest.java
@@ -100,7 +100,7 @@ class AssertionOfJUnitTest {
     void parsesAssertionsWithoutMessagesAllAreParsed() {
         final int expected = 17;
         final int actual = JavaTestClasses.TEST_WITH_JUNIT_ASSERTIONS
-            .testCase(AssertionOfJUnitTest.WITH_MESSAGES)
+            .testCase(AssertionOfJUnitTest.WITHOUT_MESSAGES)
             .assertions().size();
         MatcherAssert.assertThat(
             String.format("We expect to parse %d empty assertions, but was %s", expected, actual),
@@ -112,7 +112,7 @@ class AssertionOfJUnitTest {
     @Test
     void parsesAssertionsWithoutMessage() {
         final Collection<Assertion> all = JavaTestClasses.TEST_WITH_JUNIT_ASSERTIONS
-            .testCase(AssertionOfJUnitTest.WITH_MESSAGES)
+            .testCase(AssertionOfJUnitTest.WITHOUT_MESSAGES)
             .assertions();
         MatcherAssert.assertThat(
             String.format(
@@ -134,7 +134,7 @@ class AssertionOfJUnitTest {
     void parsesAllSpecialAssertionsAllAreParsed() {
         final int expected = 6;
         final int actual = JavaTestClasses.TEST_WITH_JUNIT_ASSERTIONS
-            .testCase(AssertionOfJUnitTest.WITH_MESSAGES)
+            .testCase(AssertionOfJUnitTest.SPECIAL_MESSAGES)
             .assertions().size();
         MatcherAssert.assertThat(
             String.format("We expect to parse %d special assertions, but was %s", expected, actual),
@@ -146,7 +146,7 @@ class AssertionOfJUnitTest {
     @Test
     void ignoresFailAssertion() {
         final Collection<Assertion> all = JavaTestClasses.TEST_WITH_JUNIT_ASSERTIONS
-            .testCase(AssertionOfJUnitTest.WITH_MESSAGES)
+            .testCase(AssertionOfJUnitTest.SPECIAL_MESSAGES)
             .assertions();
         MatcherAssert.assertThat(
             String.format(

--- a/src/test/java/com/github/lombrozo/testnames/javaparser/AssertionOfJUnitTest.java
+++ b/src/test/java/com/github/lombrozo/testnames/javaparser/AssertionOfJUnitTest.java
@@ -24,7 +24,6 @@
 package com.github.lombrozo.testnames.javaparser;
 
 import com.github.lombrozo.testnames.Assertion;
-import com.github.lombrozo.testnames.TestCase;
 import java.util.Collection;
 import java.util.Optional;
 import java.util.stream.Collectors;

--- a/src/test/java/com/github/lombrozo/testnames/javaparser/AssertionOfJUnitTest.java
+++ b/src/test/java/com/github/lombrozo/testnames/javaparser/AssertionOfJUnitTest.java
@@ -57,7 +57,8 @@ class AssertionOfJUnitTest {
     @Test
     void parsesJUnitAssertionsAllPresent() {
         final int expected = 36;
-        final int actual = AssertionOfJUnitTest.method(AssertionOfJUnitTest.WITH_MESSAGES)
+        final int actual = JavaTestClasses.TEST_WITH_JUNIT_ASSERTIONS
+            .testCase(AssertionOfJUnitTest.WITH_MESSAGES)
             .assertions().size();
         MatcherAssert.assertThat(
             String.format("We expect to parse %d assertions, but was %s", expected, actual),
@@ -70,7 +71,8 @@ class AssertionOfJUnitTest {
     void parsesJUnitAssertionsAllHaveExplanation() {
         MatcherAssert.assertThat(
             "All assertions should have explanation assertions",
-            AssertionOfJUnitTest.method(AssertionOfJUnitTest.WITH_MESSAGES)
+            JavaTestClasses.TEST_WITH_JUNIT_ASSERTIONS
+                .testCase(AssertionOfJUnitTest.WITH_MESSAGES)
                 .assertions()
                 .stream()
                 .map(Assertion::explanation)
@@ -83,7 +85,8 @@ class AssertionOfJUnitTest {
     void parsesJUnitAssertionsNoneHasEmptyExplanation() {
         MatcherAssert.assertThat(
             "All assertions should have JUnit explanation text",
-            AssertionOfJUnitTest.method(AssertionOfJUnitTest.WITH_MESSAGES)
+            JavaTestClasses.TEST_WITH_JUNIT_ASSERTIONS
+                .testCase(AssertionOfJUnitTest.WITH_MESSAGES)
                 .assertions().stream()
                 .map(Assertion::explanation)
                 .filter(Optional::isPresent)
@@ -96,7 +99,8 @@ class AssertionOfJUnitTest {
     @Test
     void parsesAssertionsWithoutMessagesAllAreParsed() {
         final int expected = 17;
-        final int actual = AssertionOfJUnitTest.method(AssertionOfJUnitTest.WITHOUT_MESSAGES)
+        final int actual = JavaTestClasses.TEST_WITH_JUNIT_ASSERTIONS
+            .testCase(AssertionOfJUnitTest.WITH_MESSAGES)
             .assertions().size();
         MatcherAssert.assertThat(
             String.format("We expect to parse %d empty assertions, but was %s", expected, actual),
@@ -107,9 +111,9 @@ class AssertionOfJUnitTest {
 
     @Test
     void parsesAssertionsWithoutMessage() {
-        final Collection<Assertion> all = AssertionOfJUnitTest.method(
-            AssertionOfJUnitTest.WITHOUT_MESSAGES
-        ).assertions();
+        final Collection<Assertion> all = JavaTestClasses.TEST_WITH_JUNIT_ASSERTIONS
+            .testCase(AssertionOfJUnitTest.WITH_MESSAGES)
+            .assertions();
         MatcherAssert.assertThat(
             String.format(
                 "All assertions should be without assertion message, but was: %s",
@@ -129,7 +133,8 @@ class AssertionOfJUnitTest {
     @Test
     void parsesAllSpecialAssertionsAllAreParsed() {
         final int expected = 6;
-        final int actual = AssertionOfJUnitTest.method(AssertionOfJUnitTest.SPECIAL_MESSAGES)
+        final int actual = JavaTestClasses.TEST_WITH_JUNIT_ASSERTIONS
+            .testCase(AssertionOfJUnitTest.WITH_MESSAGES)
             .assertions().size();
         MatcherAssert.assertThat(
             String.format("We expect to parse %d special assertions, but was %s", expected, actual),
@@ -140,9 +145,9 @@ class AssertionOfJUnitTest {
 
     @Test
     void ignoresFailAssertion() {
-        final Collection<Assertion> all = AssertionOfJUnitTest.method(
-            AssertionOfJUnitTest.SPECIAL_MESSAGES
-        ).assertions();
+        final Collection<Assertion> all = JavaTestClasses.TEST_WITH_JUNIT_ASSERTIONS
+            .testCase(AssertionOfJUnitTest.WITH_MESSAGES)
+            .assertions();
         MatcherAssert.assertThat(
             String.format(
                 "We should accept special assertions as assertions with explanation, but was %s",
@@ -153,22 +158,5 @@ class AssertionOfJUnitTest {
                 .allMatch(Optional::isPresent),
             Matchers.is(true)
         );
-    }
-
-    /**
-     * Returns test case by name.
-     * @param name Name of test case.
-     * @return Test case.
-     */
-    private static TestCase method(final String name) {
-        return JavaTestClasses.TEST_WITH_JUNIT_ASSERTIONS
-            .toTestClass().all().stream()
-            .filter(method -> name.equals(method.name()))
-            .findFirst()
-            .orElseThrow(
-                () -> {
-                    throw new IllegalStateException(String.format("Method not found: %s", name));
-                }
-            );
     }
 }

--- a/src/test/java/com/github/lombrozo/testnames/javaparser/AssertionOfJavaParserTest.java
+++ b/src/test/java/com/github/lombrozo/testnames/javaparser/AssertionOfJavaParserTest.java
@@ -23,11 +23,9 @@
  */
 package com.github.lombrozo.testnames.javaparser;
 
-import com.github.javaparser.ast.expr.MethodCallExpr;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
@@ -46,7 +44,9 @@ class AssertionOfJavaParserTest {
 
     @Test
     void parsesJunitAssertionOnly() {
-        final List<AssertionOfJavaParser> all = AssertionOfJavaParserTest.method("junit")
+        final List<AssertionOfJavaParser> all = JavaTestClasses.TEST_WITH_ASSERTIONS
+            .method("junit")
+            .statements()
             .map(AssertionOfJavaParser::new)
             .filter(AssertionOfJavaParser::isAssertion)
             .collect(Collectors.toList());
@@ -60,8 +60,9 @@ class AssertionOfJavaParserTest {
 
     @Test
     void parsesHamcrestAssertionOnly() {
-        final List<AssertionOfJavaParser> all = AssertionOfJavaParserTest
+        final List<AssertionOfJavaParser> all = JavaTestClasses.TEST_WITH_ASSERTIONS
             .method("hamcrestAssertion")
+            .statements()
             .map(AssertionOfJavaParser::new)
             .filter(AssertionOfJavaParser::isAssertion)
             .collect(Collectors.toList());
@@ -75,8 +76,9 @@ class AssertionOfJavaParserTest {
 
     @Test
     void parsesSeveralAssertionsFromDifferentLibraries() {
-        final List<AssertionOfJavaParser> all = AssertionOfJavaParserTest
+        final List<AssertionOfJavaParser> all = JavaTestClasses.TEST_WITH_ASSERTIONS
             .method("severalFrameworks")
+            .statements()
             .map(AssertionOfJavaParser::new)
             .filter(AssertionOfJavaParser::isAssertion)
             .collect(Collectors.toList());
@@ -90,8 +92,9 @@ class AssertionOfJavaParserTest {
 
     @Test
     void extractsMessagesFromAllAssertions() {
-        final List<AssertionOfJavaParser> all = AssertionOfJavaParserTest
+        final List<AssertionOfJavaParser> all = JavaTestClasses.TEST_WITH_ASSERTIONS
             .method("severalFrameworks")
+            .statements()
             .map(AssertionOfJavaParser::new)
             .filter(AssertionOfJavaParser::isAssertion)
             .collect(Collectors.toList());
@@ -111,8 +114,9 @@ class AssertionOfJavaParserTest {
 
     @Test
     void parsesAssertionsWithoutMessage() {
-        final List<AssertionOfJavaParser> all = AssertionOfJavaParserTest
+        final List<AssertionOfJavaParser> all = JavaTestClasses.TEST_WITH_ASSERTIONS
             .method("assertionsWithoutMesssages")
+            .statements()
             .map(AssertionOfJavaParser::new)
             .filter(AssertionOfJavaParser::isAssertion)
             .collect(Collectors.toList());
@@ -128,18 +132,5 @@ class AssertionOfJavaParserTest {
                 .noneMatch(Optional::isPresent),
             Matchers.is(true)
         );
-    }
-
-    /**
-     * Returns all statements of the method with the given name.
-     * @param name Name of the method.
-     * @return All statements of the method with the given name.
-     */
-    private static Stream<MethodCallExpr> method(final String name) {
-        return JavaTestClasses.TEST_WITH_ASSERTIONS.toJavaParserClass()
-            .methods(new ByName(name))
-            .findFirst()
-            .orElseThrow(() -> new MethodNotFound(name))
-            .statements();
     }
 }

--- a/src/test/java/com/github/lombrozo/testnames/javaparser/JavaTestClasses.java
+++ b/src/test/java/com/github/lombrozo/testnames/javaparser/JavaTestClasses.java
@@ -123,6 +123,13 @@ enum JavaTestClasses {
         );
     }
 
+    JavaParserMethod method(final String name) {
+        return JavaTestClasses.TEST_WITH_ASSERTIONS.toJavaParserClass()
+            .methods(new ByName(name))
+            .findFirst()
+            .orElseThrow(() -> new MethodNotFound(name));
+    }
+
     TestCase testCase(final String name) {
         return this.toTestClass().all()
             .stream()

--- a/src/test/java/com/github/lombrozo/testnames/javaparser/JavaTestClasses.java
+++ b/src/test/java/com/github/lombrozo/testnames/javaparser/JavaTestClasses.java
@@ -23,6 +23,7 @@
  */
 package com.github.lombrozo.testnames.javaparser;
 
+import com.github.lombrozo.testnames.TestCase;
 import java.io.InputStream;
 import java.nio.file.Paths;
 import java.util.Arrays;
@@ -120,6 +121,18 @@ enum JavaTestClasses {
             this.inputStream(),
             Arrays.asList(suppressed)
         );
+    }
+
+    TestCase testCase(final String name) {
+        return this.toTestClass().all()
+            .stream()
+            .filter(method -> name.equals(method.name()))
+            .findFirst()
+            .orElseThrow(
+                () -> {
+                    throw new IllegalStateException(String.format("Method not found: %s", name));
+                }
+            );
     }
 
     /**

--- a/src/test/java/com/github/lombrozo/testnames/javaparser/JavaTestClasses.java
+++ b/src/test/java/com/github/lombrozo/testnames/javaparser/JavaTestClasses.java
@@ -123,13 +123,23 @@ enum JavaTestClasses {
         );
     }
 
+    /**
+     * Returns method by name.
+     * @param name Method name.
+     * @return Method.
+     */
     JavaParserMethod method(final String name) {
-        return JavaTestClasses.TEST_WITH_ASSERTIONS.toJavaParserClass()
+        return new JavaParserClass(this.inputStream())
             .methods(new ByName(name))
             .findFirst()
             .orElseThrow(() -> new MethodNotFound(name));
     }
 
+    /**
+     * Returns test case by name.
+     * @param name Test case name.
+     * @return Test case.
+     */
     TestCase testCase(final String name) {
         return this.toTestClass().all()
             .stream()
@@ -137,17 +147,9 @@ enum JavaTestClasses {
             .findFirst()
             .orElseThrow(
                 () -> {
-                    throw new IllegalStateException(String.format("Method not found: %s", name));
+                    throw new MethodNotFound(name);
                 }
             );
-    }
-
-    /**
-     * Creates {@link JavaParserClass} for current class.
-     * @return Concrete test class implementation - {@link JavaParserClass}.
-     */
-    JavaParserClass toJavaParserClass() {
-        return new JavaParserClass(this.inputStream());
     }
 
     /**

--- a/src/test/java/com/github/lombrozo/testnames/javaparser/TestCaseJavaParserTest.java
+++ b/src/test/java/com/github/lombrozo/testnames/javaparser/TestCaseJavaParserTest.java
@@ -76,12 +76,7 @@ class TestCaseJavaParserTest {
     @Test
     void parsesSuppressedAnnotations() {
         final Collection<String> suppressed = JavaTestClasses.ONLY_METHODS_SUPPRESSED
-            .toTestClass()
-            .all()
-            .stream()
-            .filter(method -> method.name().equals("cheksTest"))
-            .findFirst()
-            .orElseThrow(IllegalStateException::new)
+            .testCase("cheksTest")
             .suppressed();
         MatcherAssert.assertThat(suppressed, Matchers.hasSize(2));
         MatcherAssert.assertThat(
@@ -93,12 +88,7 @@ class TestCaseJavaParserTest {
     @Test
     void parsesSingleSuppressedAnnotation() {
         final Collection<String> suppressed = JavaTestClasses.ONLY_METHODS_SUPPRESSED
-            .toTestClass()
-            .all()
-            .stream()
-            .filter(method -> method.name().equals("checksSingle"))
-            .findFirst()
-            .orElseThrow(IllegalStateException::new)
+            .testCase("checksSingle")
             .suppressed();
         MatcherAssert.assertThat(suppressed, Matchers.hasSize(1));
         MatcherAssert.assertThat(
@@ -110,12 +100,7 @@ class TestCaseJavaParserTest {
     @Test
     void parsesSuppressedAnnotationsForClassAndMethodTogether() {
         final Collection<String> suppressed = JavaTestClasses.MANY_SUPPRESSED
-            .toTestClass()
-            .all()
-            .stream()
-            .filter(method -> method.name().equals("cheksTest"))
-            .findFirst()
-            .orElseThrow(IllegalStateException::new)
+            .testCase("cheksTest")
             .suppressed();
         MatcherAssert.assertThat(suppressed, Matchers.hasSize(5));
         MatcherAssert.assertThat(


### PR DESCRIPTION
Removes method duplication between classes.

Closes: #161 

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds new methods to the `JavaTestClasses` class to retrieve specific test cases and methods, and refactors the test classes to use these new methods. It also removes duplicated code from the `AssertionOfJavaParserTest` and `AssertionOfHamcrestTest` classes.

### Detailed summary
- Added `method` method to `JavaTestClasses` class to retrieve a specific test case or method
- Added `testCase` method to `JavaTestClasses` class to retrieve a specific test case
- Refactored test classes to use the new `method` and `testCase` methods
- Removed duplicated `method` method from `AssertionOfJavaParserTest` and `AssertionOfHamcrestTest` classes

> The following files were skipped due to too many changes: `src/test/java/com/github/lombrozo/testnames/javaparser/AssertionOfJUnitTest.java`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->