### PR TITLE
feat(#180): informative description

### DIFF
--- a/docs/rules/not-spam.md
+++ b/docs/rules/not-spam.md
@@ -1,0 +1,4 @@
+@todo #180:90min Add documentation for the RuleNotSpam. The documentation
+ should be added to the `docs/rules/not-spam.md` file. The documentation
+ should contain the description of the rule and the examples of the correct
+ and incorrect code.

--- a/docs/rules/not-special-characters.md
+++ b/docs/rules/not-special-characters.md
@@ -1,4 +1,4 @@
 @todo #180:90min Add documentation for the `RuleNotUsesSpecialCharacters` rule. 
- The documentation should be added to the `docs/rules/not-spam.md` file. 
- The documentation should contain the description of the rule and the 
+ The documentation should be added to the `docs/rules/not-special-characters.md`
+ file. The documentation should contain the description of the rule and the 
  examples of the correct and incorrect code.

--- a/docs/rules/not-special-characters.md
+++ b/docs/rules/not-special-characters.md
@@ -1,0 +1,4 @@
+@todo #180:90min Add documentation for the `RuleNotUsesSpecialCharacters` rule. 
+ The documentation should be added to the `docs/rules/not-spam.md` file. 
+ The documentation should contain the description of the rule and the 
+ examples of the correct and incorrect code.

--- a/docs/rules/test-word.md
+++ b/docs/rules/test-word.md
@@ -1,0 +1,4 @@
+@todo #180:90min Add documentation for the RuleNotContainsTestWord. 
+  The documentation should be added to the `docs/rules/test-word.md` file.
+  The documentation should contain the description of the rule and the
+  examples of the correct and incorrect code.

--- a/src/main/java/com/github/lombrozo/testnames/complaints/LinkedComplaint.java
+++ b/src/main/java/com/github/lombrozo/testnames/complaints/LinkedComplaint.java
@@ -1,3 +1,26 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2022-2023 Volodya
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package com.github.lombrozo.testnames.complaints;
 
 import com.github.lombrozo.testnames.Complaint;
@@ -9,12 +32,12 @@ import java.net.URL;
  *
  * @since 0.1.15
  */
-public class LinkedComplaint implements Complaint {
+public final class LinkedComplaint implements Complaint {
 
     /**
      * The complaint message.
      */
-    private final String message;
+    private final String complaint;
 
     /**
      * The suggestion how to solve the problem.
@@ -33,34 +56,36 @@ public class LinkedComplaint implements Complaint {
 
     /**
      * Constructor.
-     * @param message The complaint message.
+     * @param complaint The complaint message.
      * @param suggestion The suggestion how to solve the problem
      * @param rule The rule name
      * @param document The document name to the rule description in the default repo.
+     * @checkstyle ParameterNumberCheck (10 lines)
      */
     public LinkedComplaint(
-        final String message,
+        final String complaint,
         final String suggestion,
         final Class<?> rule,
         final String document
     ) {
-        this(message, suggestion, rule.getSimpleName(), LinkedComplaint.link(document));
+        this(complaint, suggestion, rule.getSimpleName(), LinkedComplaint.url(document));
     }
 
     /**
      * Constructor.
-     * @param message The complaint message.
+     * @param complaint The complaint message.
      * @param suggestion The suggestion how to solve the problem
      * @param rule The rule name
      * @param link The link to the rule description
+     * @checkstyle ParameterNumberCheck (10 lines)
      */
     private LinkedComplaint(
-        final String message,
+        final String complaint,
         final String suggestion,
         final String rule,
         final URL link
     ) {
-        this.message = message;
+        this.complaint = complaint;
         this.suggestion = suggestion;
         this.rule = rule;
         this.link = link;
@@ -71,7 +96,7 @@ public class LinkedComplaint implements Complaint {
         return new Complaint.Text(
             String.format(
                 "%s.%n\t%s.%n\tYou can also ignore the rule by adding @SuppressWarnings(\"JTCOP.%s\") annotation.%n\tRule: %s.%n\tYou can read more about the rule here: %s",
-                this.message,
+                this.complaint,
                 this.suggestion,
                 this.rule,
                 this.rule,
@@ -81,11 +106,11 @@ public class LinkedComplaint implements Complaint {
     }
 
     /**
-     * Parses URL from String
+     * Parses URL from String.
      * @param document String representation of the doc markdown file in the repo.
      * @return URL link
      */
-    private static URL link(final String document) {
+    private static URL url(final String document) {
         try {
             return new URL(
                 String.format(
@@ -95,7 +120,8 @@ public class LinkedComplaint implements Complaint {
             );
         } catch (final MalformedURLException ex) {
             throw new IllegalStateException(
-                String.format("We have  problems with parsing rule documentation link %s",
+                String.format(
+                    "We have  problems with parsing rule documentation link %s",
                     document
                 ),
                 ex

--- a/src/main/java/com/github/lombrozo/testnames/complaints/LinkedComplaint.java
+++ b/src/main/java/com/github/lombrozo/testnames/complaints/LinkedComplaint.java
@@ -70,7 +70,7 @@ public class LinkedComplaint implements Complaint {
     public String message() {
         return new Complaint.Text(
             String.format(
-                "Problem: %s.%n\tPossible solution: %s.%n\tYou can also ignore the rule by adding @SuppressWarnings(\"JTCOP.%s\") annotation.%n\tRule code: %s.%n\tYou can read more about the rule here: %s",
+                "%s.%n\t%s.%n\tYou can also ignore the rule by adding @SuppressWarnings(\"JTCOP.%s\") annotation.%n\tRule: %s.%n\tYou can read more about the rule here: %s",
                 this.message,
                 this.suggestion,
                 this.rule,

--- a/src/main/java/com/github/lombrozo/testnames/complaints/LinkedComplaint.java
+++ b/src/main/java/com/github/lombrozo/testnames/complaints/LinkedComplaint.java
@@ -4,13 +4,40 @@ import com.github.lombrozo.testnames.Complaint;
 import java.net.MalformedURLException;
 import java.net.URL;
 
+/**
+ * The complaint with link to the rule description.
+ *
+ * @since 0.1.15
+ */
 public class LinkedComplaint implements Complaint {
 
+    /**
+     * The complaint message.
+     */
     private final String message;
+
+    /**
+     * The suggestion how to solve the problem.
+     */
     private final String suggestion;
+
+    /**
+     * Rule name.
+     */
     private final String rule;
+
+    /**
+     * The link to the rule description.
+     */
     private final URL link;
 
+    /**
+     * Constructor.
+     * @param message The complaint message.
+     * @param suggestion The suggestion how to solve the problem
+     * @param rule The rule name
+     * @param document The document name to the rule description in the default repo.
+     */
     public LinkedComplaint(
         final String message,
         final String suggestion,
@@ -20,6 +47,13 @@ public class LinkedComplaint implements Complaint {
         this(message, suggestion, rule.getSimpleName(), LinkedComplaint.link(document));
     }
 
+    /**
+     * Constructor.
+     * @param message The complaint message.
+     * @param suggestion The suggestion how to solve the problem
+     * @param rule The rule name
+     * @param link The link to the rule description
+     */
     private LinkedComplaint(
         final String message,
         final String suggestion,
@@ -36,7 +70,7 @@ public class LinkedComplaint implements Complaint {
     public String message() {
         return new Complaint.Text(
             String.format(
-                "Problem: %s.%nPossible solution: %s.%nYou can also ignore the rule by adding @SuppressWarnings(\"JTCOP.%s\") annotation.%nRule code: %s.%nYou can read more about the rule here: %s",
+                "Problem: %s.%n\tPossible solution: %s.%n\tYou can also ignore the rule by adding @SuppressWarnings(\"JTCOP.%s\") annotation.%n\tRule code: %s.%n\tYou can read more about the rule here: %s",
                 this.message,
                 this.suggestion,
                 this.rule,

--- a/src/main/java/com/github/lombrozo/testnames/complaints/LinkedComplaint.java
+++ b/src/main/java/com/github/lombrozo/testnames/complaints/LinkedComplaint.java
@@ -1,0 +1,71 @@
+package com.github.lombrozo.testnames.complaints;
+
+import com.github.lombrozo.testnames.Complaint;
+import java.net.MalformedURLException;
+import java.net.URL;
+
+public class LinkedComplaint implements Complaint {
+
+    private final String message;
+    private final String suggestion;
+    private final String rule;
+    private final URL link;
+
+    public LinkedComplaint(
+        final String message,
+        final String suggestion,
+        final Class<?> rule,
+        final String document
+    ) {
+        this(message, suggestion, rule.getSimpleName(), LinkedComplaint.link(document));
+    }
+
+    private LinkedComplaint(
+        final String message,
+        final String suggestion,
+        final String rule,
+        final URL link
+    ) {
+        this.message = message;
+        this.suggestion = suggestion;
+        this.rule = rule;
+        this.link = link;
+    }
+
+    @Override
+    public String message() {
+        return new Complaint.Text(
+            String.format(
+                "Problem: %s.%nPossible solution: %s.%nYou can also ignore the rule by adding @SuppressWarnings(\"JTCOP.%s\") annotation.%nRule code: %s.%nYou can read more about the rule here: %s",
+                this.message,
+                this.suggestion,
+                this.rule,
+                this.rule,
+                this.link
+            )
+        ).message();
+    }
+
+    /**
+     * Parses URL from String
+     * @param document String representation of the doc markdown file in the repo.
+     * @return URL link
+     */
+    private static URL link(final String document) {
+        try {
+            return new URL(
+                String.format(
+                    "https://github.com/volodya-lombrozo/jtcop/blob/main/docs/rules/%s",
+                    document
+                )
+            );
+        } catch (final MalformedURLException ex) {
+            throw new IllegalStateException(
+                String.format("We have  problems with parsing rule documentation link %s",
+                    document
+                ),
+                ex
+            );
+        }
+    }
+}

--- a/src/main/java/com/github/lombrozo/testnames/rules/RuleAllTestsHaveProductionClass.java
+++ b/src/main/java/com/github/lombrozo/testnames/rules/RuleAllTestsHaveProductionClass.java
@@ -84,7 +84,7 @@ public final class RuleAllTestsHaveProductionClass implements Rule {
                     new LinkedComplaint(
                         String.format("Test %s doesn't have corresponding production class", name),
                         String.format(
-                            "You can either rename or move the test class %s",
+                            "Either rename or move the test class %s",
                             test.path()
                         ),
                         this.getClass(),

--- a/src/main/java/com/github/lombrozo/testnames/rules/RuleAllTestsHaveProductionClass.java
+++ b/src/main/java/com/github/lombrozo/testnames/rules/RuleAllTestsHaveProductionClass.java
@@ -28,6 +28,7 @@ import com.github.lombrozo.testnames.ProductionClass;
 import com.github.lombrozo.testnames.Project;
 import com.github.lombrozo.testnames.Rule;
 import com.github.lombrozo.testnames.TestClass;
+import com.github.lombrozo.testnames.complaints.LinkedComplaint;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Map;
@@ -80,13 +81,14 @@ public final class RuleAllTestsHaveProductionClass implements Rule {
             if (!classes.containsKey(name)
                 && RuleAllTestsHaveProductionClass.isNotSuppressed(test)) {
                 complaints.add(
-                    new Complaint.Text(
+                    new LinkedComplaint(
+                        String.format("Test %s doesn't have corresponding production class", name),
                         String.format(
-                            "Test %s doesn't have corresponding production class.\n\tYou can either rename or move the test class %s:\n\tMore about that rule you can read here %s",
-                            name,
-                            test.path(),
-                            "https://github.com/volodya-lombrozo/jtcop/blob/main/docs/rules/all-have-production-class.md"
-                        )
+                            "You can either rename or move the test class %s",
+                            test.path()
+                        ),
+                        this.getClass(),
+                        "all-have-production-class.md"
                     )
                 );
             }

--- a/src/main/java/com/github/lombrozo/testnames/rules/RuleNotCamelCase.java
+++ b/src/main/java/com/github/lombrozo/testnames/rules/RuleNotCamelCase.java
@@ -28,6 +28,7 @@ import com.github.lombrozo.testnames.Complaint;
 import com.github.lombrozo.testnames.Rule;
 import com.github.lombrozo.testnames.TestCase;
 import com.github.lombrozo.testnames.complaints.ComplaintWrongTestName;
+import com.github.lombrozo.testnames.complaints.LinkedComplaint;
 import java.util.Collection;
 
 /**
@@ -60,9 +61,14 @@ public final class RuleNotCamelCase implements Rule {
     public Collection<Complaint> complaints() {
         return new RuleConditional(
             this::notCamelCase,
-            new ComplaintWrongTestName(
-                this.test,
-                "test has to be written by using Camel Case"
+            new LinkedComplaint(
+                new ComplaintWrongTestName(
+                    this.test,
+                    "test has to be written by using Camel Case"
+                ).message(),
+                "Please rename the test by using the Camel Case",
+                this.getClass(),
+                "camel-case.md"
             )
         ).complaints();
     }

--- a/src/main/java/com/github/lombrozo/testnames/rules/RuleNotContainsTestWord.java
+++ b/src/main/java/com/github/lombrozo/testnames/rules/RuleNotContainsTestWord.java
@@ -28,6 +28,7 @@ import com.github.lombrozo.testnames.Complaint;
 import com.github.lombrozo.testnames.Rule;
 import com.github.lombrozo.testnames.TestCase;
 import com.github.lombrozo.testnames.complaints.ComplaintWrongTestName;
+import com.github.lombrozo.testnames.complaints.LinkedComplaint;
 import java.util.Collection;
 import java.util.stream.Stream;
 
@@ -61,10 +62,16 @@ public final class RuleNotContainsTestWord implements Rule {
     public Collection<Complaint> complaints() {
         return new RuleConditional(
             this::containsTest,
-            new ComplaintWrongTestName(
-                this.test,
-                "test name doesn't have to contain the word 'test'"
+            new LinkedComplaint(
+                new ComplaintWrongTestName(
+                    this.test,
+                    "test name doesn't have to contain the word 'test'"
+                ).message(),
+                "Remove 'test' word from the test name",
+                this.getClass(),
+                "test-word.md"
             )
+
         ).complaints();
     }
 

--- a/src/main/java/com/github/lombrozo/testnames/rules/RuleNotContainsTestWord.java
+++ b/src/main/java/com/github/lombrozo/testnames/rules/RuleNotContainsTestWord.java
@@ -71,7 +71,6 @@ public final class RuleNotContainsTestWord implements Rule {
                 this.getClass(),
                 "test-word.md"
             )
-
         ).complaints();
     }
 

--- a/src/main/java/com/github/lombrozo/testnames/rules/RuleNotSpam.java
+++ b/src/main/java/com/github/lombrozo/testnames/rules/RuleNotSpam.java
@@ -28,6 +28,7 @@ import com.github.lombrozo.testnames.Complaint;
 import com.github.lombrozo.testnames.Rule;
 import com.github.lombrozo.testnames.TestCase;
 import com.github.lombrozo.testnames.complaints.ComplaintWrongTestName;
+import com.github.lombrozo.testnames.complaints.LinkedComplaint;
 import java.util.Collection;
 
 /**
@@ -55,9 +56,14 @@ public final class RuleNotSpam implements Rule {
     public Collection<Complaint> complaints() {
         return new RuleConditional(
             () -> !this.notSpam(),
-            new ComplaintWrongTestName(
-                this.test,
-                "test name doesn't have to contain duplicated symbols"
+            new LinkedComplaint(
+                new ComplaintWrongTestName(
+                    this.test,
+                    "test name doesn't have to contain duplicated symbols"
+                ).message(),
+                "Remove duplicated symbols from the test name",
+                this.getClass(),
+                "not-spam.md"
             )
         ).complaints();
     }

--- a/src/main/java/com/github/lombrozo/testnames/rules/RuleNotUsesSpecialCharacters.java
+++ b/src/main/java/com/github/lombrozo/testnames/rules/RuleNotUsesSpecialCharacters.java
@@ -28,6 +28,7 @@ import com.github.lombrozo.testnames.Complaint;
 import com.github.lombrozo.testnames.Rule;
 import com.github.lombrozo.testnames.TestCase;
 import com.github.lombrozo.testnames.complaints.ComplaintWrongTestName;
+import com.github.lombrozo.testnames.complaints.LinkedComplaint;
 import java.util.Collection;
 
 /**
@@ -55,9 +56,14 @@ public final class RuleNotUsesSpecialCharacters implements Rule {
     public Collection<Complaint> complaints() {
         return new RuleConditional(
             this::usesSpecialCharacters,
-            new ComplaintWrongTestName(
-                this.test,
-                "test name shouldn't contain special characters like '$' or '_'"
+            new LinkedComplaint(
+                new ComplaintWrongTestName(
+                    this.test,
+                    "test name shouldn't contain special characters like '$' or '_'"
+                ).message(),
+                "Remove all special characters like '$' or '_' from test name",
+                this.getClass(),
+                "not-special-characters.md"
             )
         ).complaints();
     }

--- a/src/main/java/com/github/lombrozo/testnames/rules/RulePresentTense.java
+++ b/src/main/java/com/github/lombrozo/testnames/rules/RulePresentTense.java
@@ -28,6 +28,7 @@ import com.github.lombrozo.testnames.Complaint;
 import com.github.lombrozo.testnames.Rule;
 import com.github.lombrozo.testnames.TestCase;
 import com.github.lombrozo.testnames.complaints.ComplaintWrongTestName;
+import com.github.lombrozo.testnames.complaints.LinkedComplaint;
 import java.util.Collection;
 
 /**
@@ -55,9 +56,14 @@ public final class RulePresentTense implements Rule {
     public Collection<Complaint> complaints() {
         return new RuleConditional(
             () -> !this.presentTense(),
-            new ComplaintWrongTestName(
-                this.test,
-                "the test name has to be written using present tense"
+            new LinkedComplaint(
+                new ComplaintWrongTestName(
+                    this.test,
+                    "the test name has to be written using present tense"
+                ).message(),
+                "Please, rename the test name using present tense",
+                this.getClass(),
+                "present-tense.md"
             )
         ).complaints();
     }


### PR DESCRIPTION
Add `LinkedComplaint` class for more informative error description.

Closes: #180 

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds documentation and links to rules in the `docs/rules` directory. It also introduces a new complaint type `LinkedComplaint` that contains a link to the rule description.

### Detailed summary
- Added documentation for `RuleNotSpam` to `docs/rules/not-spam.md`
- Added documentation for `RuleNotContainsTestWord` to `docs/rules/test-word.md`
- Added documentation for `RuleNotUsesSpecialCharacters` to `docs/rules/not-special-characters.md`
- Added link to `RuleNotCamelCase` in `src/main/java/com/github/lombrozo/testnames/rules/RuleNotCamelCase.java`
- Added link to `RuleNotSpam` in `src/main/java/com/github/lombrozo/testnames/rules/RuleNotSpam.java`
- Added link to `RulePresentTense` in `src/main/java/com/github/lombrozo/testnames/rules/RulePresentTense.java`
- Added link to `RuleNotContainsTestWord` in `src/main/java/com/github/lombrozo/testnames/rules/RuleNotContainsTestWord.java`
- Added link to `RuleNotUsesSpecialCharacters` in `src/main/java/com/github/lombrozo/testnames/rules/RuleNotUsesSpecialCharacters.java`
- Added `LinkedComplaint` class to `src/main/java/com/github/lombrozo/testnames/complaints/LinkedComplaint.java` that contains a link to the rule description.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->