### PR TITLE
feat(#192):  ignore interfaces and annotations in rule checking

### DIFF
--- a/src/it/all-have-production-class/src/test/java/MyAnnotation.java
+++ b/src/it/all-have-production-class/src/test/java/MyAnnotation.java
@@ -21,16 +21,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-String log = new File(basedir, 'build.log').text;
-[
-  'Test CorrectTest.java doesn\'t have corresponding production class.',
-].each { assert log.contains(it): "Log doesn't contain ['$it']" }
-[
-  'SuppressedTest.java',
-  'SuppressedInterface.java',
-  'SuppressedAnnotation.java',
-  'MyAnnotation.java',
-  'MyInterface.java',
-  'package-info.java',
-].each { assert !log.contains(it): "Log contains ['$it']" }
-true
+package com.github.lombrozo.testnames.complaints;
+
+public @interface MyAnnotation {
+}

--- a/src/it/all-have-production-class/src/test/java/MyInterface.java
+++ b/src/it/all-have-production-class/src/test/java/MyInterface.java
@@ -21,16 +21,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-String log = new File(basedir, 'build.log').text;
-[
-  'Test CorrectTest.java doesn\'t have corresponding production class.',
-].each { assert log.contains(it): "Log doesn't contain ['$it']" }
-[
-  'SuppressedTest.java',
-  'SuppressedInterface.java',
-  'SuppressedAnnotation.java',
-  'MyAnnotation.java',
-  'MyInterface.java',
-  'package-info.java',
-].each { assert !log.contains(it): "Log contains ['$it']" }
-true
+
+public interface MyInterface {
+}

--- a/src/main/java/com/github/lombrozo/testnames/javaparser/JavaParserClass.java
+++ b/src/main/java/com/github/lombrozo/testnames/javaparser/JavaParserClass.java
@@ -26,6 +26,8 @@ package com.github.lombrozo.testnames.javaparser;
 import com.github.javaparser.StaticJavaParser;
 import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.Node;
+import com.github.javaparser.ast.PackageDeclaration;
+import com.github.javaparser.ast.body.AnnotationDeclaration;
 import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
 import com.github.javaparser.ast.body.MethodDeclaration;
 import com.github.javaparser.ast.body.TypeDeclaration;
@@ -138,14 +140,17 @@ final class JavaParserClass {
     }
 
     boolean isAnnotation() {
-        return false;
+        return this.klass instanceof AnnotationDeclaration;
     }
 
     boolean isInterface() {
-        return false;
+        return this.klass instanceof ClassOrInterfaceDeclaration
+            && ((ClassOrInterfaceDeclaration) this.klass).isInterface();
     }
 
     boolean isPackageInfo() {
-        return false;
+        return this.klass instanceof ClassOrInterfaceDeclaration
+            && ((ClassOrInterfaceDeclaration) this.klass).getNameAsString()
+            .equals("empty");
     }
 }

--- a/src/main/java/com/github/lombrozo/testnames/javaparser/JavaParserClass.java
+++ b/src/main/java/com/github/lombrozo/testnames/javaparser/JavaParserClass.java
@@ -26,7 +26,6 @@ package com.github.lombrozo.testnames.javaparser;
 import com.github.javaparser.StaticJavaParser;
 import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.Node;
-import com.github.javaparser.ast.PackageDeclaration;
 import com.github.javaparser.ast.body.AnnotationDeclaration;
 import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
 import com.github.javaparser.ast.body.MethodDeclaration;
