### PR TITLE
fix(#353): Consider Inner Blocks During Statements Scan

### DIFF
--- a/src/it/assertions/README.md
+++ b/src/it/assertions/README.md
@@ -1,0 +1,13 @@
+# Assertions Integration Tests
+
+This module contains integration tests for assertions.
+It tests different assertions from JUnit and Hamcrest libraries along with
+assertion messages.
+
+## How to run
+
+To run only these tests, execute the following command:
+
+```bash
+mvn clean integration-test invoker:run -Dinvoker.test=assertions -DskipTests
+```

--- a/src/it/assertions/src/test/java/AssertionsTest.java
+++ b/src/it/assertions/src/test/java/AssertionsTest.java
@@ -40,8 +40,22 @@ class AssertionsTest {
     private static final String MSG = "MESSAGE";
 
     @Test
-    void checksTheCaseFrom357issue() {
-        // This test were added to check the issue #357
+    void checksTheCaseFrom353issueWithAssertionInLoop() {
+        // This test were added to check the issue #353
+        // You can read more about it here:
+        // https://github.com/volodya-lombrozo/jtcop/issues/347
+        for (int i = 0; i < 10; ++i) {
+            MatcherAssert.assertThat(
+                AssertionsTest.MSG,
+                "1",
+                Matchers.equalTo("1")
+            );
+        }
+    }
+
+    @Test
+    void checksTheCaseFrom347issue() {
+        // This test were added to check the issue #347
         // You can read more about it here:
         // https://github.com/volodya-lombrozo/jtcop/issues/347
         MatcherAssert.assertThat(

--- a/src/main/java/com/github/lombrozo/testnames/javaparser/JavaParserTestCase.java
+++ b/src/main/java/com/github/lombrozo/testnames/javaparser/JavaParserTestCase.java
@@ -36,7 +36,7 @@ import java.util.stream.Stream;
 import lombok.Data;
 
 /**
- * Parser for test case.
+ * Parser for a test case.
  *
  * @since 0.1.0
  */

--- a/src/main/java/com/github/lombrozo/testnames/javaparser/JavaParserTestCase.java
+++ b/src/main/java/com/github/lombrozo/testnames/javaparser/JavaParserTestCase.java
@@ -26,7 +26,6 @@ package com.github.lombrozo.testnames.javaparser;
 
 import com.github.javaparser.ast.NodeList;
 import com.github.javaparser.ast.body.MethodDeclaration;
-import com.github.javaparser.ast.expr.MethodCallExpr;
 import com.github.javaparser.ast.type.VarType;
 import com.github.lombrozo.testnames.Assertion;
 import com.github.lombrozo.testnames.TestCase;

--- a/src/main/java/com/github/lombrozo/testnames/javaparser/JavaParserTestCase.java
+++ b/src/main/java/com/github/lombrozo/testnames/javaparser/JavaParserTestCase.java
@@ -26,6 +26,7 @@ package com.github.lombrozo.testnames.javaparser;
 
 import com.github.javaparser.ast.NodeList;
 import com.github.javaparser.ast.body.MethodDeclaration;
+import com.github.javaparser.ast.expr.MethodCallExpr;
 import com.github.javaparser.ast.type.VarType;
 import com.github.lombrozo.testnames.Assertion;
 import com.github.lombrozo.testnames.TestCase;

--- a/src/test/java/com/github/lombrozo/testnames/javaparser/JavaParserTestCaseTest.java
+++ b/src/test/java/com/github/lombrozo/testnames/javaparser/JavaParserTestCaseTest.java
@@ -30,7 +30,9 @@ import com.github.lombrozo.testnames.rules.RuleNotCamelCase;
 import com.github.lombrozo.testnames.rules.RuleNotContainsTestWord;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
@@ -165,6 +167,30 @@ final class JavaParserTestCaseTest {
             String.format("The '%s' assertion message is wrong", assertion),
             assertion.explanation().get(),
             Matchers.equalTo("JUnit explanation")
+        );
+    }
+
+    @Test
+    void parsesAssertionInsideLoop() {
+        final JavaParserTestClass parser = JavaTestClasses.TEST_WITH_ASSERTIONS.toTestClass();
+        final String method = "checksTheCaseFrom353issueWithAssertionInLoop";
+        final TestCase tested = parser.all().stream()
+            .filter(test -> method.equals(test.name()))
+            .findFirst()
+            .orElseThrow(() -> new AssertionError(String.format("Method %s not found", method)));
+        final Collection<Assertion> assertions = tested.assertions();
+        MatcherAssert.assertThat(
+            String.format("The '%s' method has to contain at least one assertion", method),
+            assertions,
+            Matchers.hasSize(1)
+        );
+        final Assertion assertion = assertions.stream()
+            .findFirst()
+            .orElseThrow(() -> new AssertionError("Assertion not found"));
+        MatcherAssert.assertThat(
+            String.format("The '%s' assertion has to contain an explanation", assertion),
+            assertion.explanation().isPresent(),
+            Matchers.is(true)
         );
     }
 

--- a/src/test/java/com/github/lombrozo/testnames/javaparser/JavaParserTestCaseTest.java
+++ b/src/test/java/com/github/lombrozo/testnames/javaparser/JavaParserTestCaseTest.java
@@ -30,9 +30,7 @@ import com.github.lombrozo.testnames.rules.RuleNotCamelCase;
 import com.github.lombrozo.testnames.rules.RuleNotContainsTestWord;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collectors;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
@@ -171,6 +169,7 @@ final class JavaParserTestCaseTest {
     }
 
     @Test
+    @SuppressWarnings("PMD.JUnitTestContainsTooManyAsserts")
     void parsesAssertionInsideLoop() {
         final JavaParserTestClass parser = JavaTestClasses.TEST_WITH_ASSERTIONS.toTestClass();
         final String method = "checksTheCaseFrom353issueWithAssertionInLoop";
@@ -178,13 +177,7 @@ final class JavaParserTestCaseTest {
             .filter(test -> method.equals(test.name()))
             .findFirst()
             .orElseThrow(() -> new AssertionError(String.format("Method %s not found", method)));
-        final Collection<Assertion> assertions = tested.assertions();
-        MatcherAssert.assertThat(
-            String.format("The '%s' method has to contain at least one assertion", method),
-            assertions,
-            Matchers.hasSize(1)
-        );
-        final Assertion assertion = assertions.stream()
+        final Assertion assertion = tested.assertions().stream()
             .findFirst()
             .orElseThrow(() -> new AssertionError("Assertion not found"));
         MatcherAssert.assertThat(

--- a/src/test/resources/TestWithAssertions.java
+++ b/src/test/resources/TestWithAssertions.java
@@ -79,4 +79,18 @@ class TestWithAssertions {
         MatcherAssert.assertThat(1, Matchers.is(1));
         Assertions.assertEquals(1, 1);
     }
+
+    @Test
+    void checksTheCaseFrom353issueWithAssertionInLoop() {
+        // This test were added to check the issue #353
+        // You can read more about it here:
+        // https://github.com/volodya-lombrozo/jtcop/issues/347
+        for (int i = 0; i < 10; ++i) {
+            MatcherAssert.assertThat(
+                AssertionsTest.MSG,
+                "1",
+                Matchers.equalTo("1")
+            );
+        }
+    }
 }


### PR DESCRIPTION
In this PR, I fixed the problem related to missed assertions. The problem occurred when we had inner blocks with inner statements. Now we consider all statements.

Closes: #353.
History:
- **fix(#353): identify the problem**
- **fix(#353): add one more unit test**
- **fix(#353): suggest ugly solution**
- **fix(#353): simplify the solution**
- **fix(#353): fix all qulice suggestions**


<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to enhance Java test parsing capabilities by adding support for assertions inside loops.

### Detailed summary
- Added a new test case for parsing assertions inside a loop
- Updated the `JavaParserMethod` class to unroll inner method statements
- Modified test methods to accommodate new functionality

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->