### PR TITLE
fix(#222): Fix the problem of parsing enum classes when we check for JUnit extension

### DIFF
--- a/src/main/java/com/github/lombrozo/testnames/javaparser/JavaParserClass.java
+++ b/src/main/java/com/github/lombrozo/testnames/javaparser/JavaParserClass.java
@@ -31,6 +31,7 @@ import com.github.javaparser.ast.body.AnnotationDeclaration;
 import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
 import com.github.javaparser.ast.body.MethodDeclaration;
 import com.github.javaparser.ast.body.TypeDeclaration;
+import com.github.javaparser.ast.nodeTypes.NodeWithImplements;
 import com.github.javaparser.ast.nodeTypes.NodeWithMembers;
 import com.github.javaparser.ast.type.ClassOrInterfaceType;
 import java.io.IOException;
@@ -145,7 +146,7 @@ final class JavaParserClass {
      */
     Collection<Class<?>> parents() {
         final Collection<String> all = this.imports();
-        return this.cast().getImplementedTypes().stream()
+        return this.implement().getImplementedTypes().stream()
             .filter(ClassOrInterfaceType::isClassOrInterfaceType)
             .map(ClassOrInterfaceType::getNameWithScope)
             .map(name -> all.stream().filter(s -> s.contains(name)).findFirst().orElse(name))
@@ -181,7 +182,7 @@ final class JavaParserClass {
      * @return All the imports of the current class.
      */
     private Collection<String> imports() {
-        return this.cast()
+        return this.klass
             .getParentNode()
             .map(
                 node -> ((CompilationUnit) node)
@@ -191,6 +192,20 @@ final class JavaParserClass {
                     .collect(Collectors.toList())
             )
             .orElse(Collections.emptyList());
+    }
+
+    /**
+     * Cast the class to NodeWithImplements.
+     * @return NodeWithImplements
+     */
+    private NodeWithImplements<?> implement() {
+        if (this.klass instanceof NodeWithImplements<?>) {
+            return (NodeWithImplements<?>) this.klass;
+        } else {
+            throw new IllegalStateException(
+                String.format("Can't cast %s to NodeWithImplements", this.klass)
+            );
+        }
     }
 
     /**

--- a/src/test/java/com/github/lombrozo/testnames/javaparser/JavaTestClasses.java
+++ b/src/test/java/com/github/lombrozo/testnames/javaparser/JavaTestClasses.java
@@ -115,7 +115,12 @@ enum JavaTestClasses {
     /**
      * Test class with mistakes in test names.
      */
-    WRONG_NAME("TestWrongName.java");
+    WRONG_NAME("TestWrongName.java"),
+
+    /**
+     * Enum class.
+     */
+    ENUM("EnumInTests.java");
 
     /**
      * Java file name in resources.

--- a/src/test/java/com/github/lombrozo/testnames/javaparser/TestCaseJavaParserTest.java
+++ b/src/test/java/com/github/lombrozo/testnames/javaparser/TestCaseJavaParserTest.java
@@ -178,7 +178,7 @@ class TestCaseJavaParserTest {
     }
 
     @Test
-    void checksIfJUnitExtensionForEnum(){
+    void checksIfJUnitExtensionForEnum() {
         MatcherAssert.assertThat(
             "Java enum has to be parsed, but doesn't have to be a JUnit extension",
             JavaTestClasses.ENUM.toTestClass().isJUnitExtension(),

--- a/src/test/java/com/github/lombrozo/testnames/javaparser/TestCaseJavaParserTest.java
+++ b/src/test/java/com/github/lombrozo/testnames/javaparser/TestCaseJavaParserTest.java
@@ -176,4 +176,13 @@ class TestCaseJavaParserTest {
             Matchers.hasSize(0)
         );
     }
+
+    @Test
+    void checksIfJUnitExtensionForEnum(){
+        MatcherAssert.assertThat(
+            "Java enum has to be parsed, but doesn't have to be a JUnit extension",
+            JavaTestClasses.ENUM.toTestClass().isJUnitExtension(),
+            Matchers.is(false)
+        );
+    }
 }

--- a/src/test/resources/EnumInTests.java
+++ b/src/test/resources/EnumInTests.java
@@ -1,0 +1,45 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2022-2023 Volodya
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.github.lombrozo.testnames.javaparser;
+
+import com.github.lombrozo.testnames.TestCase;
+import java.io.InputStream;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import org.cactoos.io.ResourceOf;
+
+/**
+ * Enum in tests.
+ *
+ * @since 0.1.18
+ */
+enum EnumInTests {
+
+    /**
+     * Enum class.
+     */
+    ENUM("EnumInTests.java");
+
+
+}


### PR DESCRIPTION
Fix the problem of parsing enum classes when we check for JUnit extension.

Closes: #222 

<!-- start pr-codex -->

---

## PR-Codex overview
### Detailed summary
- Added `ENUM` enum class to `JavaTestClasses.java`.
- Added test method `checksIfJUnitExtensionForEnum()` to `TestCaseJavaParserTest.java`.
- Added `EnumInTests.java` file.
- Imported `NodeWithImplements` class in `JavaParserClass.java`.
- Modified `isPackageInfo()` method in `JavaParserClass.java` to use `implement()` method.
- Added `implement()` method in `JavaParserClass.java` to cast the class to `NodeWithImplements`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->