### PR TITLE
feat(#187): hotfix handle package-info.java classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ mvn com.github.volodya-lombrozo:jtcop-maven-plugin:check
 ```
 
 After that you will see the result of the plugin execution in the console. If
-you want to use specific (older) version of the plugin, for example `0.1.9`,
+you want to use specific (older) version of the plugin, for example `0.1.16`,
 just run the next maven command with specified version:
 
 ```shell
@@ -53,7 +53,7 @@ In order to do that, just add the next snippet to your `pom.xml`:
     <plugin>
       <groupId>com.github.volodya-lombrozo</groupId>
       <artifactId>jtcop-maven-plugin</artifactId>
-      <version>0.1.9</version>
+      <version>0.1.16</version>
       <executions>
         <execution>
           <goals>

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ you want to use specific (older) version of the plugin, for example `0.1.9`,
 just run the next maven command with specified version:
 
 ```shell
-mvn com.github.volodya-lombrozo:jtcop-maven-plugin:0.1.9:check
+mvn com.github.volodya-lombrozo:jtcop-maven-plugin:0.1.16:check
 ```
 
 ### Add the plugin to your `pom.xml`

--- a/pom.xml
+++ b/pom.xml
@@ -215,7 +215,7 @@ SOFTWARE.
           <plugin>
             <groupId>com.github.volodya-lombrozo</groupId>
             <artifactId>jtcop-maven-plugin</artifactId>
-            <version>0.1.14</version>
+            <version>0.1.15</version>
             <executions>
               <execution>
                 <phase>verify</phase>

--- a/pom.xml
+++ b/pom.xml
@@ -215,7 +215,7 @@ SOFTWARE.
           <plugin>
             <groupId>com.github.volodya-lombrozo</groupId>
             <artifactId>jtcop-maven-plugin</artifactId>
-            <version>0.1.15</version>
+            <version>0.1.14</version>
             <executions>
               <execution>
                 <phase>verify</phase>

--- a/src/it/all-have-production-class/src/test/java/package-info.java
+++ b/src/it/all-have-production-class/src/test/java/package-info.java
@@ -1,0 +1,29 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2022-2023 Volodya
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+/**
+ * Pckage of integration tests.
+ *
+ * @since 0.1.16
+ */
+package com.github.lombrozo.testnames.it;

--- a/src/main/java/com/github/lombrozo/testnames/javaparser/JavaParserClass.java
+++ b/src/main/java/com/github/lombrozo/testnames/javaparser/JavaParserClass.java
@@ -114,7 +114,12 @@ final class JavaParserClass {
             .filter(node -> node instanceof TypeDeclaration<?>)
             .collect(Collectors.toCollection(LinkedList::new));
         if (all.isEmpty()) {
-            throw new IllegalStateException("Compilation unit has contain at least one class");
+            throw new IllegalStateException(
+                String.format(
+                    "Compilation unit '%s' has contain at least one class",
+                    unit
+                )
+            );
         }
         return all.element();
     }

--- a/src/main/java/com/github/lombrozo/testnames/javaparser/JavaParserClass.java
+++ b/src/main/java/com/github/lombrozo/testnames/javaparser/JavaParserClass.java
@@ -26,6 +26,7 @@ package com.github.lombrozo.testnames.javaparser;
 import com.github.javaparser.StaticJavaParser;
 import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.Node;
+import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
 import com.github.javaparser.ast.body.MethodDeclaration;
 import com.github.javaparser.ast.body.TypeDeclaration;
 import com.github.javaparser.ast.nodeTypes.NodeWithMembers;
@@ -107,6 +108,11 @@ final class JavaParserClass {
      * Prestructor of class.
      * @param unit Compilation unit.
      * @return Node with class.
+     * @todo #187:90min Provide refactoring for JavaParserClass and TestClassJavaParser.
+     *  The JavaParserClass and TestClassJavaParser classes are very similar. They share some logic
+     *  and have similar methods. The refactoring should be provided to make the code more
+     *  readable and maintainable. Also we have to count the different cases like records and
+     *  package-info classes, inner classes and so on. For each case we must have a test.
      */
     private static Node fromCompilation(final CompilationUnit unit) {
         final Queue<Node> all = unit.getChildNodes()
@@ -114,14 +120,8 @@ final class JavaParserClass {
             .filter(node -> node instanceof TypeDeclaration<?>)
             .collect(Collectors.toCollection(LinkedList::new));
         if (all.isEmpty()) {
-            throw new IllegalStateException(
-                String.format(
-                    "Compilation unit '%s' has contain at least one class",
-                    unit
-                )
-            );
+            all.add(new ClassOrInterfaceDeclaration());
         }
         return all.element();
     }
-
 }

--- a/src/main/java/com/github/lombrozo/testnames/javaparser/ProjectJavaParser.java
+++ b/src/main/java/com/github/lombrozo/testnames/javaparser/ProjectJavaParser.java
@@ -120,4 +120,5 @@ public final class ProjectJavaParser implements Project {
         }
         return res;
     }
+
 }

