### PR TITLE
feat(#125): We don't need to refactor RuleSuppressed

### DIFF
--- a/src/main/java/com/github/lombrozo/testnames/Cop.java
+++ b/src/main/java/com/github/lombrozo/testnames/Cop.java
@@ -24,7 +24,7 @@
 package com.github.lombrozo.testnames;
 
 import com.github.lombrozo.testnames.rules.RuleAllTestsHaveProductionClass;
-import com.github.lombrozo.testnames.rules.RuleAllTestsInPresentSimple;
+import com.github.lombrozo.testnames.rules.RuleCorrectTestCases;
 import com.github.lombrozo.testnames.rules.RuleCorrectTestName;
 import com.github.lombrozo.testnames.rules.RuleSuppressed;
 import java.util.Collection;
@@ -71,8 +71,8 @@ final class Cop {
     private Stream<Rule> classLevelRules(final TestClass klass) {
         return Stream.of(
             new RuleSuppressed(new RuleAllTestsHaveProductionClass(this.project, klass), klass),
-            new RuleSuppressed(new RuleAllTestsInPresentSimple(klass), klass),
-            new RuleSuppressed(new RuleCorrectTestName(klass), klass)
+            new RuleSuppressed(new RuleCorrectTestName(klass), klass),
+            new RuleSuppressed(new RuleCorrectTestCases(klass), klass)
         );
     }
 }

--- a/src/main/java/com/github/lombrozo/testnames/rules/RuleCorrectTestCase.java
+++ b/src/main/java/com/github/lombrozo/testnames/rules/RuleCorrectTestCase.java
@@ -26,47 +26,44 @@ package com.github.lombrozo.testnames.rules;
 
 import com.github.lombrozo.testnames.Complaint;
 import com.github.lombrozo.testnames.Rule;
-import com.github.lombrozo.testnames.TestClass;
-import com.github.lombrozo.testnames.complaints.ComplaintClass;
+import com.github.lombrozo.testnames.TestCase;
 import java.util.Collection;
-import java.util.Collections;
-import java.util.List;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
- * The rule to check all tests on {@link RulePresentSimple}.
+ * The rule checks if test case in present simple.
  *
  * @since 0.1.0
  */
-public final class RuleAllTestsInPresentSimple implements Rule {
+public final class RuleCorrectTestCase implements Rule {
 
     /**
-     * All test cases.
+     * The rules.
      */
-    private final TestClass tests;
+    private final Collection<Rule> all;
 
     /**
      * Ctor.
      *
-     * @param cases The cases to check
+     * @param test The test case to check
      */
-    public RuleAllTestsInPresentSimple(final TestClass cases) {
-        this.tests = cases;
+    RuleCorrectTestCase(final TestCase test) {
+        this.all = Stream.of(
+            new RuleNotCamelCase(test),
+            new RuleNotContainsTestWord(test),
+            new RuleNotSpam(test),
+            new RuleNotUsesSpecialCharacters(test),
+            new RulePresentTense(test),
+            new RuleAssertionMessage(test)
+        ).map(rule -> new RuleSuppressed(rule, test)).collect(Collectors.toList());
     }
 
     @Override
     public Collection<Complaint> complaints() {
-        final List<Complaint> list = this.tests.all().stream()
-            .map(test -> new RuleSuppressed(new RulePresentSimple(test), test))
+        return this.all.stream()
             .map(Rule::complaints)
             .flatMap(Collection::stream)
             .collect(Collectors.toList());
-        final Collection<Complaint> result;
-        if (list.isEmpty()) {
-            result = Collections.emptyList();
-        } else {
-            result = Collections.singleton(new ComplaintClass(this.tests, list));
-        }
-        return result;
     }
 }

--- a/src/main/java/com/github/lombrozo/testnames/rules/RuleCorrectTestCases.java
+++ b/src/main/java/com/github/lombrozo/testnames/rules/RuleCorrectTestCases.java
@@ -26,44 +26,47 @@ package com.github.lombrozo.testnames.rules;
 
 import com.github.lombrozo.testnames.Complaint;
 import com.github.lombrozo.testnames.Rule;
-import com.github.lombrozo.testnames.TestCase;
+import com.github.lombrozo.testnames.TestClass;
+import com.github.lombrozo.testnames.complaints.ComplaintClass;
 import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 /**
- * The rule checks if test case in present simple.
+ * The rule to check all tests on {@link RuleCorrectTestCase}.
  *
  * @since 0.1.0
  */
-public final class RulePresentSimple implements Rule {
+public final class RuleCorrectTestCases implements Rule {
 
     /**
-     * The rules.
+     * All test cases.
      */
-    private final Collection<Rule> all;
+    private final TestClass tests;
 
     /**
      * Ctor.
      *
-     * @param test The test case to check
+     * @param cases The cases to check
      */
-    RulePresentSimple(final TestCase test) {
-        this.all = Stream.of(
-            new RuleNotCamelCase(test),
-            new RuleNotContainsTestWord(test),
-            new RuleNotSpam(test),
-            new RuleNotUsesSpecialCharacters(test),
-            new RulePresentTense(test),
-            new RuleAssertionMessage(test)
-        ).map(rule -> new RuleSuppressed(rule, test)).collect(Collectors.toList());
+    public RuleCorrectTestCases(final TestClass cases) {
+        this.tests = cases;
     }
 
     @Override
     public Collection<Complaint> complaints() {
-        return this.all.stream()
+        final List<Complaint> list = this.tests.all().stream()
+            .map(test -> new RuleSuppressed(new RuleCorrectTestCase(test), test))
             .map(Rule::complaints)
             .flatMap(Collection::stream)
             .collect(Collectors.toList());
+        final Collection<Complaint> result;
+        if (list.isEmpty()) {
+            result = Collections.emptyList();
+        } else {
+            result = Collections.singleton(new ComplaintClass(this.tests, list));
+        }
+        return result;
     }
 }

--- a/src/main/java/com/github/lombrozo/testnames/rules/RuleSuppressed.java
+++ b/src/main/java/com/github/lombrozo/testnames/rules/RuleSuppressed.java
@@ -34,12 +34,6 @@ import java.util.Collections;
  * Suppressed rule.
  *
  * @since 0.1.14
- * @todo #117:30min Continue refactoring of RuleSuppressed class.
- *  We can't apply RuleSuppressed for all cases like RuleAllTestsHaveProduction class (separate
- *  issue.) Moreover, as it was investigated all suppress annotations have to be treated as
- *  tree like structure. For example, if we have @SuppressWarnings("RulePresentTense")
- *  on a class level then we have to apply that suppressing for all test cases in that class.
- *  Current implementation of RuleSuppressed doesn't solve that problem.
  */
 public final class RuleSuppressed implements Rule {
     /**

--- a/src/test/java/com/github/lombrozo/testnames/rules/RuleCorrectTestCasesTest.java
+++ b/src/test/java/com/github/lombrozo/testnames/rules/RuleCorrectTestCasesTest.java
@@ -33,17 +33,17 @@ import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
 
 /**
- * Test case for {@link RuleAllTestsInPresentSimple}.
+ * Test case for {@link RuleCorrectTestCases}.
  *
  * @since 0.1.0
  */
-final class RuleAllTestsInPresentSimpleTest {
+final class RuleCorrectTestCasesTest {
 
     @Test
     void validatesAllWithoutExceptions() {
         MatcherAssert.assertThat(
             "All tests in present simple should not have complaints.",
-            new RuleAllTestsInPresentSimple(
+            new RuleCorrectTestCases(
                 new TestClass.Fake(
                     new TestCase.Fake("removes", new Assertion.Fake()),
                     new TestCase.Fake("creates", new Assertion.Fake())
@@ -57,7 +57,7 @@ final class RuleAllTestsInPresentSimpleTest {
     void validatesAllWithExceptions() {
         MatcherAssert.assertThat(
             "Test class which tests are not in present simple should have one complaint.",
-            new RuleAllTestsInPresentSimple(
+            new RuleCorrectTestCases(
                 new TestClass.Fake(
                     new TestCase.Fake("remove", new Assertion.Fake()),
                     new TestCase.Fake("create", new Assertion.Fake())
@@ -71,7 +71,7 @@ final class RuleAllTestsInPresentSimpleTest {
     void skipsSomeSuppressedChecksOnCaseLevel() {
         MatcherAssert.assertThat(
             "Should skip suppressed checks on method level.",
-            new RuleAllTestsInPresentSimple(
+            new RuleCorrectTestCases(
                 new TestClass.Fake(
                     new TestCase.Fake(
                         "remove",
@@ -92,13 +92,13 @@ final class RuleAllTestsInPresentSimpleTest {
     @Test
     void skipsSomeSuppressedChecksOnClassLevel() {
         final TestClass.Fake klass = new TestClass.Fake(
-            Collections.singletonList("RuleAllTestsInPresentSimple"),
+            Collections.singletonList("RuleCorrectTestCases"),
             new TestCase.Fake("remove", new Assertion.Fake()),
             new TestCase.Fake("create", new Assertion.Fake())
         );
         MatcherAssert.assertThat(
             "Should skip suppressed checks on class level.",
-            new RuleSuppressed(new RuleAllTestsInPresentSimple(klass), klass).complaints(),
+            new RuleSuppressed(new RuleCorrectTestCases(klass), klass).complaints(),
             Matchers.empty()
         );
     }

--- a/src/test/java/com/github/lombrozo/testnames/rules/RuleTest.java
+++ b/src/test/java/com/github/lombrozo/testnames/rules/RuleTest.java
@@ -74,7 +74,7 @@ final class RuleTest {
         "returnsRelativePathOfCurrentWorkingDirectory, true"
     })
     void validatesCorrectly(final String name, final boolean expected) {
-        final Collection<Complaint> complaints = new RulePresentSimple(
+        final Collection<Complaint> complaints = new RuleCorrectTestCase(
             new TestCase.Fake(name, new Assertion.Fake("Some message"))
         ).complaints();
         MatcherAssert.assertThat(


### PR DESCRIPTION
Since we don't need to refactor `RuleSuppressed`, I close the puzzle.

Closes: #125 

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on improving the test case naming rules in the codebase. 

### Detailed summary
- Renamed `RulePresentSimple` to `RuleCorrectTestCase` in `RuleTest.java`.
- Renamed `RulePresentSimple` class to `RuleCorrectTestCase` in `RulePresentSimple.java`.
- Renamed `RuleAllTestsInPresentSimple` class to `RuleCorrectTestCases` in `RuleAllTestsInPresentSimple.java`.
- Updated imports in `Cop.java` to use `RuleCorrectTestCases` instead of `RuleAllTestsInPresentSimple`.
- Updated test class names in `RuleAllTestsInPresentSimpleTest.java` to `RuleCorrectTestCasesTest`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->