### PR TITLE
Update jtcop up to 0.1.16

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -229,7 +229,7 @@ SOFTWARE.
           <plugin>
             <groupId>com.github.volodya-lombrozo</groupId>
             <artifactId>jtcop-maven-plugin</artifactId>
-            <version>0.1.14</version>
+            <version>0.1.16</version>
             <executions>
               <execution>
                 <phase>verify</phase>

--- a/src/test/java/com/github/lombrozo/testnames/javaparser/ProjectJavaParserTest.java
+++ b/src/test/java/com/github/lombrozo/testnames/javaparser/ProjectJavaParserTest.java
@@ -106,7 +106,11 @@ final class ProjectJavaParserTest {
             temp,
             Arrays.asList(exclusions)
         ).testClasses();
-        MatcherAssert.assertThat(classes, Matchers.hasSize(1));
+        MatcherAssert.assertThat(
+            String.format("Project has to have exactly one test class, but was %d", classes.size()),
+            classes,
+            Matchers.hasSize(1)
+        );
         final Set<String> clevel = classes.stream()
             .map(TestClass::suppressed)
             .flatMap(Collection::stream)

--- a/src/test/java/com/github/lombrozo/testnames/javaparser/TestCaseJavaParserTest.java
+++ b/src/test/java/com/github/lombrozo/testnames/javaparser/TestCaseJavaParserTest.java
@@ -28,6 +28,7 @@ import com.github.lombrozo.testnames.TestCase;
 import com.github.lombrozo.testnames.rules.RuleAllTestsHaveProductionClass;
 import com.github.lombrozo.testnames.rules.RuleNotCamelCase;
 import com.github.lombrozo.testnames.rules.RuleNotContainsTestWord;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Optional;
 import org.hamcrest.MatcherAssert;
