### PR TITLE
doc(#230): Add docs for RuleOnlyTestMethods

### DIFF
--- a/docs/rules/only-test-methods.md
+++ b/docs/rules/only-test-methods.md
@@ -1,4 +1,48 @@
-@todo #194:90min Add documentation for the RuleOnlyTestMethods.
-  The documentation should be added to the `docs/rules/only-test-methods.md` file.
-  The documentation should contain the description of the rule and the
-  examples of the correct and incorrect code.
+# Only test methods
+
+Rule codename: _RuleOnlyTestMethods_
+___
+
+Each test class has to contain **only** test methods. That is all.
+The _RuleOnlyTestMethods_ rule is rather strict, hence it is considered
+an experimental feature. In order to enable the _RuleOnlyTestMethods_ rule,
+please enable experimental features in your `pom.xml` file by switching the
+flag:
+
+```xml
+
+<configuration>
+  <experimental>true</experimental>
+</configuration>
+```
+After that, the rule will take effect.
+
+Wrong usage:
+
+```java
+@Test
+void checksSomethingImportant(){
+    //...
+}
+
+void anotherMethodWhichIsNotATest{
+    //...    
+}
+```
+
+Correct usage:
+
+```java
+@Test
+void checksSomethingImportant(){
+    //...
+}
+
+@Test
+void allTheMethodsAreTests(){
+    //...    
+}
+```
+
+In order to suppress the rule, please use the next annotation:
+`@SuppressedWarnings("JTCOP.RuleOnlyTestMethods")`.


### PR DESCRIPTION
Docs for `RuleOnlyTestMethods`

Closes: #230


<!-- start pr-codex -->

---

## PR-Codex overview
### Focus of this PR:
Add documentation for the "Only test methods" rule.

### Detailed summary:
- Added a new file `docs/rules/only-test-methods.md` for the rule documentation.
- Added a description of the rule and its purpose.
- Provided examples of correct and incorrect usage of the rule.
- Added instructions for enabling the rule as an experimental feature.
- Included information on how to suppress the rule if needed.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->