--- a/src/main/java/com/github/lombrozo/testnames/javaparser/TestClassJavaParser.java
+++ b/src/main/java/com/github/lombrozo/testnames/javaparser/TestClassJavaParser.java
@@ -129,8 +129,22 @@ public final class TestClassJavaParser implements TestClass {
         final Sticky<? extends CompilationUnit> parsed,
         final Collection<String> exclusions
     ) {
-        this.path = klass;
-        this.unit = new Unchecked<>(new Mapped<>(JavaParserClass::new, parsed));
+        this(klass, new Unchecked<>(new Mapped<>(JavaParserClass::new, parsed)), exclusions);
+    }
+
+    /**
+     * Constructor.
+     * @param path Path to the class
+     * @param unit Parsed class.
+     * @param exclusions Rules excluded for entire project.
+     */
+    TestClassJavaParser(
+        final Path path,
+        final Unchecked<JavaParserClass> unit,
+        final Collection<String> exclusions
+    ) {
+        this.path = path;
+        this.unit = unit;
         this.exclusions = exclusions;
     }
 
@@ -166,5 +180,4 @@ public final class TestClassJavaParser implements TestClass {
             this.exclusions.stream()
         ).collect(Collectors.toSet());
     }
-
 }

--- a/src/test/java/com/github/lombrozo/testnames/javaparser/JavaTestClasses.java
+++ b/src/test/java/com/github/lombrozo/testnames/javaparser/JavaTestClasses.java
@@ -83,6 +83,11 @@ enum JavaTestClasses {
     TEST_WITH_ASSERTIONS("TestWithAssertions.java"),
 
     /**
+     * Package info class.
+     */
+    PACKAGE_INFO("package-info.java"),
+
+    /**
      * Test class with JUnit assertions.
      */
     TEST_WITH_JUNIT_ASSERTIONS("TestWithJUnitAssertions.java"),

--- a/src/test/java/com/github/lombrozo/testnames/javaparser/TestCaseJavaParserTest.java
+++ b/src/test/java/com/github/lombrozo/testnames/javaparser/TestCaseJavaParserTest.java
@@ -146,4 +146,14 @@ class TestCaseJavaParserTest {
             Matchers.equalTo("JUnit explanation")
         );
     }
+
+    @Test
+    void parsesPackageJava() {
+        final TestClassJavaParser parser = JavaTestClasses.PACKAGE_INFO.toTestClass();
+        MatcherAssert.assertThat(
+            "Java package has to be parsed, but doesn't have to contain test cases",
+            parser.all(),
+            Matchers.hasSize(0)
+        );
+    }
 }

--- a/src/test/resources/package-info.java
+++ b/src/test/resources/package-info.java
@@ -1,0 +1,29 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2022-2023 Volodya
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+/**
+ * Pckage info for testing.
+ *
+ * @since 0.1.16
+ */
+package com.github.lombrozo.testnames.it;


### PR DESCRIPTION
Handle `package-info.java` classes separately.

Closes: #187 

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds new functionality to the `jtcop-maven-plugin` and refactors some code. 

### Detailed summary
- Added support for parsing `package-info.java` files.
- Refactored `JavaParserClass` and `TestClassJavaParser` classes for better readability and maintainability.
- Added a new test case for parsing package-info files.
- Updated license headers in some files.
- Minor changes to `README.md`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->