### PR TITLE
feat(#231): Apply RuleOnlyTestsMethods as an experimental feature

### DIFF
--- a/src/it/assertions/pom.xml
+++ b/src/it/assertions/pom.xml
@@ -72,6 +72,9 @@ SOFTWARE.
               <experimental>true</experimental>
               <exclusions>
                 <exclusion>
+                  JTCOP.RuleOnlyTestMethods
+                </exclusion>
+                <exclusion>
                   JTCOP.RuleAllTestsHaveProductionClass
                 </exclusion>
                 <exclusion>

--- a/src/it/assertions/pom.xml
+++ b/src/it/assertions/pom.xml
@@ -22,7 +22,9 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.github.volodya-lombrozo</groupId>
   <artifactId>jtcop-it</artifactId>
@@ -67,6 +69,7 @@ SOFTWARE.
               <goal>check</goal>
             </goals>
             <configuration>
+              <experimental>true</experimental>
               <exclusions>
                 <exclusion>
                   JTCOP.RuleAllTestsHaveProductionClass

--- a/src/it/correct-test-names/pom.xml
+++ b/src/it/correct-test-names/pom.xml
@@ -22,7 +22,9 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.github.volodya-lombrozo</groupId>
   <artifactId>jtcop-it</artifactId>
@@ -63,6 +65,7 @@ SOFTWARE.
           </execution>
         </executions>
         <configuration>
+          <experimental>true</experimental>
           <failOnError>false</failOnError>
           <exclusions>
             <exclusion>

--- a/src/main/java/com/github/lombrozo/testnames/CopExperimental.java
+++ b/src/main/java/com/github/lombrozo/testnames/CopExperimental.java
@@ -40,7 +40,7 @@ import java.util.stream.Stream;
  *  abstraction. It worth mention that Cop and Rule interface rather similar. So, maybe it makes
  *  sense to create a tree of rules instead.
  */
-public class CopExperimental {
+final class CopExperimental {
 
     /**
      * Project.
@@ -51,7 +51,7 @@ public class CopExperimental {
      * Constructor.
      * @param project Project.
      */
-    public CopExperimental(final Project project) {
+    CopExperimental(final Project project) {
         this.project = project;
     }
 
@@ -59,9 +59,9 @@ public class CopExperimental {
      * Checks the project.
      * @return The complaints.
      */
-    public Collection<Complaint> inspection() {
+    Collection<Complaint> inspection() {
         return this.project.testClasses().stream()
-            .flatMap(this::classLevelRules)
+            .flatMap(CopExperimental::classLevelRules)
             .map(Rule::complaints)
             .flatMap(Collection::stream)
             .collect(Collectors.toList());
@@ -72,7 +72,7 @@ public class CopExperimental {
      * @param klass The test class to check.
      * @return The class-level rules.
      */
-    private Stream<Rule> classLevelRules(final TestClass klass) {
+    private static Stream<Rule> classLevelRules(final TestClass klass) {
         return Stream.of(
             new RuleSuppressed(new RuleOnlyTestMethods(klass), klass)
         );

--- a/src/main/java/com/github/lombrozo/testnames/CopExperimental.java
+++ b/src/main/java/com/github/lombrozo/testnames/CopExperimental.java
@@ -1,0 +1,80 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2022-2023 Volodya
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.github.lombrozo.testnames;
+
+import com.github.lombrozo.testnames.rules.RuleOnlyTestMethods;
+import com.github.lombrozo.testnames.rules.RuleSuppressed;
+import java.util.Collection;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/**
+ * Experimental cop which checks only experimental rules.
+ *
+ * @since 0.1.20
+ * @todo #231:90min Refactor Cop and CopExperimental.
+ *  We need to refactor Cop and CopExperimental classes because they both have significant
+ *  code duplication. In order to do so we have to decide if we introduce one more interface
+ *  for Cop, or just make Cop more suitable for experimental features, or create one more
+ *  abstraction. It worth mention that Cop and Rule interface rather similar. So, maybe it makes
+ *  sense to create a tree of rules instead.
+ */
+public class CopExperimental {
+
+    /**
+     * Project.
+     */
+    private final Project project;
+
+    /**
+     * Constructor.
+     * @param project Project.
+     */
+    public CopExperimental(final Project project) {
+        this.project = project;
+    }
+
+    /**
+     * Checks the project.
+     * @return The complaints.
+     */
+    public Collection<Complaint> inspection() {
+        return this.project.testClasses().stream()
+            .flatMap(this::classLevelRules)
+            .map(Rule::complaints)
+            .flatMap(Collection::stream)
+            .collect(Collectors.toList());
+    }
+
+    /**
+     * Creates the class-level rules.
+     * @param klass The test class to check.
+     * @return The class-level rules.
+     */
+    private Stream<Rule> classLevelRules(final TestClass klass) {
+        return Stream.of(
+            new RuleSuppressed(new RuleOnlyTestMethods(klass), klass)
+        );
+    }
+}

--- a/src/main/java/com/github/lombrozo/testnames/ValidateMojo.java
+++ b/src/main/java/com/github/lombrozo/testnames/ValidateMojo.java
@@ -77,8 +77,8 @@ public final class ValidateMojo extends AbstractMojo {
      * @checkstyle MemberNameCheck (7 lines)
      */
     @SuppressWarnings("PMD.ImmutableField")
-    @Parameter(defaultValue = "true")
-    private boolean experimental = false;
+    @Parameter(defaultValue = "false")
+    private boolean experimental;
 
     /**
      * The rules that have to be excluded from execution.

--- a/src/test/java/com/github/lombrozo/testnames/CopExperimentalTest.java
+++ b/src/test/java/com/github/lombrozo/testnames/CopExperimentalTest.java
@@ -1,0 +1,46 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2022-2023 Volodya
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.github.lombrozo.testnames;
+
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test case for {@link CopExperimental}.
+ *
+ * @since 0.1.20
+ */
+class CopExperimentalTest {
+
+    @Test
+    void createsCopSuccessfully() {
+        MatcherAssert.assertThat(
+            "Experimental cop doesn't have to contain any complaints for a fake project",
+            new CopExperimental(new Project.Fake()).inspection(),
+            Matchers.empty()
+        );
+    }
+}
+


### PR DESCRIPTION
Add `CopExperimental` as experimental implementation of the `Cop`. Also add `RuleOnlyTestMethods` for `CopExperimental`.

- feat(#231): Add CopExperimental class to check experimental features
- feat(#231): Add CopExperimental to ValidateMojo
- feat(#231): Use experimental features in integration tests
- feat(#231): make all integration tests to pass

Closes: #231
