### PR TITLE
fix(#357): Cover More Assertions

### DIFF
--- a/src/it/assertions/src/test/java/AssertionsTest.java
+++ b/src/it/assertions/src/test/java/AssertionsTest.java
@@ -34,6 +34,7 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.stream.Stream;
+import java.util.function.Consumer;
 
 
 class AssertionsTest {
@@ -74,6 +75,20 @@ class AssertionsTest {
                 Matchers.equalTo(1)
             );
         }).limit(1).forEach(Runnable::run);
+    }
+
+    @Test
+    void checksTheCaseFrom357issueLabbdaAsParamAfterAConstructor() {
+        // This test were added to check the issue #357
+        // You can read more about it here:
+        // https://github.com/volodya-lombrozo/jtcop/issues/357
+        new AssertionsTest.Same(this).together(f -> {
+            MatcherAssert.assertThat(
+                "The class should be the same as the one that was passed to the constructor",
+                f,
+                Matchers.equalTo(this)
+            );
+        });
     }
 
     @Test
@@ -224,5 +239,17 @@ class AssertionsTest {
 
     private String message() {
         return "Message";
+    }
+
+    private static class Same {
+        private final AssertionsTest test;
+
+        public Same(final AssertionsTest test) {
+            this.test = test;
+        }
+
+        void together(Consumer<AssertionsTest> supplier) {
+            supplier.accept(this.test);
+        }
     }
 }

--- a/src/it/assertions/src/test/java/AssertionsTest.java
+++ b/src/it/assertions/src/test/java/AssertionsTest.java
@@ -63,6 +63,20 @@ class AssertionsTest {
     }
 
     @Test
+    void checksTheCaseFrom357issueLabbdaAsParam() {
+        // This test were added to check the issue #357
+        // You can read more about it here:
+        // https://github.com/volodya-lombrozo/jtcop/issues/357
+        Stream.generate(() -> (Runnable) () -> {
+            MatcherAssert.assertThat(
+                "Lambda as a parameter assertion",
+                1,
+                Matchers.equalTo(1)
+            );
+        }).limit(1).forEach(Runnable::run);
+    }
+
+    @Test
     void checksTheCaseFrom357issueIfStatement() throws InterruptedException {
         // This test were added to check the issue #357
         // You can read more about it here:

--- a/src/test/java/com/github/lombrozo/testnames/javaparser/JavaParserTestCaseTest.java
+++ b/src/test/java/com/github/lombrozo/testnames/javaparser/JavaParserTestCaseTest.java
@@ -226,6 +226,25 @@ final class JavaParserTestCaseTest {
     }
 
     @Test
+    @SuppressWarnings("PMD.JUnitTestContainsTooManyAsserts")
+    void parsesAssertionInsideLambdaAsParam() {
+        final JavaParserTestClass parser = JavaTestClasses.TEST_WITH_ASSERTIONS.toTestClass();
+        final String method = "checksTheCaseFrom357issueWithAssertionAsParam";
+        final TestCase tested = parser.all().stream()
+            .filter(test -> method.equals(test.name()))
+            .findFirst()
+            .orElseThrow(() -> new AssertionError(String.format("Method %s not found", method)));
+        final Assertion assertion = tested.assertions().stream()
+            .findFirst()
+            .orElseThrow(() -> new AssertionError("Assertion not found"));
+        MatcherAssert.assertThat(
+            String.format("The '%s' assertion has to contain an explanation", assertion),
+            assertion.explanation().isPresent(),
+            Matchers.is(true)
+        );
+    }
+
+    @Test
     void parsesPackageJava() {
         final JavaParserTestClass parser = JavaTestClasses.PACKAGE_INFO.toTestClass();
         MatcherAssert.assertThat(

--- a/src/test/java/com/github/lombrozo/testnames/javaparser/JavaParserTestCaseTest.java
+++ b/src/test/java/com/github/lombrozo/testnames/javaparser/JavaParserTestCaseTest.java
@@ -200,7 +200,7 @@ final class JavaParserTestCaseTest {
             .findFirst()
             .orElseThrow(() -> new AssertionError("Assertion not found"));
         MatcherAssert.assertThat(
-            String.format("The '%s' assertion has to contain an explanation", assertion),
+            String.format("The '%s' assertion has to contain some explanation", assertion),
             assertion.explanation().isPresent(),
             Matchers.is(true)
         );

--- a/src/test/resources/TestWithAssertions.java
+++ b/src/test/resources/TestWithAssertions.java
@@ -28,6 +28,7 @@ import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import java.util.stream.Stream;
 
 class TestWithAssertions {
     @Test
@@ -122,5 +123,16 @@ class TestWithAssertions {
             );
         };
         r.run();
+    }
+
+    @Test
+    void checksTheCaseFrom357issueWithAssertionAsParam() {
+        Stream.generate(() -> (Runnable) () -> {
+            MatcherAssert.assertThat(
+                "Lambda as a parameter assertion",
+                1,
+                Matchers.equalTo(1)
+            );
+        }).limit(1).forEach(Runnable::run);
     }
 }


### PR DESCRIPTION
In this PR I fixed the problem with finding assertions inside complicated method chains.

Related to #357.

History:
- **fix(#357): identify the problem when lambda is a parameter**
- **fix(#357): fix the problem with lambda as a parameter**
- **fix(#357): fix all qulice suggestions**
- **fix(#357): check one more case for assertion detection**


<!-- start pr-codex -->

---

## PR-Codex overview
Focus: Enhancing assertion testing with lambda expressions and method references.

### Detailed summary
- Added new test cases for lambda expressions as parameters and in constructors
- Updated assertion messages for clarity
- Improved JavaParserMethod to handle method call expressions in statements

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->