### PR TITLE
feat(#251): Ignore generated tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ hs_err_pid*
 # Maven
 target
 !src/it/all-have-production-class/target
+!src/it/empty-project/target

--- a/README.md
+++ b/README.md
@@ -33,12 +33,21 @@ in the root of your project:
 mvn com.github.volodya-lombrozo:jtcop-maven-plugin:check
 ```
 
+or short version:
+```shell
+mvn jtcop:check
+```
+
 After that you will see the result of the plugin execution in the console. If
 you want to use specific (older) version of the plugin, for example `0.1.16`,
 just run the next maven command with specified version:
 
 ```shell
 mvn com.github.volodya-lombrozo:jtcop-maven-plugin:0.1.16:check
+```
+or snapshot version:
+```shell
+mvn com.github.volodya-lombrozo:jtcop-maven-plugin:1.0-SNAPSHOT:check
 ```
 
 ### Add the plugin to your `pom.xml`

--- a/src/it/empty-project/pom.xml
+++ b/src/it/empty-project/pom.xml
@@ -61,6 +61,7 @@ SOFTWARE.
               <goal>check</goal>
             </goals>
             <configuration>
+              <ignoreGeneratedTests>true</ignoreGeneratedTests>
               <exclusions>
                 <exclusion>
                   <!--Empty exclusion-->

--- a/src/it/empty-project/target/generated-test-sources/com/github/lombrozo/testnames/CorrectNameIT.java
+++ b/src/it/empty-project/target/generated-test-sources/com/github/lombrozo/testnames/CorrectNameIT.java
@@ -1,0 +1,31 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2022-2023 Volodya
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+import org.junit.jupiter.api.Test;
+
+class CorrectNameIT {
+
+    @SuppressWarnings("JTCOP.RuleAssertionMessage")
+    @Test void creates() {}
+}

--- a/src/main/java/com/github/lombrozo/testnames/Project.java
+++ b/src/main/java/com/github/lombrozo/testnames/Project.java
@@ -164,4 +164,33 @@ public interface Project {
                 .collect(Collectors.toList());
         }
     }
+
+    /**
+     * Project without tests.
+     */
+    class WithoutTests implements Project {
+
+        /**
+         * Original project.
+         */
+        private final Project original;
+
+        /**
+         * Constructor.
+         * @param original
+         */
+        public WithoutTests(final Project original) {
+            this.original = original;
+        }
+
+        @Override
+        public Collection<ProductionClass> productionClasses() {
+            return this.original.productionClasses();
+        }
+
+        @Override
+        public Collection<TestClass> testClasses() {
+            return Collections.emptyList();
+        }
+    }
 }

--- a/src/main/java/com/github/lombrozo/testnames/Project.java
+++ b/src/main/java/com/github/lombrozo/testnames/Project.java
@@ -167,6 +167,8 @@ public interface Project {
 
     /**
      * Project without tests.
+     *
+     * @since 1.0.1
      */
     class WithoutTests implements Project {
 
@@ -177,7 +179,7 @@ public interface Project {
 
         /**
          * Constructor.
-         * @param original
+         * @param original Original project.
          */
         public WithoutTests(final Project original) {
             this.original = original;
@@ -188,6 +190,7 @@ public interface Project {
             return this.original.productionClasses();
         }
 
+        @SuppressWarnings("PMD.JUnit4TestShouldUseTestAnnotation")
         @Override
         public Collection<TestClass> testClasses() {
             return Collections.emptyList();

--- a/src/main/java/com/github/lombrozo/testnames/ValidateMojo.java
+++ b/src/main/java/com/github/lombrozo/testnames/ValidateMojo.java
@@ -75,8 +75,8 @@ public final class ValidateMojo extends AbstractMojo {
      * Ignore generated tests.
      * @checkstyle MemberNameCheck (7 lines)
      */
-    @Parameter(name = "ignoreGeneratedTests", defaultValue = "false")
     @SuppressWarnings("PMD.LongVariable")
+    @Parameter(defaultValue = "false")
     private boolean ignoreGeneratedTests;
 
     /**
@@ -109,6 +109,7 @@ public final class ValidateMojo extends AbstractMojo {
 
     @Override
     public void execute() throws MojoFailureException {
+        this.getLog().info("Validating tests...");
         final ProjectWithoutJUnitExtensions proj = new ProjectWithoutJUnitExtensions(
             new Project.Combined(this.projects())
         );
@@ -120,6 +121,9 @@ public final class ValidateMojo extends AbstractMojo {
             throw new MojoFailureException(new ComplaintCompound(complaints).message());
         } else if (!complaints.isEmpty()) {
             complaints.forEach(complaint -> this.getLog().warn(complaint.message()));
+        }
+        if (complaints.isEmpty()) {
+            this.getLog().info("All tests are valid");
         }
     }
 

--- a/src/main/java/com/github/lombrozo/testnames/ValidateMojo.java
+++ b/src/main/java/com/github/lombrozo/testnames/ValidateMojo.java
@@ -166,14 +166,21 @@ public final class ValidateMojo extends AbstractMojo {
                 this.tests.toPath(),
                 suppressed
             )
-        ).map(
-            proj -> {
-                if (this.ignoreGeneratedTests) {
-                    return new Project.WithoutTests(proj);
-                } else {
-                    return proj;
-                }
-            }
-        );
+        ).map(this::generated);
+    }
+
+    /**
+     * The generated project.
+     * @param proj The project
+     * @return The generated project
+     */
+    private Project generated(final Project proj) {
+        final Project result;
+        if (this.ignoreGeneratedTests) {
+            result = new Project.WithoutTests(proj);
+        } else {
+            result = proj;
+        }
+        return result;
     }
 }

--- a/src/main/java/com/github/lombrozo/testnames/ValidateMojo.java
+++ b/src/main/java/com/github/lombrozo/testnames/ValidateMojo.java
@@ -71,6 +71,13 @@ public final class ValidateMojo extends AbstractMojo {
     private boolean failOnError = true;
 
     /**
+     * Ignore generated tests.
+     * @checkstyle MemberNameCheck (7 lines)
+     */
+    @Parameter(name = "ignoreGeneratedTests", defaultValue = "false")
+    private boolean ignoreGeneratedTests;
+
+    /**
      * Use experimental features.
      * Since most of the experimental features are not stable and more strict
      * they are disable by default.

--- a/src/test/java/com/github/lombrozo/testnames/ProjectTest.java
+++ b/src/test/java/com/github/lombrozo/testnames/ProjectTest.java
@@ -45,4 +45,21 @@ class ProjectTest {
             Matchers.hasSize(2)
         );
     }
+
+    @Test
+    void createsWithoutTests() {
+        final Project.WithoutTests without = new Project.WithoutTests(
+            new Project.Fake(new ProductionClass.Fake(), new TestClass.Fake())
+        );
+        MatcherAssert.assertThat(
+            "Project without tests should have no test classes",
+            without.testClasses(),
+            Matchers.empty()
+        );
+        MatcherAssert.assertThat(
+            "Project without tests should have production classes",
+            without.productionClasses(),
+            Matchers.hasSize(1)
+        );
+    }
 }


### PR DESCRIPTION
Add `ignoreGeneratedTests` property to the plugin.

Closes: #251


<!-- start pr-codex -->

---

## PR-Codex overview
### Detailed summary
- Added `ignoreGeneratedTests` parameter to the `ValidateMojo` class.
- Created `WithoutTests` class in `Project.java` to represent a project without test classes.
- Added a new test method `createsWithoutTests()` in `ProjectTest.java` to test the behavior of `WithoutTests` class.
- Added a new integration test class `CorrectNameIT.java` in the `empty-project` module.
- Updated the plugin execution instructions in the `README.md` file.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->