### PR TITLE
feat(#224): Update jtcop version up to 0.1.18

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -229,7 +229,7 @@ SOFTWARE.
           <plugin>
             <groupId>com.github.volodya-lombrozo</groupId>
             <artifactId>jtcop-maven-plugin</artifactId>
-            <version>0.1.16</version>
+            <version>0.1.18</version>
             <executions>
               <execution>
                 <phase>verify</phase>

--- a/src/test/java/com/github/lombrozo/testnames/javaparser/JavaTestClasses.java
+++ b/src/test/java/com/github/lombrozo/testnames/javaparser/JavaTestClasses.java
@@ -34,7 +34,7 @@ import org.cactoos.io.ResourceOf;
  *
  * @since 0.1.14
  */
-@SuppressWarnings("JTCOP.RuleAllTestsHaveProductionClass")
+@SuppressWarnings({"JTCOP.RuleAllTestsHaveProductionClass", "JTCOP.RuleCorrectTestName"})
 enum JavaTestClasses {
 
     /**


### PR DESCRIPTION
Update `jtcop` version - `0.1.18`

Closes: #224 

<!-- start pr-codex -->

---

## PR-Codex overview
### Detailed summary
- Updated the version of `jtcop-maven-plugin` from `0.1.16` to `0.1.18` in `pom.xml`.
- Added `@SuppressWarnings("JTCOP.RuleCorrectTestName")` annotation to `JavaTestClasses` enum in `JavaTestClasses.java` file.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->