### PR TITLE
feat(#216): Correct Test Name rule implementation

### DIFF
--- a/docs/rules/test-class-name.md
+++ b/docs/rules/test-class-name.md
@@ -1,0 +1,4 @@
+@todo #216:30min Add documentation for the RuleCorrectTestName.
+The documentation should be added to the `docs/rules/test-class-name.md` file.
+The documentation should contain the description of the rule and the
+examples of the correct and incorrect code.

--- a/src/main/java/com/github/lombrozo/testnames/complaints/ComplaintLinked.java
+++ b/src/main/java/com/github/lombrozo/testnames/complaints/ComplaintLinked.java
@@ -32,7 +32,7 @@ import java.net.URL;
  *
  * @since 0.1.15
  */
-public final class LinkedComplaint implements Complaint {
+public final class ComplaintLinked implements Complaint {
 
     /**
      * The complaint message.
@@ -62,13 +62,13 @@ public final class LinkedComplaint implements Complaint {
      * @param document The document name to the rule description in the default repo.
      * @checkstyle ParameterNumberCheck (10 lines)
      */
-    public LinkedComplaint(
+    public ComplaintLinked(
         final String complaint,
         final String suggestion,
         final Class<?> rule,
         final String document
     ) {
-        this(complaint, suggestion, rule.getSimpleName(), LinkedComplaint.url(document));
+        this(complaint, suggestion, rule.getSimpleName(), ComplaintLinked.url(document));
     }
 
     /**
@@ -79,7 +79,7 @@ public final class LinkedComplaint implements Complaint {
      * @param link The link to the rule description
      * @checkstyle ParameterNumberCheck (10 lines)
      */
-    private LinkedComplaint(
+    private ComplaintLinked(
         final String complaint,
         final String suggestion,
         final String rule,

--- a/src/main/java/com/github/lombrozo/testnames/rules/RuleAllTestsHaveProductionClass.java
+++ b/src/main/java/com/github/lombrozo/testnames/rules/RuleAllTestsHaveProductionClass.java
@@ -28,7 +28,7 @@ import com.github.lombrozo.testnames.ProductionClass;
 import com.github.lombrozo.testnames.Project;
 import com.github.lombrozo.testnames.Rule;
 import com.github.lombrozo.testnames.TestClass;
-import com.github.lombrozo.testnames.complaints.LinkedComplaint;
+import com.github.lombrozo.testnames.complaints.ComplaintLinked;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Map;
@@ -92,7 +92,7 @@ public final class RuleAllTestsHaveProductionClass implements Rule {
             if (!classes.containsKey(name)
                 && RuleAllTestsHaveProductionClass.isNotSuppressed(test)) {
                 complaints.add(
-                    new LinkedComplaint(
+                    new ComplaintLinked(
                         String.format("Test %s doesn't have corresponding production class", name),
                         String.format(
                             "Either rename or move the test class %s",

--- a/src/main/java/com/github/lombrozo/testnames/rules/RuleAssertionMessage.java
+++ b/src/main/java/com/github/lombrozo/testnames/rules/RuleAssertionMessage.java
@@ -27,7 +27,7 @@ import com.github.lombrozo.testnames.Assertion;
 import com.github.lombrozo.testnames.Complaint;
 import com.github.lombrozo.testnames.Rule;
 import com.github.lombrozo.testnames.TestCase;
-import com.github.lombrozo.testnames.complaints.LinkedComplaint;
+import com.github.lombrozo.testnames.complaints.ComplaintLinked;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -87,7 +87,7 @@ class RuleAssertionMessage implements Rule {
 
         @Override
         public String message() {
-            return new LinkedComplaint(
+            return new ComplaintLinked(
                 String.format("Method %s doesn't have assertion statements", this.method.name()),
                 "Please add at least one assertion statement to the test method",
                 RuleAssertionMessage.class,
@@ -125,7 +125,7 @@ class RuleAssertionMessage implements Rule {
 
         @Override
         public String message() {
-            return new LinkedComplaint(
+            return new ComplaintLinked(
                 String.format(
                     "Method '%s' has assertion without message: '%s'",
                     this.method.name(),

--- a/src/main/java/com/github/lombrozo/testnames/rules/RuleCorrectTestName.java
+++ b/src/main/java/com/github/lombrozo/testnames/rules/RuleCorrectTestName.java
@@ -25,6 +25,9 @@ package com.github.lombrozo.testnames.rules;
 
 import com.github.lombrozo.testnames.Complaint;
 import com.github.lombrozo.testnames.Rule;
+import com.github.lombrozo.testnames.TestClass;
+import com.github.lombrozo.testnames.complaints.LinkedComplaint;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 
@@ -37,8 +40,35 @@ import java.util.Collections;
  *  pipeline. We also have to add integration tests for the RuleCorrectTestName.
  */
 public final class RuleCorrectTestName implements Rule {
+
+    private static final String[] ALLOWED_PREFIXES = {"IT", "ITCase", "Test", "Tests", "TestCase"};
+    private final TestClass test;
+
+    RuleCorrectTestName(final TestClass test) {
+        this.test = test;
+    }
+
     @Override
     public Collection<Complaint> complaints() {
-        return Collections.emptyList();
+        final Collection<Complaint> complaints;
+        final String name = this.test.name();
+        if (RuleCorrectTestName.isIncorrectName(name)) {
+            complaints = Collections.singleton(
+                new LinkedComplaint(
+                    "",
+                    "",
+                    RuleCorrectTestName.class,
+                    ""
+                )
+            );
+        } else {
+            complaints = Collections.emptySet();
+        }
+        return complaints;
+    }
+
+    private static boolean isIncorrectName(final String name) {
+        return Arrays.stream(RuleCorrectTestName.ALLOWED_PREFIXES).noneMatch(
+            prefix -> name.startsWith(prefix) || name.endsWith(prefix));
     }
 }

--- a/src/main/java/com/github/lombrozo/testnames/rules/RuleCorrectTestName.java
+++ b/src/main/java/com/github/lombrozo/testnames/rules/RuleCorrectTestName.java
@@ -26,7 +26,7 @@ package com.github.lombrozo.testnames.rules;
 import com.github.lombrozo.testnames.Complaint;
 import com.github.lombrozo.testnames.Rule;
 import com.github.lombrozo.testnames.TestClass;
-import com.github.lombrozo.testnames.complaints.LinkedComplaint;
+import com.github.lombrozo.testnames.complaints.ComplaintLinked;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -41,11 +41,22 @@ import java.util.Collections;
  */
 public final class RuleCorrectTestName implements Rule {
 
+    /**
+     * Allowed prefixes for integration and unit test class names.
+     */
     private static final String[] ALLOWED_PREFIXES = {"IT", "ITCase", "Test", "Tests", "TestCase"};
+
+    /**
+     * The test class to check.
+     */
     private final TestClass test;
 
-    RuleCorrectTestName(final TestClass test) {
-        this.test = test;
+    /**
+     * Constructor.
+     * @param klass The test class to check.
+     */
+    RuleCorrectTestName(final TestClass klass) {
+        this.test = klass;
     }
 
     @Override
@@ -54,7 +65,7 @@ public final class RuleCorrectTestName implements Rule {
         final String name = this.test.name();
         if (RuleCorrectTestName.isIncorrectName(name)) {
             complaints = Collections.singleton(
-                new LinkedComplaint(
+                new ComplaintLinked(
                     "",
                     "",
                     RuleCorrectTestName.class,
@@ -67,8 +78,13 @@ public final class RuleCorrectTestName implements Rule {
         return complaints;
     }
 
+    /**
+     * Checks if the name of the test class is incorrect.
+     * @param name The name of the test class.
+     * @return True if the name is incorrect.
+     */
     private static boolean isIncorrectName(final String name) {
-        return Arrays.stream(RuleCorrectTestName.ALLOWED_PREFIXES).noneMatch(
-            prefix -> name.startsWith(prefix) || name.endsWith(prefix));
+        return Arrays.stream(RuleCorrectTestName.ALLOWED_PREFIXES)
+            .noneMatch(prefix -> name.startsWith(prefix) || name.endsWith(prefix));
     }
 }

--- a/src/main/java/com/github/lombrozo/testnames/rules/RuleCorrectTestName.java
+++ b/src/main/java/com/github/lombrozo/testnames/rules/RuleCorrectTestName.java
@@ -66,10 +66,17 @@ public final class RuleCorrectTestName implements Rule {
         if (RuleCorrectTestName.isIncorrectName(name)) {
             complaints = Collections.singleton(
                 new ComplaintLinked(
-                    "",
-                    "",
-                    RuleCorrectTestName.class,
-                    ""
+                    String.format(
+                        "Test class name should start or end with one of the following prefixes: %s",
+                        Arrays.toString(RuleCorrectTestName.ALLOWED_PREFIXES)
+                    ),
+                    String.format(
+                        "Please rename the %s test class to start or end with one of the following prefixes: %s",
+                        name,
+                        Arrays.toString(RuleCorrectTestName.ALLOWED_PREFIXES)
+                    ),
+                    this.getClass(),
+                    "test-class-name.md"
                 )
             );
         } else {

--- a/src/main/java/com/github/lombrozo/testnames/rules/RuleNotCamelCase.java
+++ b/src/main/java/com/github/lombrozo/testnames/rules/RuleNotCamelCase.java
@@ -27,8 +27,8 @@ package com.github.lombrozo.testnames.rules;
 import com.github.lombrozo.testnames.Complaint;
 import com.github.lombrozo.testnames.Rule;
 import com.github.lombrozo.testnames.TestCase;
+import com.github.lombrozo.testnames.complaints.ComplaintLinked;
 import com.github.lombrozo.testnames.complaints.ComplaintWrongTestName;
-import com.github.lombrozo.testnames.complaints.LinkedComplaint;
 import java.util.Collection;
 
 /**
@@ -61,7 +61,7 @@ public final class RuleNotCamelCase implements Rule {
     public Collection<Complaint> complaints() {
         return new RuleConditional(
             this::notCamelCase,
-            new LinkedComplaint(
+            new ComplaintLinked(
                 new ComplaintWrongTestName(
                     this.test,
                     "test has to be written by using Camel Case"

--- a/src/main/java/com/github/lombrozo/testnames/rules/RuleNotContainsTestWord.java
+++ b/src/main/java/com/github/lombrozo/testnames/rules/RuleNotContainsTestWord.java
@@ -27,8 +27,8 @@ package com.github.lombrozo.testnames.rules;
 import com.github.lombrozo.testnames.Complaint;
 import com.github.lombrozo.testnames.Rule;
 import com.github.lombrozo.testnames.TestCase;
+import com.github.lombrozo.testnames.complaints.ComplaintLinked;
 import com.github.lombrozo.testnames.complaints.ComplaintWrongTestName;
-import com.github.lombrozo.testnames.complaints.LinkedComplaint;
 import java.util.Collection;
 import java.util.stream.Stream;
 
@@ -62,7 +62,7 @@ public final class RuleNotContainsTestWord implements Rule {
     public Collection<Complaint> complaints() {
         return new RuleConditional(
             this::containsTest,
-            new LinkedComplaint(
+            new ComplaintLinked(
                 new ComplaintWrongTestName(
                     this.test,
                     "test name doesn't have to contain the word 'test'"

--- a/src/main/java/com/github/lombrozo/testnames/rules/RuleNotSpam.java
+++ b/src/main/java/com/github/lombrozo/testnames/rules/RuleNotSpam.java
@@ -27,8 +27,8 @@ package com.github.lombrozo.testnames.rules;
 import com.github.lombrozo.testnames.Complaint;
 import com.github.lombrozo.testnames.Rule;
 import com.github.lombrozo.testnames.TestCase;
+import com.github.lombrozo.testnames.complaints.ComplaintLinked;
 import com.github.lombrozo.testnames.complaints.ComplaintWrongTestName;
-import com.github.lombrozo.testnames.complaints.LinkedComplaint;
 import java.util.Collection;
 
 /**
@@ -56,7 +56,7 @@ public final class RuleNotSpam implements Rule {
     public Collection<Complaint> complaints() {
         return new RuleConditional(
             () -> !this.notSpam(),
-            new LinkedComplaint(
+            new ComplaintLinked(
                 new ComplaintWrongTestName(
                     this.test,
                     "test name doesn't have to contain duplicated symbols"

--- a/src/main/java/com/github/lombrozo/testnames/rules/RuleNotUsesSpecialCharacters.java
+++ b/src/main/java/com/github/lombrozo/testnames/rules/RuleNotUsesSpecialCharacters.java
@@ -27,8 +27,8 @@ package com.github.lombrozo.testnames.rules;
 import com.github.lombrozo.testnames.Complaint;
 import com.github.lombrozo.testnames.Rule;
 import com.github.lombrozo.testnames.TestCase;
+import com.github.lombrozo.testnames.complaints.ComplaintLinked;
 import com.github.lombrozo.testnames.complaints.ComplaintWrongTestName;
-import com.github.lombrozo.testnames.complaints.LinkedComplaint;
 import java.util.Collection;
 
 /**
@@ -56,7 +56,7 @@ public final class RuleNotUsesSpecialCharacters implements Rule {
     public Collection<Complaint> complaints() {
         return new RuleConditional(
             this::usesSpecialCharacters,
-            new LinkedComplaint(
+            new ComplaintLinked(
                 new ComplaintWrongTestName(
                     this.test,
                     "test name shouldn't contain special characters like '$' or '_'"

--- a/src/main/java/com/github/lombrozo/testnames/rules/RulePresentTense.java
+++ b/src/main/java/com/github/lombrozo/testnames/rules/RulePresentTense.java
@@ -27,8 +27,8 @@ package com.github.lombrozo.testnames.rules;
 import com.github.lombrozo.testnames.Complaint;
 import com.github.lombrozo.testnames.Rule;
 import com.github.lombrozo.testnames.TestCase;
+import com.github.lombrozo.testnames.complaints.ComplaintLinked;
 import com.github.lombrozo.testnames.complaints.ComplaintWrongTestName;
-import com.github.lombrozo.testnames.complaints.LinkedComplaint;
 import java.util.Collection;
 
 /**
@@ -56,7 +56,7 @@ public final class RulePresentTense implements Rule {
     public Collection<Complaint> complaints() {
         return new RuleConditional(
             () -> !this.presentTense(),
-            new LinkedComplaint(
+            new ComplaintLinked(
                 new ComplaintWrongTestName(
                     this.test,
                     "the test name has to be written using present tense"

--- a/src/test/java/com/github/lombrozo/testnames/rules/RuleCorrectTestNameTest.java
+++ b/src/test/java/com/github/lombrozo/testnames/rules/RuleCorrectTestNameTest.java
@@ -23,6 +23,7 @@
  */
 package com.github.lombrozo.testnames.rules;
 
+import com.github.lombrozo.testnames.TestClass;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
@@ -40,7 +41,7 @@ class RuleCorrectTestNameTest {
     void createsCorrectly() {
         MatcherAssert.assertThat(
             "We expect that RuleCorrectTestName creates correctly, without any exceptions",
-            new RuleCorrectTestName(),
+            new RuleCorrectTestName(new TestClass.Fake("CorrectTest")),
             Matchers.notNullValue()
         );
     }
@@ -53,7 +54,7 @@ class RuleCorrectTestNameTest {
                 "We expect that %s is a correct name for an integration test class",
                 name
             ),
-            new RuleCorrectTestName().complaints(),
+            new RuleCorrectTestName(new TestClass.Fake(name)).complaints(),
             Matchers.empty()
         );
     }
@@ -75,7 +76,7 @@ class RuleCorrectTestNameTest {
                 "We expect that %s is a correct name for a unit test class",
                 name
             ),
-            new RuleCorrectTestName().complaints(),
+            new RuleCorrectTestName(new TestClass.Fake(name)).complaints(),
             Matchers.empty()
         );
     }
@@ -96,7 +97,7 @@ class RuleCorrectTestNameTest {
                 "We expect that %s is a incorrect name for an integration test class",
                 name
             ),
-            new RuleCorrectTestName().complaints(),
+            new RuleCorrectTestName(new TestClass.Fake(name)).complaints(),
             Matchers.not(Matchers.empty())
         );
     }
@@ -119,7 +120,7 @@ class RuleCorrectTestNameTest {
                 "We expect that %s is a incorrect name for a unit test class",
                 name
             ),
-            new RuleCorrectTestName().complaints(),
+            new RuleCorrectTestName(new TestClass.Fake(name)).complaints(),
             Matchers.not(Matchers.empty())
         );
     }

--- a/src/test/java/com/github/lombrozo/testnames/rules/RuleCorrectTestNameTest.java
+++ b/src/test/java/com/github/lombrozo/testnames/rules/RuleCorrectTestNameTest.java
@@ -25,7 +25,6 @@ package com.github.lombrozo.testnames.rules;
 
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -34,10 +33,6 @@ import org.junit.jupiter.params.provider.ValueSource;
  * Unit test for {@link RuleCorrectTestName}.
  *
  * @since 0.1.17
- * @todo #195:30min Continue implementing RuleIntegrationTestName.
- *  The rule should successfully check that the name of an integration test class
- *  ends with "IT" or "ITCase". When the rule is ready, remove the
- *  puzzle and enable all the tests inside {@link RuleCorrectTestNameTest}.
  */
 class RuleCorrectTestNameTest {
 
@@ -50,7 +45,6 @@ class RuleCorrectTestNameTest {
         );
     }
 
-    @Disabled
     @ParameterizedTest
     @ValueSource(strings = {"RulesIT", "RulesITCase", "ITCaseRules", "ITRules"})
     void checksCorrectITNames(final String name) {
@@ -64,7 +58,6 @@ class RuleCorrectTestNameTest {
         );
     }
 
-    @Disabled
     @ParameterizedTest
     @ValueSource(
         strings = {
@@ -87,7 +80,6 @@ class RuleCorrectTestNameTest {
         );
     }
 
-    @Disabled
     @ParameterizedTest
     @ValueSource(
         strings = {
@@ -109,7 +101,6 @@ class RuleCorrectTestNameTest {
         );
     }
 
-    @Disabled
     @ParameterizedTest
     @ValueSource(
         strings = {


### PR DESCRIPTION
Implement the `RuleCorrectTestName` rule.
Also rename `LinkedComplaint` -> `ComplaintLinked`

Close: #216 

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on adding documentation for a new rule called RuleCorrectTestName. 

### Detailed summary
- Added documentation for the RuleCorrectTestName in `docs/rules/test-class-name.md`
- Modified the RuleCorrectTestName implementation to check for correct test class names
- Added a new class called ComplaintLinked to handle linked complaints
- Updated imports in multiple files to reflect the changes

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->