### PR TITLE
feat(#262): fix the bug with java 17 support - text blocks

### DIFF
--- a/src/main/java/com/github/lombrozo/testnames/javaparser/JavaParserClass.java
+++ b/src/main/java/com/github/lombrozo/testnames/javaparser/JavaParserClass.java
@@ -23,6 +23,7 @@
  */
 package com.github.lombrozo.testnames.javaparser;
 
+import com.github.javaparser.ParserConfiguration;
 import com.github.javaparser.StaticJavaParser;
 import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.ImportDeclaration;
@@ -37,6 +38,7 @@ import com.github.javaparser.ast.nodeTypes.NodeWithName;
 import com.github.javaparser.ast.type.ClassOrInterfaceType;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Collection;
 import java.util.Collections;
@@ -54,6 +56,7 @@ import java.util.stream.Stream;
  *
  * @since 0.1.15
  */
+@SuppressWarnings("PMD.TooManyMethods")
 final class JavaParserClass {
 
     /**
@@ -63,10 +66,10 @@ final class JavaParserClass {
 
     /**
      * Ctor.
-     * @param stream Input stream with java class.
+     * @param path Input stream with java class.
      */
-    JavaParserClass(final Path stream) {
-        this(JavaParserClass.parse(stream));
+    JavaParserClass(final Path path) {
+        this(JavaParserClass.parse(path));
     }
 
     /**
@@ -74,7 +77,7 @@ final class JavaParserClass {
      * @param stream Input stream with java class.
      */
     JavaParserClass(final InputStream stream) {
-        this(StaticJavaParser.parse(stream));
+        this(JavaParserClass.parse(stream));
     }
 
     /**
@@ -269,12 +272,25 @@ final class JavaParserClass {
      */
     private static CompilationUnit parse(final Path path) {
         try {
-            return StaticJavaParser.parse(path);
+            StaticJavaParser.getParserConfiguration()
+                .setLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17);
+            return JavaParserClass.parse(Files.newInputStream(path));
         } catch (final IOException ex) {
             throw new IllegalStateException(
                 String.format("Can't parse java file: %s", path.toAbsolutePath()),
                 ex
             );
         }
+    }
+
+    /**
+     * Parse java by input stream.
+     * @param stream Input stream.
+     * @return Compilation unit.
+     */
+    private static CompilationUnit parse(final InputStream stream) {
+        StaticJavaParser.getParserConfiguration()
+            .setLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17);
+        return StaticJavaParser.parse(stream);
     }
 }

--- a/src/main/java/com/github/lombrozo/testnames/javaparser/TestClassJavaParser.java
+++ b/src/main/java/com/github/lombrozo/testnames/javaparser/TestClassJavaParser.java
@@ -25,7 +25,6 @@
 package com.github.lombrozo.testnames.javaparser;
 
 import com.github.javaparser.ParseProblemException;
-import com.github.javaparser.StaticJavaParser;
 import com.github.lombrozo.testnames.TestCase;
 import com.github.lombrozo.testnames.TestClass;
 import com.github.lombrozo.testnames.TestClassCharacteristics;
@@ -191,7 +190,7 @@ public final class TestClassJavaParser implements TestClass {
      * @return Parsed class.
      */
     private static Sticky<JavaParserClass> parse(final Path path) {
-        return new Sticky<>(() -> new JavaParserClass(StaticJavaParser.parse(path)));
+        return new Sticky<>(() -> new JavaParserClass(path));
     }
 
     /**
@@ -200,6 +199,6 @@ public final class TestClassJavaParser implements TestClass {
      * @return Parsed class.
      */
     private static Sticky<JavaParserClass> parse(final InputStream stream) {
-        return new Sticky<>(() -> new JavaParserClass(StaticJavaParser.parse(stream)));
+        return new Sticky<>(() -> new JavaParserClass(stream));
     }
 }

--- a/src/test/java/com/github/lombrozo/testnames/javaparser/JavaTestClasses.java
+++ b/src/test/java/com/github/lombrozo/testnames/javaparser/JavaTestClasses.java
@@ -133,6 +133,11 @@ enum JavaTestClasses {
     HAMCREST_ASSERT_TRUE_LINE_HITTER("HamcrestAssertTrueHitter.java"),
 
     /**
+     * Java class with java 17 features.
+     */
+    JAVA_17_TEST("Java17Test.java"),
+
+    /**
      * Assert true line hitter for junit.
      */
     JUNIT_ASSERT_TRUE_LINE_HITTER("JunitAssertTrueHitter.java");

--- a/src/test/java/com/github/lombrozo/testnames/javaparser/TestClassJavaParserTest.java
+++ b/src/test/java/com/github/lombrozo/testnames/javaparser/TestClassJavaParserTest.java
@@ -225,4 +225,15 @@ final class TestClassJavaParserTest {
         MatcherAssert.assertThat(msg, all, Matchers.hasSize(1));
         MatcherAssert.assertThat(msg, all, Matchers.hasItem(expected));
     }
+
+    @Test
+    void parsesJavaClassWithTextBlock() {
+        MatcherAssert.assertThat(
+            "We expected that test class will parsed successfully and contain only one test case",
+            JavaTestClasses.JAVA_17_TEST
+                .toTestClass()
+                .all(),
+            Matchers.hasSize(1)
+        );
+    }
 }

--- a/src/test/resources/Java17Test.java
+++ b/src/test/resources/Java17Test.java
@@ -25,12 +25,19 @@ import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
 
-class HamcrestAssertTrueHitter {
+class Java17Test {
+
+    final String cql =
+        """
+            CREATE KEYSPACE test
+            WITH REPLICATION = {
+             'class' : 'NetworkTopologyStrategy',
+             'datacenter1' : 1
+             };
+            """;
 
     @Test
-    void checksHitter() {
-        MatcherAssert.assertThat("msg", true, Matchers.equalTo(true));
-        MatcherAssert.assertThat("msg", false, Matchers.equalTo(false));
-        MatcherAssert.assertThat("msg", true || false, Matchers.equalTo(true));
+    void checksQuery() {
+        MatcherAssert.assertThat("msg", cql, Matchers.notNullValue());
     }
 }

--- a/src/test/resources/JunitAssertTrueHitter.java
+++ b/src/test/resources/JunitAssertTrueHitter.java
@@ -1,3 +1,26 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2022-2023 Volodya
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.*;


### PR DESCRIPTION
Add Java 17 support for javaparser library

Closes: #262


<!-- start pr-codex -->

---

## PR-Codex overview
### Detailed summary
- Added a new Java test class with Java 17 features.
- Modified the `parse` method in `JavaParserClass` to set the language level to Java 17 when parsing Java files.
- Added license headers to the test resource files.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->