### PR TITLE
doc(#184): Add docs for RuleNotUsesSpecialCharacters rule

### DIFF
--- a/docs/rules/not-special-characters.md
+++ b/docs/rules/not-special-characters.md
@@ -1,4 +1,39 @@
-@todo #180:90min Add documentation for the `RuleNotUsesSpecialCharacters` rule. 
- The documentation should be added to the `docs/rules/not-special-characters.md`
- file. The documentation should contain the description of the rule and the 
- examples of the correct and incorrect code.
+# Test Name: Not Uses Special Characters
+
+Rule codename: _RuleNotUsesSpecialCharacters_
+___
+
+Each test name should not contain special characters like `$` or `_`.
+
+Wrong:
+```java
+@Test
+@Test
+void checks_successfully() {
+        //...
+}
+
+@Test
+void checks$unsuccessfully(){
+        //...
+}
+```
+
+Correct:
+```java
+@Test
+void checksSuccessfully() {
+ //...
+}
+
+@Test
+void checksUnsuccessfully(){
+    //...
+}
+```
+
+In order to suppress this rule, you can use the following annotation
+`@SuppressedWarnings("JTCOP.RuleNotUsesSpecialCharacters")`.
+
+You can read more about that
+rule [here](https://www.yegor256.com/2023/01/19/layout-of-tests.html#assertions).


### PR DESCRIPTION
Add docs for RuleNotUsesSpecialCharacters rule

Closes: #184 

<!-- start pr-codex -->

---

## PR-Codex overview
### Detailed summary
- Added documentation for the rule "Not Uses Special Characters" in `docs/rules/not-special-characters.md`
- Provided examples of correct and incorrect code for the rule
- Added information on how to suppress the rule using `@SuppressWarnings` annotation
- Included a link to more information about the rule in the documentation

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->