### PR TITLE
feat(#126): Remove RuleSuppressed from RuleAllTestsHaveProductionClass 

### DIFF
--- a/src/main/java/com/github/lombrozo/testnames/Cop.java
+++ b/src/main/java/com/github/lombrozo/testnames/Cop.java
@@ -56,24 +56,22 @@ final class Cop {
      * @return The complaints.
      */
     Collection<Complaint> inspection() {
-        return Stream.concat(
-            new RuleAllTestsHaveProductionClass(this.project)
-                .complaints()
-                .stream(),
-            this.project.testClasses().stream()
-                .flatMap(Cop::classLevelRules)
-                .map(Rule::complaints)
-                .flatMap(Collection::stream)
-        ).collect(Collectors.toList());
+        return this.project.testClasses().stream()
+            .flatMap(this::classLevelRules)
+            .map(Rule::complaints)
+            .flatMap(Collection::stream)
+            .collect(Collectors.toList());
     }
+
 
     /**
      * Creates the class-level rules.
      * @param klass The test class to check.
      * @return The class-level rules.
      */
-    private static Stream<Rule> classLevelRules(final TestClass klass) {
+    private Stream<Rule> classLevelRules(final TestClass klass) {
         return Stream.of(
+            new RuleSuppressed(new RuleAllTestsHaveProductionClass(this.project, klass), klass),
             new RuleSuppressed(new RuleAllTestsInPresentSimple(klass), klass),
             new RuleSuppressed(new RuleCorrectTestName(klass), klass)
         );

--- a/src/main/java/com/github/lombrozo/testnames/Cop.java
+++ b/src/main/java/com/github/lombrozo/testnames/Cop.java
@@ -63,7 +63,6 @@ final class Cop {
             .collect(Collectors.toList());
     }
 
-
     /**
      * Creates the class-level rules.
      * @param klass The test class to check.

--- a/src/main/java/com/github/lombrozo/testnames/complaints/ComplaintLinked.java
+++ b/src/main/java/com/github/lombrozo/testnames/complaints/ComplaintLinked.java
@@ -26,12 +26,14 @@ package com.github.lombrozo.testnames.complaints;
 import com.github.lombrozo.testnames.Complaint;
 import java.net.MalformedURLException;
 import java.net.URL;
+import lombok.ToString;
 
 /**
  * The complaint with link to the rule description.
  *
  * @since 0.1.15
  */
+@ToString
 public final class ComplaintLinked implements Complaint {
 
     /**

--- a/src/main/java/com/github/lombrozo/testnames/rules/RuleAllTestsHaveProductionClass.java
+++ b/src/main/java/com/github/lombrozo/testnames/rules/RuleAllTestsHaveProductionClass.java
@@ -63,6 +63,9 @@ public final class RuleAllTestsHaveProductionClass implements Rule {
      */
     private final Project project;
 
+    /**
+     * Test class to check.
+     */
     private final TestClass test;
 
     /**

--- a/src/main/java/com/github/lombrozo/testnames/rules/RuleAllTestsHaveProductionClass.java
+++ b/src/main/java/com/github/lombrozo/testnames/rules/RuleAllTestsHaveProductionClass.java
@@ -90,7 +90,6 @@ public final class RuleAllTestsHaveProductionClass implements Rule {
         final Collection<Complaint> complaints = new ArrayList<>(0);
         final String name = RuleAllTestsHaveProductionClass.clean(this.test.name());
         if (!classes.containsKey(name)
-            && RuleAllTestsHaveProductionClass.isNotSuppressed(this.test)
             && RuleAllTestsHaveProductionClass.isNotPackageInfo(this.test.name())) {
             complaints.add(
                 new ComplaintLinked(
@@ -133,20 +132,6 @@ public final class RuleAllTestsHaveProductionClass implements Rule {
         return RuleAllTestsHaveProductionClass.DOLLAR.matcher(
             RuleAllTestsHaveProductionClass.UNDERSCORE.matcher(plain).replaceAll("")
         ).replaceAll("");
-    }
-
-    /**
-     * Checks that the test class is not suppressed.
-     * @param klass The test class to check.
-     * @return True if the test class is not suppressed.
-     * @todo #117:30min Remove isNotSuppressed method from RuleAllTestsHaveProductionClass.
-     *  We have to remove isNotSuppressed method from RuleAllTestsHaveProductionClass because
-     *  we already implemented the suppression mechanism in the RuleSuppressed rule.
-     *  The main point here to keep backward compatibility in order to not break the build for all
-     *  dependent projects.
-     */
-    private static boolean isNotSuppressed(final TestClass klass) {
-        return !klass.suppressed().contains(RuleAllTestsHaveProductionClass.NAME);
     }
 
     /**

--- a/src/main/java/com/github/lombrozo/testnames/rules/RuleAllTestsHaveProductionClass.java
+++ b/src/main/java/com/github/lombrozo/testnames/rules/RuleAllTestsHaveProductionClass.java
@@ -63,12 +63,16 @@ public final class RuleAllTestsHaveProductionClass implements Rule {
      */
     private final Project project;
 
+    private final TestClass test;
+
     /**
      * Primary ctor.
      * @param proj The project to check.
+     * @param test The test to check.
      */
-    public RuleAllTestsHaveProductionClass(final Project proj) {
+    public RuleAllTestsHaveProductionClass(final Project proj, final TestClass test) {
         this.project = proj;
+        this.test = test;
     }
 
     @Override
@@ -84,25 +88,21 @@ public final class RuleAllTestsHaveProductionClass implements Rule {
                 )
             );
         final Collection<Complaint> complaints = new ArrayList<>(0);
-        final Collection<TestClass> tests = this.project.testClasses().stream()
-            .filter(test -> RuleAllTestsHaveProductionClass.isNotPackageInfo(test.name()))
-            .collect(Collectors.toList());
-        for (final TestClass test : tests) {
-            final String name = RuleAllTestsHaveProductionClass.clean(test.name());
-            if (!classes.containsKey(name)
-                && RuleAllTestsHaveProductionClass.isNotSuppressed(test)) {
-                complaints.add(
-                    new ComplaintLinked(
-                        String.format("Test %s doesn't have corresponding production class", name),
-                        String.format(
-                            "Either rename or move the test class %s",
-                            test.path()
-                        ),
-                        this.getClass(),
-                        "all-have-production-class.md"
-                    )
-                );
-            }
+        final String name = RuleAllTestsHaveProductionClass.clean(this.test.name());
+        if (!classes.containsKey(name)
+            && RuleAllTestsHaveProductionClass.isNotSuppressed(this.test)
+            && RuleAllTestsHaveProductionClass.isNotPackageInfo(this.test.name())) {
+            complaints.add(
+                new ComplaintLinked(
+                    String.format("Test %s doesn't have corresponding production class", name),
+                    String.format(
+                        "Either rename or move the test class %s",
+                        this.test.path()
+                    ),
+                    this.getClass(),
+                    "all-have-production-class.md"
+                )
+            );
         }
         return complaints;
     }

--- a/src/main/java/com/github/lombrozo/testnames/rules/RuleSuppressed.java
+++ b/src/main/java/com/github/lombrozo/testnames/rules/RuleSuppressed.java
@@ -24,7 +24,6 @@
 package com.github.lombrozo.testnames.rules;
 
 import com.github.lombrozo.testnames.Complaint;
-import com.github.lombrozo.testnames.Project;
 import com.github.lombrozo.testnames.Rule;
 import com.github.lombrozo.testnames.TestCase;
 import com.github.lombrozo.testnames.TestClass;

--- a/src/main/java/com/github/lombrozo/testnames/rules/RuleSuppressed.java
+++ b/src/main/java/com/github/lombrozo/testnames/rules/RuleSuppressed.java
@@ -24,6 +24,7 @@
 package com.github.lombrozo.testnames.rules;
 
 import com.github.lombrozo.testnames.Complaint;
+import com.github.lombrozo.testnames.Project;
 import com.github.lombrozo.testnames.Rule;
 import com.github.lombrozo.testnames.TestCase;
 import com.github.lombrozo.testnames.TestClass;

--- a/src/test/java/com/github/lombrozo/testnames/rules/RuleAllTestsHaveProductionClassTest.java
+++ b/src/test/java/com/github/lombrozo/testnames/rules/RuleAllTestsHaveProductionClassTest.java
@@ -45,13 +45,15 @@ final class RuleAllTestsHaveProductionClassTest {
 
     @Test
     void checksThatAllHaveCorrespondingProductionClass() {
+        final TestClass.Fake test = new TestClass.Fake("IdenticalTest", new TestCase.Fake());
         MatcherAssert.assertThat(
             "Should not have complaints, because all tests have corresponding production class",
             new RuleAllTestsHaveProductionClass(
                 new Project.Fake(
                     new ProductionClass.Fake("Identical"),
-                    new TestClass.Fake("IdenticalTest", new TestCase.Fake())
-                )
+                    test
+                ),
+                test
             ).complaints(),
             Matchers.empty()
         );
@@ -59,13 +61,15 @@ final class RuleAllTestsHaveProductionClassTest {
 
     @Test
     void checksThatClassHasCorrespondingProductionClassWithExtension() {
+        final TestClass.Fake test = new TestClass.Fake("HelloTest.java");
         MatcherAssert.assertThat(
             "Should not have complaints, because all tests have corresponding production class, even with .java extension",
             new RuleAllTestsHaveProductionClass(
                 new Project.Fake(
                     new ProductionClass.Fake("Hello.java"),
-                    new TestClass.Fake("HelloTest.java")
-                )
+                    test
+                ),
+                test
             ).complaints(),
             Matchers.empty()
         );
@@ -73,13 +77,15 @@ final class RuleAllTestsHaveProductionClassTest {
 
     @Test
     void checksThatClassHasCorrespondingProductionClassWithClassExtension() {
+        final TestClass.Fake test = new TestClass.Fake("HelloTest.class");
         MatcherAssert.assertThat(
             "Should not have complaints, because all tests have corresponding production class, even with .class extension",
             new RuleAllTestsHaveProductionClass(
                 new Project.Fake(
                     new ProductionClass.Fake("Hello.class"),
-                    new TestClass.Fake("HelloTest.class")
-                )
+                    test
+                ),
+                test
             ).complaints(),
             Matchers.empty()
         );
@@ -91,9 +97,9 @@ final class RuleAllTestsHaveProductionClassTest {
             "Should not have complaints, because all tests have corresponding production class, even if they have different extensions",
             new RuleAllTestsHaveProductionClass(
                 new Project.Fake(
-                    new ProductionClass.Fake("ComplaintClass.java"),
-                    new TestClass.Fake("ComplaintClassTest.class")
-                )
+                    new ProductionClass.Fake("ComplaintClass.java")
+                ),
+                new TestClass.Fake("ComplaintClassTest.class")
             ).complaints(),
             Matchers.empty()
         );
@@ -101,8 +107,10 @@ final class RuleAllTestsHaveProductionClassTest {
 
     @Test
     void checksThatDoesNotHaveCorrespondingProductionClass() {
+        final TestClass.Fake test = new TestClass.Fake();
         final Collection<Complaint> complaints = new RuleAllTestsHaveProductionClass(
-            new Project.Fake(new TestClass.Fake())
+            new Project.Fake(test),
+            test
         ).complaints();
         MatcherAssert.assertThat(
             "Should have complaints, because doesn't have corresponding production class",
@@ -124,10 +132,9 @@ final class RuleAllTestsHaveProductionClassTest {
             "Should not have complaints, because suppressed",
             new RuleSuppressed(
                 new RuleAllTestsHaveProductionClass(
-                    new Project.Fake(
-                        new TestClass.Fake(
-                            Collections.singletonList(RuleAllTestsHaveProductionClass.NAME)
-                        )
+                    new Project.Fake(),
+                    new TestClass.Fake(
+                        Collections.singletonList(RuleAllTestsHaveProductionClass.NAME)
                     )
                 )
             ).complaints(),
@@ -143,7 +150,8 @@ final class RuleAllTestsHaveProductionClassTest {
                 new ProductionClass.Fake(info),
                 new ProductionClass.Fake(info),
                 new ProductionClass.Fake(info)
-            )
+            ),
+            new TestClass.Fake(info)
         ).complaints();
         MatcherAssert.assertThat(
             String.format(
@@ -158,12 +166,14 @@ final class RuleAllTestsHaveProductionClassTest {
     @Test
     void filtersPackageInfoClasses() {
         final String info = "package-info.java";
+        final TestClass.Fake fake = new TestClass.Fake(info);
         final Collection<Complaint> complaints = new RuleAllTestsHaveProductionClass(
             new Project.Fake(
-                new TestClass.Fake(info),
+                fake,
                 new TestClass.Fake(info),
                 new TestClass.Fake(info)
-            )
+            ),
+            fake
         ).complaints();
         MatcherAssert.assertThat(
             String.format(
@@ -178,11 +188,13 @@ final class RuleAllTestsHaveProductionClassTest {
     @Test
     void handlesClassesWithTheSameNames() {
         final String name = "Hello";
+        final TestClass.Fake test = new TestClass.Fake("HelloTest");
         final Collection<Complaint> complaints = new RuleAllTestsHaveProductionClass(
             new Project.Fake(
                 Arrays.asList(new ProductionClass.Fake(name), new ProductionClass.Fake(name)),
-                Collections.singleton(new TestClass.Fake("HelloTest"))
-            )
+                Collections.singleton(test)
+            ),
+            test
         ).complaints();
         MatcherAssert.assertThat(
             String.format("Should not have complaints, but was %s", complaints),
@@ -193,13 +205,15 @@ final class RuleAllTestsHaveProductionClassTest {
 
     @Test
     void handlesCasesWithUnderscores() {
+        final TestClass.Fake test = new TestClass.Fake("Identical_Name_Test", new TestCase.Fake());
         MatcherAssert.assertThat(
             "Should not have complaints, because all tests have corresponding production class, but with underscores",
             new RuleAllTestsHaveProductionClass(
                 new Project.Fake(
                     new ProductionClass.Fake("IdenticalName"),
-                    new TestClass.Fake("Identical_Name_Test", new TestCase.Fake())
-                )
+                    test
+                ),
+                test
             ).complaints(),
             Matchers.empty()
         );
@@ -207,13 +221,15 @@ final class RuleAllTestsHaveProductionClassTest {
 
     @Test
     void handlesCasesWithDollarSign() {
+        final TestClass.Fake test = new TestClass.Fake("EObool$EOnot$Test", new TestCase.Fake());
         MatcherAssert.assertThat(
             "Should not have complaints, because all tests have corresponding production class, but with dollar sign",
             new RuleAllTestsHaveProductionClass(
                 new Project.Fake(
                     new ProductionClass.Fake("EObool$EOnot"),
-                    new TestClass.Fake("EObool$EOnot$Test", new TestCase.Fake())
-                )
+                    test
+                ),
+                test
             ).complaints(),
             Matchers.empty()
         );


### PR DESCRIPTION
Remove RuleSuppressed from RuleAllTestsHaveProductionClass.

Closes: #126 

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on adding the `@ToString` annotation to the `ComplaintLinked` class and refactoring the `inspection` method in the `Cop` class. 

### Detailed summary
- Added `@ToString` annotation to `ComplaintLinked` class.
- Refactored `inspection` method in `Cop` class to use method references and stream operations.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->