### PR TITLE
feat(#145): Add RuleAssertionMessage to the entire Cop pipeline

### DIFF
--- a/src/it/all-have-production-class/pom.xml
+++ b/src/it/all-have-production-class/pom.xml
@@ -62,6 +62,11 @@ SOFTWARE.
             </goals>
             <configuration>
               <failOnError>false</failOnError>
+              <exclusions>
+                <exclusion>
+                  JTCOP.RuleAssertionMessage
+                </exclusion>
+              </exclusions>
             </configuration>
           </execution>
         </executions>

--- a/src/it/assertions/pom.xml
+++ b/src/it/assertions/pom.xml
@@ -22,7 +22,9 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.github.volodya-lombrozo</groupId>
   <artifactId>jtcop-it</artifactId>
@@ -60,6 +62,21 @@ SOFTWARE.
         <groupId>com.github.volodya-lombrozo</groupId>
         <artifactId>jtcop-maven-plugin</artifactId>
         <version>@project.version@</version>
+        <executions>
+          <execution>
+            <id>integration-test</id>
+            <goals>
+              <goal>check</goal>
+            </goals>
+            <configuration>
+              <exclusions>
+                <exclusion>
+                  JTCOP.RuleAllTestsHaveProductionClass
+                </exclusion>
+              </exclusions>
+            </configuration>
+          </execution>
+        </executions>
       </plugin>
     </plugins>
   </build>

--- a/src/it/assertions/pom.xml
+++ b/src/it/assertions/pom.xml
@@ -22,9 +22,7 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.github.volodya-lombrozo</groupId>
   <artifactId>jtcop-it</artifactId>

--- a/src/it/assertions/pom.xml
+++ b/src/it/assertions/pom.xml
@@ -47,6 +47,12 @@ SOFTWARE.
       <version>5.9.3</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest</artifactId>
+      <version>2.2</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
   <build>
     <plugins>
@@ -54,21 +60,6 @@ SOFTWARE.
         <groupId>com.github.volodya-lombrozo</groupId>
         <artifactId>jtcop-maven-plugin</artifactId>
         <version>@project.version@</version>
-        <executions>
-          <execution>
-            <id>integration-test</id>
-            <goals>
-              <goal>check</goal>
-            </goals>
-            <configuration>
-              <exclusions>
-                <exclusion>
-                  JTCOP.RuleAllTestsHaveProductionClass
-                </exclusion>
-              </exclusions>
-            </configuration>
-          </execution>
-        </executions>
       </plugin>
     </plugins>
   </build>

--- a/src/it/assertions/src/test/java/AssertionsTest.java
+++ b/src/it/assertions/src/test/java/AssertionsTest.java
@@ -87,12 +87,14 @@ class AssertionsTest {
     }
 
     @Test
+    @SuppressWarnings("JTCOP.RuleAssertionMessage")
     void ignoresJUnitAssertions() {
         Assertions.assertSame(1, 1);
         Assertions.assertSame(1, 1);
     }
 
     @Test
+    @SuppressWarnings("JTCOP.RuleAssertionMessage")
     void ignoresHamcrestAssertions() {
         MatcherAssert.assertThat(
             "1",

--- a/src/it/assertions/src/test/java/AssertionsTest.java
+++ b/src/it/assertions/src/test/java/AssertionsTest.java
@@ -1,0 +1,112 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2022-2023 Volodya
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Assertions;
+
+class AssertionsTest {
+
+    /**
+     * Default explanation for assertions.
+     */
+    private final static String CONSTANT = "Message";
+
+    @Test
+    void checksJUnitASsertions() {
+        Assertions.assertEquals("1", "1", message());
+        Assertions.assertEquals("1", "1", "Message");
+        Assertions.assertTrue(true, "Message");
+        Assertions.assertFalse(true, message());
+        Assertions.assertNotNull(new Object(), CONSTANT);
+        Assertions.assertNotNull(new Object(), message());
+    }
+
+    @Test
+    void checksHamcrestAssertions() {
+        MatcherAssert.assertThat(
+            CONSTANT,
+            "1",
+            Matchers.equalTo("1")
+        );
+        MatcherAssert.assertThat(
+            message(),
+            "1",
+            Matchers.equalTo("1")
+        );
+        MatcherAssert.assertThat(
+            "Message",
+            true,
+            Matchers.is(true)
+        );
+    }
+
+    @Test
+    void checksCombinedAssertions() {
+        Assertions.assertSame(1, 1, "Message");
+        Assertions.assertSame(1, 1, CONSTANT);
+        Assertions.assertNull(null, "Message");
+        Assertions.assertNull(null, CONSTANT);
+        MatcherAssert.assertThat(
+            CONSTANT,
+            "1",
+            Matchers.equalTo("1")
+        );
+        MatcherAssert.assertThat(
+            message(),
+            "1",
+            Matchers.equalTo("1")
+        );
+        MatcherAssert.assertThat(
+            "Message",
+            true,
+            Matchers.is(true)
+        );
+    }
+
+    @Test
+    void ignoresJUnitAssertions() {
+        Assertions.assertSame(1, 1);
+        Assertions.assertSame(1, 1);
+    }
+
+    @Test
+    void ignoresHamcrestAssertions() {
+        MatcherAssert.assertThat(
+            "1",
+            Matchers.equalTo("1")
+        );
+        MatcherAssert.assertThat(
+            "1",
+            Matchers.equalTo("1")
+        );
+        MatcherAssert.assertThat(
+            true,
+            Matchers.is(true)
+        );
+    }
+
+    private String message() {
+        return "Message";
+    }
+}

--- a/src/it/assertions/src/test/java/AssertionsTest.java
+++ b/src/it/assertions/src/test/java/AssertionsTest.java
@@ -24,6 +24,8 @@
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Assertions;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
 
 class AssertionsTest {
 
@@ -33,11 +35,11 @@ class AssertionsTest {
     private final static String CONSTANT = "Message";
 
     @Test
-    void checksJUnitASsertions() {
+    void checksJUnitAssertions() {
         Assertions.assertEquals("1", "1", message());
         Assertions.assertEquals("1", "1", "Message");
         Assertions.assertTrue(true, "Message");
-        Assertions.assertFalse(true, message());
+        Assertions.assertFalse(false, message());
         Assertions.assertNotNull(new Object(), CONSTANT);
         Assertions.assertNotNull(new Object(), message());
     }

--- a/src/it/assertions/verify.groovy
+++ b/src/it/assertions/verify.groovy
@@ -1,0 +1,26 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2022-2023 Volodya
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+String log = new File(basedir, 'build.log').text;
+log.contains("BUILD SUCCESS")
+true

--- a/src/it/exclusions/pom.xml
+++ b/src/it/exclusions/pom.xml
@@ -65,6 +65,9 @@ SOFTWARE.
                 <exclusion>
                   JTCOP.RuleAllTestsHaveProductionClass
                 </exclusion>
+                <exclusion>
+                  JTCOP.RuleAssertionMessage
+                </exclusion>
               </exclusions>
             </configuration>
           </execution>

--- a/src/it/exclusions/pom.xml
+++ b/src/it/exclusions/pom.xml
@@ -60,13 +60,6 @@ SOFTWARE.
             <goals>
               <goal>check</goal>
             </goals>
-            <configuration>
-              <exclusions>
-                <exclusion>
-                  JTCOP.RuleAllTestsHaveProductionClass
-                </exclusion>
-              </exclusions>
-            </configuration>
           </execution>
         </executions>
       </plugin>

--- a/src/main/java/com/github/lombrozo/testnames/TestCase.java
+++ b/src/main/java/com/github/lombrozo/testnames/TestCase.java
@@ -113,7 +113,7 @@ public interface TestCase {
          * @param name The name of test case
          * @param asserts Assertions of test case
          */
-        public Fake(final String name, Assertion... asserts) {
+        public Fake(final String name, final Assertion... asserts) {
             this(name, Collections.emptyList(), Arrays.asList(asserts));
         }
 

--- a/src/main/java/com/github/lombrozo/testnames/TestCase.java
+++ b/src/main/java/com/github/lombrozo/testnames/TestCase.java
@@ -111,6 +111,15 @@ public interface TestCase {
         /**
          * Ctor.
          * @param name The name of test case
+         * @param asserts Assertions of test case
+         */
+        public Fake(final String name, Assertion... asserts) {
+            this(name, Collections.emptyList(), Arrays.asList(asserts));
+        }
+
+        /**
+         * Ctor.
+         * @param name The name of test case
          * @param suppressed The suppressed rules
          */
         public Fake(final String name, final Collection<String> suppressed) {

--- a/src/main/java/com/github/lombrozo/testnames/javaparser/AssertionOfJavaParser.java
+++ b/src/main/java/com/github/lombrozo/testnames/javaparser/AssertionOfJavaParser.java
@@ -25,14 +25,12 @@ package com.github.lombrozo.testnames.javaparser;
 
 import com.github.javaparser.ast.expr.MethodCallExpr;
 import java.util.Optional;
-import lombok.ToString;
 
 /**
  * The assertion of the test method.
  *
  * @since 0.1.15
  */
-@ToString
 public final class AssertionOfJavaParser implements ParsedAssertion {
 
     /**
@@ -67,5 +65,10 @@ public final class AssertionOfJavaParser implements ParsedAssertion {
     public boolean isAssertion() {
         return new AssertionOfJUnit(this.call).isAssertion()
             || new AssertionOfHamcrest(this.call).isAssertion();
+    }
+
+    @Override
+    public String toString() {
+        return this.call.toString();
     }
 }

--- a/src/main/java/com/github/lombrozo/testnames/rules/RuleAssertionMessage.java
+++ b/src/main/java/com/github/lombrozo/testnames/rules/RuleAssertionMessage.java
@@ -35,11 +35,6 @@ import java.util.Collections;
  * The rule that checks that test method has assertion and the assertion message is not empty.
  *
  * @since 0.1.15
- * @todo #67:90min Add RuleAssertionMessage to the Cop checking pipeline.
- *  We have to add the RuleAssertionMessage rule to the Cop checking pipeline.
- *  For now, it's just added to repository and doesn't work during the entire check.
- *  I believe it makes sense to add this rule when it will work without any problems
- *  and we will have integration tests that check it.
  */
 class RuleAssertionMessage implements Rule {
 

--- a/src/main/java/com/github/lombrozo/testnames/rules/RuleAssertionMessage.java
+++ b/src/main/java/com/github/lombrozo/testnames/rules/RuleAssertionMessage.java
@@ -125,7 +125,7 @@ class RuleAssertionMessage implements Rule {
         @Override
         public String message() {
             return String.format(
-                "Method %s has assertion without message: %s, please add the explanation message to make the test more readable",
+                "Method '%s' has assertion without message: '%s', please add the explanation message to make the test more readable",
                 this.method.name(),
                 this.assertion
             );

--- a/src/main/java/com/github/lombrozo/testnames/rules/RulePresentSimple.java
+++ b/src/main/java/com/github/lombrozo/testnames/rules/RulePresentSimple.java
@@ -54,7 +54,8 @@ public final class RulePresentSimple implements Rule {
             new RuleNotContainsTestWord(test),
             new RuleNotSpam(test),
             new RuleNotUsesSpecialCharacters(test),
-            new RulePresentTense(test)
+            new RulePresentTense(test),
+            new RuleAssertionMessage(test)
         ).map(rule -> new RuleSuppressed(rule, test)).collect(Collectors.toList());
     }
 

--- a/src/test/java/com/github/lombrozo/testnames/rules/RuleAllTestsInPresentSimpleTest.java
+++ b/src/test/java/com/github/lombrozo/testnames/rules/RuleAllTestsInPresentSimpleTest.java
@@ -24,6 +24,7 @@
 
 package com.github.lombrozo.testnames.rules;
 
+import com.github.lombrozo.testnames.Assertion;
 import com.github.lombrozo.testnames.TestCase;
 import com.github.lombrozo.testnames.TestClass;
 import java.util.Collections;
@@ -43,8 +44,8 @@ final class RuleAllTestsInPresentSimpleTest {
         MatcherAssert.assertThat(
             new RuleAllTestsInPresentSimple(
                 new TestClass.Fake(
-                    new TestCase.Fake("removes"),
-                    new TestCase.Fake("creates")
+                    new TestCase.Fake("removes", new Assertion.Fake()),
+                    new TestCase.Fake("creates", new Assertion.Fake())
                 )
             ).complaints(),
             Matchers.empty()
@@ -56,8 +57,8 @@ final class RuleAllTestsInPresentSimpleTest {
         MatcherAssert.assertThat(
             new RuleAllTestsInPresentSimple(
                 new TestClass.Fake(
-                    new TestCase.Fake("remove"),
-                    new TestCase.Fake("create")
+                    new TestCase.Fake("remove", new Assertion.Fake()),
+                    new TestCase.Fake("create", new Assertion.Fake())
                 )
             ).complaints(),
             Matchers.allOf(Matchers.hasSize(1))
@@ -71,11 +72,13 @@ final class RuleAllTestsInPresentSimpleTest {
                 new TestClass.Fake(
                     new TestCase.Fake(
                         "remove",
-                        Collections.singletonList("RulePresentTense")
+                        Collections.singletonList("RulePresentTense"),
+                        Collections.singletonList(new Assertion.Fake())
                     ),
                     new TestCase.Fake(
                         "create",
-                        Collections.singletonList("RulePresentTense")
+                        Collections.singletonList("RulePresentTense"),
+                        Collections.singletonList(new Assertion.Fake())
                     )
                 )
             ).complaints(),
@@ -87,8 +90,8 @@ final class RuleAllTestsInPresentSimpleTest {
     void skipsSomeSuppressedChecksOnClassLevel() {
         final TestClass.Fake klass = new TestClass.Fake(
             Collections.singletonList("RuleAllTestsInPresentSimple"),
-            new TestCase.Fake("remove"),
-            new TestCase.Fake("create")
+            new TestCase.Fake("remove", new Assertion.Fake()),
+            new TestCase.Fake("create", new Assertion.Fake())
         );
         MatcherAssert.assertThat(
             new RuleSuppressed(new RuleAllTestsInPresentSimple(klass), klass).complaints(),

--- a/src/test/java/com/github/lombrozo/testnames/rules/RuleTest.java
+++ b/src/test/java/com/github/lombrozo/testnames/rules/RuleTest.java
@@ -24,6 +24,7 @@
 
 package com.github.lombrozo.testnames.rules;
 
+import com.github.lombrozo.testnames.Assertion;
 import com.github.lombrozo.testnames.Complaint;
 import com.github.lombrozo.testnames.TestCase;
 import java.util.Collection;
@@ -74,7 +75,7 @@ final class RuleTest {
     })
     void validatesCorrectly(final String name, final boolean expected) {
         final Collection<Complaint> complaints = new RulePresentSimple(
-            new TestCase.Fake(name)
+            new TestCase.Fake(name, new Assertion.Fake("Some message"))
         ).complaints();
         MatcherAssert.assertThat(
             complaints.toString(),


### PR DESCRIPTION
Add `RuleAssertionMessage` to the entire `Cop` pipeline.

Closes: #145

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds a new rule, `RuleAssertionMessage`, to the Cop checking pipeline. It also adds some test cases and assertions.

### Detailed summary
- Added `RuleAssertionMessage` to the Cop checking pipeline
- Added some test cases and assertions

> The following files were skipped due to too many changes: `src/it/assertions/src/test/java/AssertionsTest.java`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->