@@ -108,6 +107,46 @@ final class JavaParserClass {
     }
 
     /**
+     * Checks if the class is an annotation.
+     * @return True if an annotation
+     */
+    boolean isAnnotation() {
+        return this.klass instanceof AnnotationDeclaration;
+    }
+
+    /**
+     * Checks if the class is an interface.
+     * @return True if an interface
+     */
+    boolean isInterface() {
+        return this.klass instanceof ClassOrInterfaceDeclaration
+            && this.cast().isInterface();
+    }
+
+    /**
+     * Checks if the class is a package-info.java.
+     * @return True if a package-info.java
+     */
+    boolean isPackageInfo() {
+        return this.klass instanceof ClassOrInterfaceDeclaration
+            && "empty".equals(this.cast().getNameAsString());
+    }
+
+    /**
+     * Cast the class to ClassOrInterfaceDeclaration.
+     * @return ClassOrInterfaceDeclaration
+     */
+    private ClassOrInterfaceDeclaration cast() {
+        if (this.klass instanceof ClassOrInterfaceDeclaration) {
+            return (ClassOrInterfaceDeclaration) this.klass;
+        } else {
+            throw new IllegalStateException(
+                String.format("Can't cast %s to ClassOrInterfaceDeclaration", this.klass)
+            );
+        }
+    }
+
+    /**
      * Prestructor of class.
      * @param unit Compilation unit.
      * @return Node with class.
@@ -128,6 +167,11 @@ final class JavaParserClass {
         return all.element();
     }
 
+    /**
+     * Parse java by path.
+     * @param path Path to java file
+     * @return Compilation unit.
+     */
     private static CompilationUnit parse(final Path path) {
         try {
             return StaticJavaParser.parse(path);
@@ -139,18 +183,4 @@ final class JavaParserClass {
         }
     }
 
-    boolean isAnnotation() {
-        return this.klass instanceof AnnotationDeclaration;
-    }
-
-    boolean isInterface() {
-        return this.klass instanceof ClassOrInterfaceDeclaration
-            && ((ClassOrInterfaceDeclaration) this.klass).isInterface();
-    }
-
-    boolean isPackageInfo() {
-        return this.klass instanceof ClassOrInterfaceDeclaration
-            && ((ClassOrInterfaceDeclaration) this.klass).getNameAsString()
-            .equals("empty");
-    }
 }