@@ -45,6 +46,7 @@ class TestCaseJavaParserTest {
     void convertsToString() {
         final String name = "name";
         MatcherAssert.assertThat(
+            "Test case should be converted to string which contains its name",
             new TestCaseJavaParser(name).toString(),
             Matchers.stringContainsInOrder(
                 String.format(
@@ -59,6 +61,7 @@ class TestCaseJavaParserTest {
     void hasTheSameHashCode() {
         final String name = "nm";
         MatcherAssert.assertThat(
+            "Test cases with the same name should have the same hash code",
             new TestCaseJavaParser(name).hashCode(),
             Matchers.is(new TestCaseJavaParser(name).hashCode())
         );
@@ -68,6 +71,7 @@ class TestCaseJavaParserTest {
     void equalsIfBothTheSame() {
         final String name = "nme";
         MatcherAssert.assertThat(
+            "Test cases with the same name should be equal",
             new TestCaseJavaParser(name),
             Matchers.equalTo(new TestCaseJavaParser(name))
         );
@@ -75,44 +79,60 @@ class TestCaseJavaParserTest {
 
     @Test
     void parsesSuppressedAnnotations() {
+        final String test = "cheksTest";
         final Collection<String> suppressed = JavaTestClasses.ONLY_METHODS_SUPPRESSED
-            .testCase("cheksTest")
+            .testCase(test)
             .suppressed();
-        MatcherAssert.assertThat(suppressed, Matchers.hasSize(2));
-        MatcherAssert.assertThat(
-            suppressed,
-            Matchers.hasItems(RuleNotContainsTestWord.NAME, RuleNotCamelCase.NAME)
+        final String[] expected = {RuleNotContainsTestWord.NAME, RuleNotCamelCase.NAME};
+        final String msg = String.format(
+            "The '%s' method has to contain %d suppressed annotations %s, but was %s",
+            test, expected.length,
+            Arrays.toString(expected),
+            suppressed
         );
+        MatcherAssert.assertThat(msg, suppressed, Matchers.hasSize(2));
+        MatcherAssert.assertThat(msg, suppressed, Matchers.hasItems(expected));
     }
 
     @Test
     void parsesSingleSuppressedAnnotation() {
+        final String test = "checksSingle";
         final Collection<String> suppressed = JavaTestClasses.ONLY_METHODS_SUPPRESSED
-            .testCase("checksSingle")
+            .testCase(test)
             .suppressed();
-        MatcherAssert.assertThat(suppressed, Matchers.hasSize(1));
-        MatcherAssert.assertThat(
-            suppressed,
-            Matchers.hasItems(RuleNotContainsTestWord.NAME)
+        final String expected = RuleNotContainsTestWord.NAME;
+        final String msg = String.format(
+            "The '%s' method has to contain single suppressed annotation '%s', but was %s",
+            test,
+            expected,
+            suppressed
         );
+        MatcherAssert.assertThat(msg, suppressed, Matchers.hasSize(1));
+        MatcherAssert.assertThat(msg, suppressed, Matchers.hasItems(expected));
     }
 
     @Test
     void parsesSuppressedAnnotationsForClassAndMethodTogether() {
+        final String test = "cheksTest";
         final Collection<String> suppressed = JavaTestClasses.MANY_SUPPRESSED
-            .testCase("cheksTest")
+            .testCase(test)
             .suppressed();
-        MatcherAssert.assertThat(suppressed, Matchers.hasSize(5));
-        MatcherAssert.assertThat(
-            suppressed,
-            Matchers.hasItems(
-                RuleAllTestsHaveProductionClass.NAME,
-                RuleNotContainsTestWord.NAME,
-                RuleNotCamelCase.NAME,
-                "AnotherRule",
-                "UnknownRule"
-            )
+        final String[] expected = {
+            RuleAllTestsHaveProductionClass.NAME,
+            RuleNotContainsTestWord.NAME,
+            RuleNotCamelCase.NAME,
+            "AnotherRule",
+            "UnknownRule",
+        };
+        final String msg = String.format(
+            "The '%s' method has to contain %d suppressed annotations %s, but was %s",
+            test,
+            expected.length,
+            Arrays.toString(expected),
+            suppressed
         );
+        MatcherAssert.assertThat(msg, suppressed, Matchers.hasSize(5));
+        MatcherAssert.assertThat(msg, suppressed, Matchers.hasItems(expected));
     }
 
     @Test

--- a/src/test/java/com/github/lombrozo/testnames/javaparser/TestClassJavaParserTest.java
+++ b/src/test/java/com/github/lombrozo/testnames/javaparser/TestClassJavaParserTest.java
@@ -29,7 +29,9 @@ import com.github.lombrozo.testnames.rules.RuleAllTestsHaveProductionClass;
 import com.github.lombrozo.testnames.rules.RuleNotCamelCase;
 import com.github.lombrozo.testnames.rules.RuleNotContainsTestWord;
 import java.nio.file.Path;
+import java.util.Arrays;
 import java.util.Collection;
+import java.util.Set;
 import java.util.stream.Collectors;
 import org.cactoos.io.InputStreamOf;
 import org.hamcrest.MatcherAssert;
@@ -47,44 +49,66 @@ final class TestClassJavaParserTest {
 
     @Test
     void getsNames() {
+        final String[] expected = {"creates", "removes", "updates"};
+        final Set<String> all = JavaTestClasses.SIMPLE.toTestClass()
+            .all()
+            .stream()
+            .map(TestCase::name)
+            .collect(Collectors.toSet());
         MatcherAssert.assertThat(
-            JavaTestClasses.SIMPLE.toTestClass()
-                .all()
-                .stream()
-                .map(TestCase::name)
-                .collect(Collectors.toSet()),
-            Matchers.containsInAnyOrder(
-                "creates", "removes", "updates"
-            )
+            String.format(
+                "We expected that test class will contain only three test cases: %s, but was %s",
+                Arrays.toString(expected),
+                all
+            ),
+            all,
+            Matchers.containsInAnyOrder(expected)
         );
     }
 
     @Test
     void returnsEmptyListIfItDoesNotHaveAnyCases() {
+        final Collection<TestCase> all = JavaTestClasses.WITHOUT_TESTS.toTestClass().all();
         MatcherAssert.assertThat(
-            JavaTestClasses.WITHOUT_TESTS.toTestClass().all(),
+            String.format(
+                "We expected that test class %s will not contain any test cases, but was %s",
+                JavaTestClasses.WITHOUT_TESTS,
+                all
+            ),
+            all,
             Matchers.empty()
         );
     }
 
     @Test
     void getsNamesFromParameterizedCase() {
+        final String cases = "checksCases";
         MatcherAssert.assertThat(
+            String.format(
+                "We expected that test class %s will contain only one test case %s",
+                JavaTestClasses.PARAMETERIZED,
+                cases
+            ),
             JavaTestClasses.PARAMETERIZED
                 .toTestClass()
                 .all()
                 .stream()
                 .map(TestCase::name)
                 .collect(Collectors.toSet()),
-            Matchers.containsInAnyOrder("checksCases")
+            Matchers.containsInAnyOrder(cases)
         );
     }
 
     @Test
     void throwsExceptionIfFileNotFound(@TempDir final Path temp) {
+        final Path test = temp.resolve("TestNotFound.java");
         Assertions.assertThrows(
             IllegalStateException.class,
-            () -> new TestClassJavaParser(temp.resolve("TestNotFound.java")).all()
+            () -> new TestClassJavaParser(test).all(),
+            String.format(
+                "We expected that exception will be thrown, because file %s not found",
+                test
+            )
         );
     }
 
@@ -92,7 +116,11 @@ final class TestClassJavaParserTest {
     void throwsExceptionIfFileIsNotJava(@TempDir final Path temp) {
         Assertions.assertThrows(
             IllegalStateException.class,
-            () -> new TestClassJavaParser(temp, new InputStreamOf("Not Java")).all()
+            () -> new TestClassJavaParser(temp, new InputStreamOf("Not Java")).all(),
+            String.format(
+                "We expected that exception will be thrown, because file %s is not Java",
+                temp
+            )
         );
     }
 
@@ -157,8 +185,17 @@ final class TestClassJavaParserTest {
         final Collection<String> all = JavaTestClasses.SUPPRESSED_ANNOTATION
             .toTestClass()
             .suppressed();
-        MatcherAssert.assertThat(all, Matchers.hasSize(1));
-        MatcherAssert.assertThat(all, Matchers.hasItem(RuleAllTestsHaveProductionClass.NAME));
+        final String expected = RuleAllTestsHaveProductionClass.NAME;
+        MatcherAssert.assertThat(
+            String.format("Expected only %s rule, but was %s", expected, all),
+            all,
+            Matchers.hasSize(1)
+        );
+        MatcherAssert.assertThat(
+            String.format("Expected exactly %s rule, but was %s", expected, all),
+            all,
+            Matchers.hasItem(expected)
+        );
     }
 
     @Test
@@ -166,7 +203,16 @@ final class TestClassJavaParserTest {
         final Collection<String> all = JavaTestClasses.SUPPRESSED_INTERFACE
             .toTestClass()
             .suppressed();
-        MatcherAssert.assertThat(all, Matchers.hasSize(1));
-        MatcherAssert.assertThat(all, Matchers.hasItem(RuleAllTestsHaveProductionClass.NAME));
+        final String expected = RuleAllTestsHaveProductionClass.NAME;
+        MatcherAssert.assertThat(
+            String.format("Expected only %s rule, but was %s", expected, all),
+            all,
+            Matchers.hasSize(1)
+        );
+        MatcherAssert.assertThat(
+            String.format("Expected exactly %s rule, but was %s", expected, all),
+            all,
+            Matchers.hasItem(expected)
+        );
     }
 }

--- a/src/test/java/com/github/lombrozo/testnames/javaparser/TestClassJavaParserTest.java
+++ b/src/test/java/com/github/lombrozo/testnames/javaparser/TestClassJavaParserTest.java
@@ -126,8 +126,14 @@ final class TestClassJavaParserTest {
 
     @Test
     void returnsEmptyListOfSuppressedRules() {
+        final Collection<String> suppressed = JavaTestClasses.SIMPLE.toTestClass().suppressed();
         MatcherAssert.assertThat(
-            JavaTestClasses.SIMPLE.toTestClass().suppressed(),
+            String.format(
+                "We expected that test class %s will not contain any suppressed rules, but was %s",
+                JavaTestClasses.SIMPLE,
+                suppressed
+            ),
+            suppressed,
             Matchers.empty()
         );
     }
@@ -137,8 +143,14 @@ final class TestClassJavaParserTest {
         final Collection<String> all = JavaTestClasses.SUPPRESSED_CLASS
             .toTestClass()
             .suppressed();
-        MatcherAssert.assertThat(all, Matchers.hasSize(1));
+        final String msg = String.format(
+            "We expected that test class %s will contain only one suppressed rule %s",
+            JavaTestClasses.SUPPRESSED_CLASS,
+            RuleAllTestsHaveProductionClass.NAME
+        );
+        MatcherAssert.assertThat(msg, all, Matchers.hasSize(1));
         MatcherAssert.assertThat(
+            msg,
             all.iterator().next(),
             Matchers.equalTo(RuleAllTestsHaveProductionClass.NAME)
         );
@@ -149,35 +161,43 @@ final class TestClassJavaParserTest {
         final Collection<String> all = JavaTestClasses.MANY_SUPPRESSED
             .toTestClass()
             .suppressed();
-        MatcherAssert.assertThat(all, Matchers.hasSize(3));
-        MatcherAssert.assertThat(
-            all,
-            Matchers.hasItems(
-                RuleAllTestsHaveProductionClass.NAME,
-                RuleNotCamelCase.NAME,
-                RuleNotContainsTestWord.NAME
-            )
+        final String[] expected = {
+            RuleAllTestsHaveProductionClass.NAME,
+            RuleNotCamelCase.NAME,
+            RuleNotContainsTestWord.NAME,
+        };
+        final String msg = String.format(
+            "We expected that test class %s will contain only three suppressed rules: %s, but was %s",
+            JavaTestClasses.MANY_SUPPRESSED,
+            Arrays.toString(expected),
+            all
         );
+        MatcherAssert.assertThat(msg, all, Matchers.hasSize(3));
+        MatcherAssert.assertThat(msg, all, Matchers.hasItems(expected));
     }
 
     @Test
     void excludesProjectSuppressedRules() {
         final String custom = "Custom";
         final String project = "Project";
+        final String[] expected = {
+            custom,
+            project,
+            RuleAllTestsHaveProductionClass.NAME,
+            RuleNotCamelCase.NAME,
+            RuleNotContainsTestWord.NAME,
+        };
         final Collection<String> all = JavaTestClasses.MANY_SUPPRESSED
             .toTestClass(custom, project)
             .suppressed();
-        MatcherAssert.assertThat(all, Matchers.hasSize(5));
-        MatcherAssert.assertThat(
-            all,
-            Matchers.hasItems(
-                RuleAllTestsHaveProductionClass.NAME,
-                RuleNotCamelCase.NAME,
-                RuleNotContainsTestWord.NAME,
-                custom,
-                project
-            )
+        final String msg = String.format(
+            "We expected that test class %s will contain exactly five suppressed rules: %s, but was %s",
+            JavaTestClasses.MANY_SUPPRESSED,
+            Arrays.toString(expected),
+            all
         );
+        MatcherAssert.assertThat(msg, all, Matchers.hasSize(5));
+        MatcherAssert.assertThat(msg, all, Matchers.hasItems(expected));
     }
 
     @Test
@@ -186,15 +206,12 @@ final class TestClassJavaParserTest {
             .toTestClass()
             .suppressed();
         final String expected = RuleAllTestsHaveProductionClass.NAME;
+        final String msg = String.format("Expected exactly %s rule, but was %s", expected, all);
         MatcherAssert.assertThat(
-            String.format("Expected only %s rule, but was %s", expected, all),
-            all,
-            Matchers.hasSize(1)
+            msg, all, Matchers.hasSize(1)
         );
         MatcherAssert.assertThat(
-            String.format("Expected exactly %s rule, but was %s", expected, all),
-            all,
-            Matchers.hasItem(expected)
+            msg, all, Matchers.hasItem(expected)
         );
     }
 
@@ -204,15 +221,8 @@ final class TestClassJavaParserTest {
             .toTestClass()
             .suppressed();
         final String expected = RuleAllTestsHaveProductionClass.NAME;
-        MatcherAssert.assertThat(
-            String.format("Expected only %s rule, but was %s", expected, all),
-            all,
-            Matchers.hasSize(1)
-        );
-        MatcherAssert.assertThat(
-            String.format("Expected exactly %s rule, but was %s", expected, all),
-            all,
-            Matchers.hasItem(expected)
-        );
+        final String msg = String.format("Expected only %s rule, but was %s", expected, all);
+        MatcherAssert.assertThat(msg, all, Matchers.hasSize(1));
+        MatcherAssert.assertThat(msg, all, Matchers.hasItem(expected));
     }
 }

--- a/src/test/java/com/github/lombrozo/testnames/rules/ml/ModelSourceFileSystemTest.java
+++ b/src/test/java/com/github/lombrozo/testnames/rules/ml/ModelSourceFileSystemTest.java
@@ -46,6 +46,10 @@ class ModelSourceFileSystemTest {
     void loadsFromFileSystem(@TempDir final Path temp) throws IOException {
         final Path path = temp.resolve("model.bin");
         new ModelSourceInternet().model().serialize(path);
-        MatcherAssert.assertThat(new ModelSourceFileSystem(path).model(), Matchers.notNullValue());
+        MatcherAssert.assertThat(
+            String.format("Model from %s is null", path),
+            new ModelSourceFileSystem(path).model(),
+            Matchers.notNullValue()
+        );
     }
 }

--- a/src/test/java/com/github/lombrozo/testnames/rules/ml/RulePresentSimpleMlTest.java
+++ b/src/test/java/com/github/lombrozo/testnames/rules/ml/RulePresentSimpleMlTest.java
@@ -81,6 +81,7 @@ class RulePresentSimpleMlTest {
     @ParameterizedTest
     void checksCorrectNames(final String name) {
         MatcherAssert.assertThat(
+            String.format("Name '%s' has to be correct", name),
             new RulePresentSimpleMl(
                 RulePresentSimpleMlTest.model,
                 new TestCase.Fake(name)
@@ -105,6 +106,7 @@ class RulePresentSimpleMlTest {
     @ParameterizedTest
     void checksWrongNames(final String name) {
         MatcherAssert.assertThat(
+            String.format("Name '%s' has to be incorrect", name),
             new RulePresentSimpleMl(
                 RulePresentSimpleMlTest.model,
                 new TestCase.Fake(name)


### PR DESCRIPTION
Update jtcop up to the `0.1.16` version.
Add assertion messages for all the rest tests.

<!-- start pr-codex -->

---

## PR-Codex overview
### Focus of this PR:
Update the version of a Maven plugin and add additional assertions in test cases.

### Detailed summary:
- Updated the version of the `jtcop-maven-plugin` to `0.1.16` in the `pom.xml` file.
- Added additional assertions in the `ModelSourceFileSystemTest` and `ProjectJavaParserTest` test cases.
- Added formatted error messages for assertion failures in various test cases.
- Added new test cases in the `RulePresentSimpleMlTest`, `TestCaseJavaParserTest`, `TestClassJavaParserTest`, and `TestClassJavaParserTest` classes.
- Improved error messages and added additional assertions in the `TestClassJavaParserTest` class.

> The following files were skipped due to too many changes: `src/test/java/com/github/lombrozo/testnames/javaparser/TestClassJavaParserTest.java`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->