### PR TITLE
feat(#218): Add docs for test class name rule

### DIFF
--- a/docs/rules/test-class-name.md
+++ b/docs/rules/test-class-name.md
@@ -1,4 +1,65 @@
-@todo #216:30min Add documentation for the RuleCorrectTestName.
-The documentation should be added to the `docs/rules/test-class-name.md` file.
-The documentation should contain the description of the rule and the
-examples of the correct and incorrect code.
+# Test Class Name
+
+The test class name should start or end with one of the next prefixes:
+- `Test`
+- `Tests`
+- `TestCase`
+- `IT`
+- `ITCase`
+
+Examples of valid test class names:
+```java
+public class UserTest {
+    // valid
+}
+
+public class UserTests {
+    // valid
+}
+
+public class UserTestCase {
+    // valid
+}
+
+public class UserIT {
+    // valid
+}
+
+public class UserITCase {
+    // valid
+}
+
+public class TestsUser {
+    // valid
+}
+
+public class TestUser {
+    // valid
+}
+
+public class TestCaseUser {
+    // valid
+}
+
+public class ITUser {
+    // valid
+}
+
+public class ITCaseUser {
+    // valid
+}
+```
+
+The next cases will be considered as invalid:
+
+```java
+public class User {
+    // invalid!
+}
+
+public class UserTestCaseTest {
+    // invalid!
+}
+```
+
+You can read more about that rule [here](https://www.yegor256.com/2023/01/19/layout-of-tests.html#integration-tests).

--- a/docs/rules/test-class-name.md
+++ b/docs/rules/test-class-name.md
@@ -1,4 +1,6 @@
 # Test Class Name
+Rule codename: _RuleCorrectTestName_
+___
 
 The test class name should start or end with one of the next prefixes:
 - `Test`
@@ -61,5 +63,8 @@ public class UserTestCaseTest {
     // invalid!
 }
 ```
+
+In order to suppress this rule, you can use the following annotation
+`@SuppressWarnings("JTCOP.RuleCorrectTestName")`.
 
 You can read more about that rule [here](https://www.yegor256.com/2023/01/19/layout-of-tests.html#integration-tests).


### PR DESCRIPTION
Add docs for `RuleCorrectTestName` rule

Closes: #218

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on adding a new rule called "Test Class Name" to the documentation. 

### Detailed summary
- Added a new rule called "Test Class Name" to the documentation.
- The rule specifies that test class names should start or end with certain prefixes.
- Provided examples of valid and invalid test class names.
- Added information on how to suppress the rule using the `@SuppressWarnings` annotation.
- Included a link to read more about the rule.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->