--- a/src/main/java/com/github/lombrozo/testnames/javaparser/ProjectJavaParser.java
+++ b/src/main/java/com/github/lombrozo/testnames/javaparser/ProjectJavaParser.java
@@ -110,7 +110,13 @@ public final class ProjectJavaParser implements Project {
                     .filter(Files::exists)
                     .filter(Files::isRegularFile)
                     .filter(path -> path.toString().endsWith(".java"))
-                    .map(path -> new TestClassJavaParser(path, this.exclusions))
+                    .filter(path -> {
+                        final JavaParserClass parsed = new JavaParserClass(path);
+                        return !parsed.isAnnotation()
+                            && !parsed.isInterface()
+                            && !parsed.isPackageInfo();
+                    })
+                    .map(klass -> new TestClassJavaParser(klass, this.exclusions))
                     .collect(Collectors.toList());
             } catch (final IOException exception) {
                 throw new IllegalStateException(exception);

--- a/src/main/java/com/github/lombrozo/testnames/javaparser/ProjectJavaParser.java
+++ b/src/main/java/com/github/lombrozo/testnames/javaparser/ProjectJavaParser.java
@@ -110,12 +110,14 @@ public final class ProjectJavaParser implements Project {
                     .filter(Files::exists)
                     .filter(Files::isRegularFile)
                     .filter(path -> path.toString().endsWith(".java"))
-                    .filter(path -> {
-                        final JavaParserClass parsed = new JavaParserClass(path);
-                        return !parsed.isAnnotation()
-                            && !parsed.isInterface()
-                            && !parsed.isPackageInfo();
-                    })
+                    .filter(
+                        path -> {
+                            final JavaParserClass parsed = new JavaParserClass(path);
+                            return !parsed.isAnnotation()
+                                && !parsed.isInterface()
+                                && !parsed.isPackageInfo();
+                        }
+                    )
                     .map(klass -> new TestClassJavaParser(klass, this.exclusions))
                     .collect(Collectors.toList());
             } catch (final IOException exception) {

--- a/src/main/java/com/github/lombrozo/testnames/javaparser/TestClassJavaParser.java
+++ b/src/main/java/com/github/lombrozo/testnames/javaparser/TestClassJavaParser.java
@@ -34,6 +34,7 @@ import java.io.UncheckedIOException;
 import java.nio.file.Path;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.cactoos.scalar.Mapped;
@@ -69,7 +70,7 @@ public final class TestClassJavaParser implements TestClass {
      * @param klass Path to the class
      */
     TestClassJavaParser(final Path klass) {
-        this(klass, new Sticky<>(() -> StaticJavaParser.parse(klass)));
+        this(klass, TestClassJavaParser.parse(klass));
     }
 
     /**
@@ -79,7 +80,7 @@ public final class TestClassJavaParser implements TestClass {
      * @param exclusions Rules excluded for entire project.
      */
     TestClassJavaParser(final Path klass, final Collection<String> exclusions) {
-        this(klass, new Sticky<>(() -> StaticJavaParser.parse(klass)), exclusions);
+        this(klass, TestClassJavaParser.parse(klass), exclusions);
     }
 
     /**
@@ -89,7 +90,7 @@ public final class TestClassJavaParser implements TestClass {
      * @param stream Parsed Java class
      */
     TestClassJavaParser(final Path klass, final InputStream stream) {
-        this(klass, new Sticky<>(() -> StaticJavaParser.parse(stream)));
+        this(klass, TestClassJavaParser.parse(stream));
     }
 
     /**
@@ -98,8 +99,8 @@ public final class TestClassJavaParser implements TestClass {
      * @param klass Path to the class
      * @param parsed Parsed class.
      */
-    private TestClassJavaParser(final Path klass, final Sticky<? extends CompilationUnit> parsed) {
-        this(klass, parsed, Collections.emptySet());
+    private TestClassJavaParser(final Path klass, final Sticky<JavaParserClass> parsed) {
+        this(klass, new Unchecked<>(parsed), Collections.emptySet());
     }
 
     /**
@@ -114,7 +115,7 @@ public final class TestClassJavaParser implements TestClass {
         final InputStream stream,
         final Collection<String> exclusions
     ) {
-        this(klass, new Sticky<>(() -> StaticJavaParser.parse(stream)), exclusions);
+        this(klass, TestClassJavaParser.parse(stream), exclusions);
     }
 
     /**
@@ -126,10 +127,10 @@ public final class TestClassJavaParser implements TestClass {
      */
     TestClassJavaParser(
         final Path klass,
-        final Sticky<? extends CompilationUnit> parsed,
+        final Sticky<JavaParserClass> parsed,
         final Collection<String> exclusions
     ) {
-        this(klass, new Unchecked<>(new Mapped<>(JavaParserClass::new, parsed)), exclusions);
+        this(klass, new Unchecked<>(parsed), exclusions);
     }
 
     /**
@@ -179,5 +180,23 @@ public final class TestClassJavaParser implements TestClass {
             this.unit.value().annotations().suppressed(),
             this.exclusions.stream()
         ).collect(Collectors.toSet());
+    }
+
+    /**
+     * Parse Java class.
+     * @param path Path to the class
+     * @return Parsed class.
+     */
+    private static Sticky<JavaParserClass> parse(final Path path) {
+        return new Sticky<>(() -> new JavaParserClass(StaticJavaParser.parse(path)));
+    }
+
+    /**
+     * Parse Java class.
+     * @param stream Raw class.
+     * @return Parsed class.
+     */
+    private static Sticky<JavaParserClass> parse(final InputStream stream) {
+        return new Sticky<>(() -> new JavaParserClass(StaticJavaParser.parse(stream)));
     }
 }

--- a/src/main/java/com/github/lombrozo/testnames/javaparser/TestClassJavaParser.java
+++ b/src/main/java/com/github/lombrozo/testnames/javaparser/TestClassJavaParser.java
@@ -73,6 +73,14 @@ public final class TestClassJavaParser implements TestClass {
         this(klass, TestClassJavaParser.parse(klass));
     }
 
+    TestClassJavaParser(
+        final Path path,
+        final JavaParserClass parsed,
+        final Collection<String> exclusions
+    ) {
+        this(path, new Unchecked<>(() -> parsed), exclusions);
+    }
+
     /**
      * Ctor.
      *

--- a/src/main/java/com/github/lombrozo/testnames/javaparser/TestClassJavaParser.java
+++ b/src/main/java/com/github/lombrozo/testnames/javaparser/TestClassJavaParser.java
@@ -26,7 +26,6 @@ package com.github.lombrozo.testnames.javaparser;
 
 import com.github.javaparser.ParseProblemException;
 import com.github.javaparser.StaticJavaParser;
-import com.github.javaparser.ast.CompilationUnit;
 import com.github.lombrozo.testnames.TestCase;
 import com.github.lombrozo.testnames.TestClass;
 import java.io.InputStream;
@@ -34,10 +33,8 @@ import java.io.UncheckedIOException;
 import java.nio.file.Path;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import org.cactoos.scalar.Mapped;
 import org.cactoos.scalar.Sticky;
 import org.cactoos.scalar.Unchecked;
 
@@ -71,14 +68,6 @@ public final class TestClassJavaParser implements TestClass {
      */
     TestClassJavaParser(final Path klass) {
         this(klass, TestClassJavaParser.parse(klass));
-    }
-
-    TestClassJavaParser(
-        final Path path,
-        final JavaParserClass parsed,
-        final Collection<String> exclusions
-    ) {
-        this(path, new Unchecked<>(() -> parsed), exclusions);
     }
 
     /**

--- a/src/test/java/com/github/lombrozo/testnames/javaparser/JavaTestClasses.java
+++ b/src/test/java/com/github/lombrozo/testnames/javaparser/JavaTestClasses.java
@@ -88,6 +88,11 @@ enum JavaTestClasses {
     PACKAGE_INFO("package-info.java"),
 
     /**
+     * Annotation.
+     */
+    ANNOTATION_DECLARATION("AnnotationDeclaration.java"),
+
+    /**
      * Test class with JUnit assertions.
      */
     TEST_WITH_JUNIT_ASSERTIONS("TestWithJUnitAssertions.java"),

--- a/src/test/java/com/github/lombrozo/testnames/javaparser/ProjectJavaParserTest.java
+++ b/src/test/java/com/github/lombrozo/testnames/javaparser/ProjectJavaParserTest.java
@@ -76,7 +76,7 @@ final class ProjectJavaParserTest {
     @Test
     void returnsNotProductionClasses(@TempDir final Path tmp) throws IOException {
         final String name = "TestClass.java";
-        Files.write(tmp.resolve(name), "".getBytes(StandardCharsets.UTF_8));
+        Files.write(tmp.resolve(name), "final class TestClass{}".getBytes(StandardCharsets.UTF_8));
         final Collection<TestClass> classes = new ProjectJavaParser(
             tmp,
             tmp

--- a/src/test/java/com/github/lombrozo/testnames/javaparser/ProjectJavaParserTest.java
+++ b/src/test/java/com/github/lombrozo/testnames/javaparser/ProjectJavaParserTest.java
@@ -135,4 +135,52 @@ final class ProjectJavaParserTest {
             Matchers.containsInAnyOrder(exclusions)
         );
     }
+
+    @Test
+    void ignoresAnnotations(@TempDir final Path temp) throws IOException {
+        Files.copy(
+            JavaTestClasses.PACKAGE_INFO.inputStream(),
+            temp.resolve("AnnotationDeclaration.java")
+        );
+        final Collection<TestClass> classes = new ProjectJavaParser(
+            temp,
+            temp
+        ).testClasses();
+        MatcherAssert.assertThat(
+            String.format("Project has to ignore annotations, but was: %s", classes),
+            classes,
+            Matchers.empty()
+        );
+    }
+
+    @Test
+    void ignoresPackageInfoClasses(@TempDir final Path temp) throws IOException {
+        Files.copy(JavaTestClasses.PACKAGE_INFO.inputStream(), temp.resolve("package-info.java"));
+        final Collection<TestClass> classes = new ProjectJavaParser(
+            temp,
+            temp
+        ).testClasses();
+        MatcherAssert.assertThat(
+            String.format("Project has to ignore package-info.java classes, but was: %s", classes),
+            classes,
+            Matchers.empty()
+        );
+    }
+
+    @Test
+    void ignoresInterfaces(@TempDir final Path temp) throws IOException {
+        Files.copy(
+            JavaTestClasses.SUPPRESSED_INTERFACE.inputStream(),
+            temp.resolve("SuppressedInterface.java")
+        );
+        final Collection<TestClass> classes = new ProjectJavaParser(
+            temp,
+            temp
+        ).testClasses();
+        MatcherAssert.assertThat(
+            String.format("Project has to ignore interfaces, but was: %s", classes),
+            classes,
+            Matchers.empty()
+        );
+    }
 }

--- a/src/test/java/com/github/lombrozo/testnames/rules/RuleAllTestsHaveProductionClassTest.java
+++ b/src/test/java/com/github/lombrozo/testnames/rules/RuleAllTestsHaveProductionClassTest.java
@@ -161,5 +161,4 @@ final class RuleAllTestsHaveProductionClassTest {
             Matchers.empty()
         );
     }
-
 }

--- a/src/test/resources/AnnotationDeclaration.java
+++ b/src/test/resources/AnnotationDeclaration.java
@@ -1,0 +1,33 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2022-2023 Volodya
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface AnnotationDeclaration {
+}


### PR DESCRIPTION
Ignore interfaces and annotations in during checking rules.

Closes: #192 