### PR TITLE
feat(#202):  RuleAllTestsHaveProductionClass - ignore dollars and underscores

### DIFF
--- a/src/main/java/com/github/lombrozo/testnames/rules/RuleAllTestsHaveProductionClass.java
+++ b/src/main/java/com/github/lombrozo/testnames/rules/RuleAllTestsHaveProductionClass.java
@@ -33,6 +33,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Map;
 import java.util.function.Function;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 /**
@@ -46,6 +47,16 @@ public final class RuleAllTestsHaveProductionClass implements Rule {
      * The name of the rule.
      */
     public static final String NAME = "RuleAllTestsHaveProductionClass";
+
+    /**
+     * The pattern to replace the underscore sign "_".
+     */
+    private static final Pattern UNDERSCORE = Pattern.compile("_");
+
+    /**
+     * The pattern to replace the dollar sign "$".
+     */
+    private static final Pattern DOLLAR = Pattern.compile("\\$");
 
     /**
      * The project to check.
@@ -77,7 +88,7 @@ public final class RuleAllTestsHaveProductionClass implements Rule {
             .filter(test -> RuleAllTestsHaveProductionClass.isNotPackageInfo(test.name()))
             .collect(Collectors.toList());
         for (final TestClass test : tests) {
-            final String name = test.name();
+            final String name = RuleAllTestsHaveProductionClass.clean(test.name());
             if (!classes.containsKey(name)
                 && RuleAllTestsHaveProductionClass.isNotSuppressed(test)) {
                 complaints.add(
@@ -97,6 +108,17 @@ public final class RuleAllTestsHaveProductionClass implements Rule {
     }
 
     /**
+     * Removes that not important part of the name.
+     * @param original The original name.
+     * @return The cleaned name.
+     */
+    private static String clean(final CharSequence original) {
+        return RuleAllTestsHaveProductionClass.DOLLAR.matcher(
+            RuleAllTestsHaveProductionClass.UNDERSCORE.matcher(original).replaceAll("")
+        ).replaceAll("");
+    }
+
+    /**
      * Returns the name of the test class that corresponds to the production class.
      * @param klass The production class.
      * @return The name of the test class.
@@ -109,7 +131,7 @@ public final class RuleAllTestsHaveProductionClass implements Rule {
         } else {
             plain = String.format("%sTest", name);
         }
-        return plain;
+        return RuleAllTestsHaveProductionClass.clean(plain);
     }
 
     /**

--- a/src/test/java/com/github/lombrozo/testnames/rules/RuleAllTestsHaveProductionClassTest.java
+++ b/src/test/java/com/github/lombrozo/testnames/rules/RuleAllTestsHaveProductionClassTest.java
@@ -163,7 +163,7 @@ final class RuleAllTestsHaveProductionClassTest {
     }
 
     @Test
-    void handlesTestsWithUnderscores() {
+    void handlesCasesWithUnderscores() {
         MatcherAssert.assertThat(
             "Should not have complaints, because all tests have corresponding production class, but with underscores",
             new RuleAllTestsHaveProductionClass(
@@ -177,7 +177,7 @@ final class RuleAllTestsHaveProductionClassTest {
     }
 
     @Test
-    void handlesTestsWithDollarSign() {
+    void handlesCasesWithDollarSign() {
         MatcherAssert.assertThat(
             "Should not have complaints, because all tests have corresponding production class, but with dollar sign",
             new RuleAllTestsHaveProductionClass(

--- a/src/test/java/com/github/lombrozo/testnames/rules/RuleAllTestsHaveProductionClassTest.java
+++ b/src/test/java/com/github/lombrozo/testnames/rules/RuleAllTestsHaveProductionClassTest.java
@@ -161,4 +161,32 @@ final class RuleAllTestsHaveProductionClassTest {
             Matchers.empty()
         );
     }
+
+    @Test
+    void handlesTestsWithUnderscores() {
+        MatcherAssert.assertThat(
+            "Should not have complaints, because all tests have corresponding production class, but with underscores",
+            new RuleAllTestsHaveProductionClass(
+                new Project.Fake(
+                    new ProductionClass.Fake("IdenticalName"),
+                    new TestClass.Fake("Identical_Name_Test", new TestCase.Fake())
+                )
+            ).complaints(),
+            Matchers.empty()
+        );
+    }
+
+    @Test
+    void handlesTestsWithAmpersands() {
+        MatcherAssert.assertThat(
+            "Should not have complaints, because all tests have corresponding production class, but with ampersands",
+            new RuleAllTestsHaveProductionClass(
+                new Project.Fake(
+                    new ProductionClass.Fake("EObool$EOnot"),
+                    new TestClass.Fake("EOboolEOnotTest", new TestCase.Fake())
+                )
+            ).complaints(),
+            Matchers.empty()
+        );
+    }
 }

--- a/src/test/java/com/github/lombrozo/testnames/rules/RuleAllTestsHaveProductionClassTest.java
+++ b/src/test/java/com/github/lombrozo/testnames/rules/RuleAllTestsHaveProductionClassTest.java
@@ -177,13 +177,13 @@ final class RuleAllTestsHaveProductionClassTest {
     }
 
     @Test
-    void handlesTestsWithAmpersands() {
+    void handlesTestsWithDollarSign() {
         MatcherAssert.assertThat(
-            "Should not have complaints, because all tests have corresponding production class, but with ampersands",
+            "Should not have complaints, because all tests have corresponding production class, but with dollar sign",
             new RuleAllTestsHaveProductionClass(
                 new Project.Fake(
                     new ProductionClass.Fake("EObool$EOnot"),
-                    new TestClass.Fake("EOboolEOnotTest", new TestCase.Fake())
+                    new TestClass.Fake("EObool$EOnot$Test", new TestCase.Fake())
                 )
             ).complaints(),
             Matchers.empty()


### PR DESCRIPTION
Make `RuleAllTestsHaveProductionClass` to ignore dollars and underscores.

Closes: #202 

<!-- start pr-codex -->

---

## PR-Codex overview
### Focus of this PR:
This PR focuses on adding functionality to handle test cases with underscores and dollar signs in their names.

### Detailed summary:
- Added `handlesCasesWithUnderscores()` method to handle test cases with underscores in their names.
- Added `handlesCasesWithDollarSign()` method to handle test cases with dollar signs in their names.
- Added `UNDERSCORE` pattern to replace underscores in test names.
- Added `DOLLAR` pattern to replace dollar signs in test names.
- Added `clean()` method to remove unnecessary parts of the test names.
- Modified `complaints()` method to use the `clean()` method when checking for corresponding test names.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->