### PR TITLE
fix(#347): Fix The Problem With Instance Field Explanation Messages

### DIFF
--- a/src/it/assertions/src/test/java/AssertionsTest.java
+++ b/src/it/assertions/src/test/java/AssertionsTest.java
@@ -34,6 +34,24 @@ class AssertionsTest {
      */
     private final static String CONSTANT = "Message";
 
+    /**
+     * Default message for assertions.
+     */
+    private static final String MSG = "MESSAGE";
+
+    @Test
+    void checksTheCaseFrom357issue() {
+        // This test were added to check the issue #357
+        // You can read more about it here:
+        // https://github.com/volodya-lombrozo/jtcop/issues/347
+        MatcherAssert.assertThat(
+            AssertionsTest.MSG,
+            "1",
+            Matchers.equalTo("1")
+        );
+    }
+
+
     @Test
     @SuppressWarnings("JTCOP.LineHitterRule")
     void checksJUnitAssertions() {

--- a/src/main/java/com/github/lombrozo/testnames/javaparser/StingExpression.java
+++ b/src/main/java/com/github/lombrozo/testnames/javaparser/StingExpression.java
@@ -56,7 +56,11 @@ class StingExpression {
         final Optional<String> result;
         if (this.expr.isStringLiteralExpr()) {
             result = Optional.of(this.expr.asStringLiteralExpr().asString());
-        } else if (this.expr.isNameExpr() || this.expr.isMethodCallExpr()) {
+        } else if (
+            this.expr.isNameExpr()
+                || this.expr.isMethodCallExpr()
+                || this.expr.isFieldAccessExpr()
+        ) {
             result = new UnknownMessage().message();
         } else {
             result = Optional.empty();

--- a/src/test/java/com/github/lombrozo/testnames/javaparser/AssertionOfHamcrestTest.java
+++ b/src/test/java/com/github/lombrozo/testnames/javaparser/AssertionOfHamcrestTest.java
@@ -126,16 +126,31 @@ class AssertionOfHamcrestTest {
         );
     }
 
+    @Test
+    void findsExplanationMessage() {
+        final AssertionOfHamcrest first = JavaTestClasses.TEST_WITH_HAMCREST_ASSERTIONS
+            .method("checksTheCaseFrom357issue")
+            .statements()
+            .map(AssertionOfHamcrest::new)
+            .filter(AssertionOfHamcrest::isAssertion)
+            .findFirst().orElseThrow(() -> new AssertionError("No assertions found"));
+        MatcherAssert.assertThat(
+            String.format("We expect that assertion has a valid message", first),
+            first.explanation().orElseThrow(() -> new AssertionError("No explanation found")),
+            Matchers.equalTo("Unknown message. The message will be known only in runtime")
+        );
+    }
+
     @SuppressWarnings("PMD.JUnitTestContainsTooManyAsserts")
     @Test
     void checksCorrectlyOnLineHitters() {
         final List<AssertionOfHamcrest> assertions =
             JavaTestClasses.HAMCREST_ASSERT_TRUE_LINE_HITTER
-            .method("checksHitter")
-            .statements()
-            .map(AssertionOfHamcrest::new)
-            .filter(AssertionOfHamcrest::isLineHitter)
-            .collect(Collectors.toList());
+                .method("checksHitter")
+                .statements()
+                .map(AssertionOfHamcrest::new)
+                .filter(AssertionOfHamcrest::isLineHitter)
+                .collect(Collectors.toList());
         MatcherAssert.assertThat(
             String.format("%s contains two line hitters", assertions),
             assertions,

--- a/src/test/resources/TestWithHamcrestAssertions.java
+++ b/src/test/resources/TestWithHamcrestAssertions.java
@@ -41,6 +41,23 @@ class TestWithHamcrestAssertions {
      */
     private final static Supplier<String> DEFAULT_SUPPLIER = () -> TestWithJUnitAssertions.DEFAULT_EXPLANATION;
 
+    /**
+     * Static final message for assertions.
+     */
+    private static final String MSG = "MESSAGE";
+
+    @Test
+    void checksTheCaseFrom357issue() {
+        // This test were added to check the issue #357
+        // You can read more about it here:
+        // https://github.com/volodya-lombrozo/jtcop/issues/347
+        MatcherAssert.assertThat(
+            TestWithHamcrestAssertions.MSG,
+            "1",
+            Matchers.equalTo("1")
+        );
+    }
+
     @Test
     void withMessages() {
         MatcherAssert.assertThat(


### PR DESCRIPTION
In this PR I fixed the problem of checking explanation messages by full path of the field.

We didn't consider:
```
AssertionMessage.MSG
```
as a valid message, but now we do.


Closes: #347

History:
- **fix(#347): identify the problem**
- **fix(#347): fix the bug with related to instance field message**
