### PR TITLE
feat(#304): update pdd-action version and javassist library version

### DIFF
--- a/.github/workflows/pdd.yml
+++ b/.github/workflows/pdd.yml
@@ -12,4 +12,4 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
-      - uses: g4s8/pdd-action@master
+      - uses: volodya-lombrozo/pdd-action@master

--- a/pom.xml
+++ b/pom.xml
@@ -127,7 +127,7 @@ SOFTWARE.
     <dependency>
       <groupId>org.javassist</groupId>
       <artifactId>javassist</artifactId>
-      <version>3.29.2-GA</version>
+      <version>3.30.1-GA</version>
       <scope>compile</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
Closes: #304


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the PDD action and the version of the `javassist` dependency in the `pom.xml` file.

### Detailed summary
- Updated the PDD action from `g4s8/pdd-action` to `volodya-lombrozo/pdd-action`.
- Updated the version of the `javassist` dependency from `3.29.2-GA` to `3.30.1-GA` in the `pom.xml` file.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->