### PR TITLE
feat(#393): RuleTestCaseContainsMockery, NumberOfMockitoMocks

### DIFF
--- a/docs/rules/mockery.md
+++ b/docs/rules/mockery.md
@@ -1,0 +1,64 @@
+# Mockery
+
+Sometimes mocking can be good, and handy. But sometimes developers can lose
+themselves in their effort to mock out what isn’t being tested. In this case, a
+unit test contains so many mocks, stubs, and/or fakes that the system under
+test isn’t even being tested at all, instead data returned from mocks is what
+is being tested.
+
+## Bad
+
+```java
+import java.util.ArrayList;
+import org.mockito.Mockito;
+
+final class FooTest {
+
+    @Test
+    void testsSomething() {
+        Frame frame = Mockito.mock(Frame.class);
+        Mockito.doReturn(new ArrayList<>(...)).when(frame).iterator();
+        Table table = Mockito.mock(Table.class);
+        Mockito.doReturn(frame).when(table).frame();
+        Region region = Mockito.mock(Region.class);
+        Mockito.doReturn(table).when(region).table(Mockito.anyString());
+    }
+}
+```
+
+## Good
+
+Consider using less mocks, or try to use [Fake Objects]:
+
+```java
+import java.util.ArrayList;
+import org.mockito.Mockito;
+
+final class FooTest {
+
+    @Test
+    void testsSomething() {
+        // FakeRegion, FakeTable, FakeFrame are fake objects, used for testing.
+        Region region = new FakeRegion(
+            new FakeTable(
+                new FakeFrame()
+            )
+        );
+        // region is ready
+    }
+}
+```
+
+You can configure the `maxNumberOfMocks` in plugin configuration (2 is the
+default value):
+
+```xml
+<configuration>
+  <maxNumberOfMocks>3</maxNumberOfMocks>
+</configuration>
+```
+
+In order to suppress this rule, you can use the following annotation
+`@SuppressedWarnings("JTCOP.RuleTestCaseContainsMockery")`.
+
+[Fake Objects]: https://www.yegor256.com/2014/09/23/built-in-fake-objects.html

--- a/docs/rules/mockery.md
+++ b/docs/rules/mockery.md
@@ -4,7 +4,7 @@ Sometimes mocking can be good, and handy. But sometimes developers can lose
 themselves in their effort to mock out what isn’t being tested. In this case, a
 unit test contains so many mocks, stubs, and/or fakes that the system under
 test isn’t even being tested at all, instead data returned from mocks is what
-is being tested.
+is being tested. [Source][SA-description].
 
 ## Bad
 
@@ -62,3 +62,4 @@ In order to suppress this rule, you can use the following annotation
 `@SuppressedWarnings("JTCOP.RuleTestCaseContainsMockery")`.
 
 [Fake Objects]: https://www.yegor256.com/2014/09/23/built-in-fake-objects.html
+[SA-description]: https://stackoverflow.com/questions/333682/unit-testing-anti-patterns-catalogue/333686#333686

--- a/src/it/all-incorrect/pom.xml
+++ b/src/it/all-incorrect/pom.xml
@@ -51,6 +51,12 @@ SOFTWARE.
       <version>5.10.3</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <version>5.12.0</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
   <build>
     <plugins>
@@ -65,6 +71,7 @@ SOFTWARE.
               <goal>check</goal>
             </goals>
             <configuration>
+              <maxNumberOfMocks>1</maxNumberOfMocks>
               <failOnError>false</failOnError>
             </configuration>
           </execution>

--- a/src/it/all-incorrect/src/test/java/MockeryTest.java
+++ b/src/it/all-incorrect/src/test/java/MockeryTest.java
@@ -31,10 +31,8 @@ final class MockeryTest {
 
     @Test
     void testsSomething() {
-        final List list = Mockito.mock(List.class);
-        final Set set = Mockito.mock(Set.class);
-        final Map map = Mockito.mock(Map.class);
-        Mockito.when(list.get(0)).thenReturn("jeff");
-        Mockito.when(map.get("test")).thenReturn("jeff");
+        Mockito.when(Mockito.mock(List.class).get(0)).thenReturn("jeff");
+        Mockito.when(Mockito.mock(Map.class).get("test")).thenReturn("jeff");
+        Mockito.when(Mockito.mock(Set.class).add(1)).thenReturn(true);
     }
 }

--- a/src/it/all-incorrect/src/test/java/MockeryTest.java
+++ b/src/it/all-incorrect/src/test/java/MockeryTest.java
@@ -21,44 +21,20 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-package com.github.lombrozo.testnames.javaparser;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 
-import com.github.lombrozo.testnames.TestCase;
-import java.util.regex.Pattern;
-import org.cactoos.Scalar;
+final class MockeryTest {
 
-/**
- * Number of Mockito mocks in the test case.
- *
- * @since 1.3.4
- */
-public final class NumberOfMockitoMocks implements Scalar<Long> {
-
-    /**
-     * Mockito Mock Pattern.
-     */
-    private static final Pattern MOCK_PATTERN =
-        Pattern.compile("^(mock\\(.*?\\);)|(Mockito\\.mock\\(.*?\\);)$");
-
-    /**
-     * Test case.
-     */
-    private final TestCase test;
-
-    /**
-     * Ctor.
-     * @param tst Test case
-     */
-    public NumberOfMockitoMocks(final TestCase tst) {
-        this.test = tst;
-    }
-
-    @Override
-    public Long value() {
-        return this.test.statements().stream()
-            .filter(
-                statement ->
-                    NumberOfMockitoMocks.MOCK_PATTERN.matcher(statement).find()
-            ).count();
+    @Test
+    void testsSomething() {
+        final List list = Mockito.mock(List.class);
+        final Set set = Mockito.mock(Set.class);
+        final Map map = Mockito.mock(Map.class);
+        Mockito.when(list.get(0)).thenReturn("jeff");
+        Mockito.when(map.get("test")).thenReturn("jeff");
     }
 }

--- a/src/it/all-incorrect/verify.groovy
+++ b/src/it/all-incorrect/verify.groovy
@@ -39,5 +39,6 @@ String log = new File(basedir, 'build.log').text;
   "Test name 'testAnother' doesn't follow naming rules, because the test name has to be written using present tense",
   "Method 'containsLineHitter' contains line hitter anti-pattern",
   "The test class 'UsesInheritenceTest.java' has the parent class 'AbstractTest'. Inheritance in tests is dangerous for maintainability",
+  "Method 'testsSomething' contains excessive number of mocks: 3. max allowed: 1.",
 ].each { assert log.contains(it): "Log doesn't contain ['$it']" }
 true

--- a/src/it/exclusions/pom.xml
+++ b/src/it/exclusions/pom.xml
@@ -74,9 +74,6 @@ SOFTWARE.
                 <exclusion>
                   JTCOP.RuleAssertionMessage
                 </exclusion>
-                <exclusion>
-                  JTCOP.RuleNotContainsTestWord
-                </exclusion>
               </exclusions>
             </configuration>
           </execution>

--- a/src/it/exclusions/pom.xml
+++ b/src/it/exclusions/pom.xml
@@ -47,6 +47,12 @@ SOFTWARE.
       <version>5.10.3</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <version>5.12.0</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
   <build>
     <plugins>
@@ -67,6 +73,9 @@ SOFTWARE.
                 </exclusion>
                 <exclusion>
                   JTCOP.RuleAssertionMessage
+                </exclusion>
+                <exclusion>
+                  JTCOP.RuleNotContainsTestWord
                 </exclusion>
               </exclusions>
             </configuration>

--- a/src/it/exclusions/src/test/java/MockeryTest.java
+++ b/src/it/exclusions/src/test/java/MockeryTest.java
@@ -32,10 +32,8 @@ final class MockeryTest {
     @Test
     @SuppressWarnings("JTCOP.RuleTestCaseContainsMockery")
     void checksSomething() {
-        final List list = Mockito.mock(List.class);
-        final Set set = Mockito.mock(Set.class);
-        final Map map = Mockito.mock(Map.class);
-        Mockito.when(list.get(0)).thenReturn("jeff");
-        Mockito.when(map.get("test")).thenReturn("jeff");
+        Mockito.when(Mockito.mock(List.class).get(0)).thenReturn("jeff");
+        Mockito.when(Mockito.mock(Map.class).get("test")).thenReturn("jeff");
+        Mockito.when(Mockito.mock(Set.class).add(1)).thenReturn(true);
     }
 }

--- a/src/it/exclusions/src/test/java/MockeryTest.java
+++ b/src/it/exclusions/src/test/java/MockeryTest.java
@@ -21,44 +21,21 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-package com.github.lombrozo.testnames.javaparser;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 
-import com.github.lombrozo.testnames.TestCase;
-import java.util.regex.Pattern;
-import org.cactoos.Scalar;
+final class MockeryTest {
 
-/**
- * Number of Mockito mocks in the test case.
- *
- * @since 1.3.4
- */
-public final class NumberOfMockitoMocks implements Scalar<Long> {
-
-    /**
-     * Mockito Mock Pattern.
-     */
-    private static final Pattern MOCK_PATTERN =
-        Pattern.compile("^(mock\\(.*?\\);)|(Mockito\\.mock\\(.*?\\);)$");
-
-    /**
-     * Test case.
-     */
-    private final TestCase test;
-
-    /**
-     * Ctor.
-     * @param tst Test case
-     */
-    public NumberOfMockitoMocks(final TestCase tst) {
-        this.test = tst;
-    }
-
-    @Override
-    public Long value() {
-        return this.test.statements().stream()
-            .filter(
-                statement ->
-                    NumberOfMockitoMocks.MOCK_PATTERN.matcher(statement).find()
-            ).count();
+    @Test
+    @SuppressWarnings("JTCOP.RuleTestCaseContainsMockery")
+    void testsSomething() {
+        final List list = Mockito.mock(List.class);
+        final Set set = Mockito.mock(Set.class);
+        final Map map = Mockito.mock(Map.class);
+        Mockito.when(list.get(0)).thenReturn("jeff");
+        Mockito.when(map.get("test")).thenReturn("jeff");
     }
 }

--- a/src/it/exclusions/src/test/java/MockeryTest.java
+++ b/src/it/exclusions/src/test/java/MockeryTest.java
@@ -31,7 +31,7 @@ final class MockeryTest {
 
     @Test
     @SuppressWarnings("JTCOP.RuleTestCaseContainsMockery")
-    void testsSomething() {
+    void checksSomething() {
         final List list = Mockito.mock(List.class);
         final Set set = Mockito.mock(Set.class);
         final Map map = Mockito.mock(Map.class);

--- a/src/main/java/com/github/lombrozo/testnames/Cop.java
+++ b/src/main/java/com/github/lombrozo/testnames/Cop.java
@@ -104,6 +104,7 @@ final class Cop {
 
     /**
      * Regular law.
+     * @param mocks Max number of mocks allowed
      * @return The regular law which will be applied to all projects.
      */
     private static Function<Suspect, Stream<Rule>> regular(final int mocks) {

--- a/src/main/java/com/github/lombrozo/testnames/Cop.java
+++ b/src/main/java/com/github/lombrozo/testnames/Cop.java
@@ -54,9 +54,14 @@ final class Cop {
     /**
      * Ctor.
      * @param proj The project to check.
+     * @param mocks Max number of mocks allowed
+     * @todo #393:35min Refactor Cop ctor to accept number of arguments.
+     *  We should refactor ctor to accept a number of argument from one
+     *  object with them. For instance: new Args(new Arg("maxNumberOfMocks", 2), ...).
+     *  The same object should be applied to Cop#regular method.
      */
-    Cop(final Project proj) {
-        this(proj, Cop.regular());
+    Cop(final Project proj, final int mocks) {
+        this(proj, Cop.regular(mocks));
     }
 
     /**
@@ -100,7 +105,7 @@ final class Cop {
      * Regular law.
      * @return The regular law which will be applied to all projects.
      */
-    private static Function<Suspect, Stream<Rule>> regular() {
+    private static Function<Suspect, Stream<Rule>> regular(final int mocks) {
         return suspect -> Stream.of(
             new RuleSuppressed(
                 new RuleAllTestsHaveProductionClass(suspect.project(), suspect.test()),
@@ -108,7 +113,7 @@ final class Cop {
             ),
             new RuleSuppressed(new RuleCorrectTestName(suspect.test()), suspect.test()),
             new RuleSuppressed(new RuleInheritanceInTests(suspect.test()), suspect.test()),
-            new RuleSuppressed(new RuleCorrectTestCases(suspect.test()), suspect.test())
+            new RuleSuppressed(new RuleCorrectTestCases(suspect.test(), mocks), suspect.test())
         );
     }
 }

--- a/src/main/java/com/github/lombrozo/testnames/Cop.java
+++ b/src/main/java/com/github/lombrozo/testnames/Cop.java
@@ -58,7 +58,8 @@ final class Cop {
      * @todo #393:35min Refactor Cop ctor to accept number of arguments.
      *  We should refactor ctor to accept a number of argument from one
      *  object with them. For instance: new Args(new Arg("maxNumberOfMocks", 2), ...).
-     *  The same object should be applied to Cop#regular method.
+     *  The same object should be applied to Cop#regular method. We should
+     *  adjust RuleCorrectTestCases ctor too.
      */
     Cop(final Project proj, final int mocks) {
         this(proj, Cop.regular(mocks));

--- a/src/main/java/com/github/lombrozo/testnames/TestCase.java
+++ b/src/main/java/com/github/lombrozo/testnames/TestCase.java
@@ -24,6 +24,7 @@
 
 package com.github.lombrozo.testnames;
 
+import com.github.javaparser.ast.expr.MethodCallExpr;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -56,6 +57,12 @@ public interface TestCase {
     Collection<Assertion> assertions();
 
     /**
+     * The method statements.
+     * @return The list of statements.
+     */
+    Collection<String> statements();
+
+    /**
      * The fake test case.
      *
      * @since 0.1.0
@@ -85,6 +92,11 @@ public interface TestCase {
         private final Collection<Assertion> assertions;
 
         /**
+         * Statements.
+         */
+        private final Collection<String> statements;
+
+        /**
          * Ctor.
          */
         public Fake() {
@@ -106,7 +118,12 @@ public interface TestCase {
          * @param asserts The method assertions.
          */
         public Fake(final Assertion... asserts) {
-            this(Fake.FAKE_NAME, Collections.emptyList(), Arrays.asList(asserts));
+            this(
+                Fake.FAKE_NAME,
+                Collections.emptyList(),
+                Arrays.asList(asserts),
+                Collections.emptyList()
+            );
         }
 
         /**
@@ -115,7 +132,12 @@ public interface TestCase {
          * @param asserts Assertions of test case
          */
         public Fake(final String name, final Assertion... asserts) {
-            this(name, Collections.emptyList(), Arrays.asList(asserts));
+            this(
+                name,
+                Collections.emptyList(),
+                Arrays.asList(asserts),
+                Collections.emptyList()
+            );
         }
 
         /**
@@ -124,7 +146,12 @@ public interface TestCase {
          * @param suppressed The suppressed rules
          */
         public Fake(final String name, final Collection<String> suppressed) {
-            this(name, suppressed, Collections.emptyList());
+            this(
+                name,
+                suppressed,
+                Collections.emptyList(),
+                Collections.emptyList()
+            );
         }
 
         /**
@@ -136,11 +163,13 @@ public interface TestCase {
         public Fake(
             final String name,
             final Collection<String> suppressed,
-            final Collection<Assertion> assertions
+            final Collection<Assertion> assertions,
+            final Collection<String> statements
         ) {
             this.name = name;
             this.suppressed = suppressed;
             this.assertions = assertions;
+            this.statements = statements;
         }
 
         @Override
@@ -156,6 +185,11 @@ public interface TestCase {
         @Override
         public Collection<Assertion> assertions() {
             return Collections.unmodifiableCollection(this.assertions);
+        }
+
+        @Override
+        public Collection<String> statements() {
+            return Collections.unmodifiableCollection(this.statements);
         }
     }
 }

--- a/src/main/java/com/github/lombrozo/testnames/TestCase.java
+++ b/src/main/java/com/github/lombrozo/testnames/TestCase.java
@@ -24,7 +24,6 @@
 
 package com.github.lombrozo.testnames;
 
-import com.github.javaparser.ast.expr.MethodCallExpr;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -68,7 +67,7 @@ public interface TestCase {
      * @since 0.1.0
      */
     @Data
-    @SuppressWarnings("PMD.TestClassWithoutTestCases")
+    @SuppressWarnings({"PMD.TestClassWithoutTestCases", "PMD.DataClass"})
     final class Fake implements TestCase {
 
         /**
@@ -159,6 +158,8 @@ public interface TestCase {
          * @param name The name of test case
          * @param suppressed The suppressed rules
          * @param assertions The method assertions
+         * @param statements The method statements
+         * @checkstyle ParameterNumberCheck (2 lines)
          */
         public Fake(
             final String name,

--- a/src/main/java/com/github/lombrozo/testnames/ValidateMojo.java
+++ b/src/main/java/com/github/lombrozo/testnames/ValidateMojo.java
@@ -110,6 +110,7 @@ public final class ValidateMojo extends AbstractMojo {
     /**
      * Max number of mocks allowed.
      * Needed for {@link com.github.lombrozo.testnames.rules.RuleTestCaseContainsMockery}.
+     * @checkstyle MemberNameCheck (3 lines)
      */
     @Parameter(defaultValue = "2")
     private int maxNumberOfMocks;

--- a/src/main/java/com/github/lombrozo/testnames/ValidateMojo.java
+++ b/src/main/java/com/github/lombrozo/testnames/ValidateMojo.java
@@ -107,13 +107,22 @@ public final class ValidateMojo extends AbstractMojo {
     @Parameter(defaultValue = "${project.build.directory}/generated-test-sources")
     private File tests;
 
+    /**
+     * Max number of mocks allowed.
+     * Needed for {@link com.github.lombrozo.testnames.rules.RuleTestCaseContainsMockery}.
+     */
+    @Parameter(defaultValue = "2")
+    private int maxNumberOfMocks;
+
     @Override
     public void execute() throws MojoFailureException {
         this.getLog().info("Validating tests...");
         final ProjectWithoutJUnitExtensions proj = new ProjectWithoutJUnitExtensions(
             new Project.Combined(this.projects())
         );
-        final Collection<Complaint> complaints = new ArrayList<>(new Cop(proj).inspection());
+        final Collection<Complaint> complaints = new ArrayList<>(
+            new Cop(proj, this.maxNumberOfMocks).inspection()
+        );
         if (this.experimental) {
             complaints.addAll(new Cop(proj, Cop.experimental()).inspection());
         }

--- a/src/main/java/com/github/lombrozo/testnames/javaparser/JavaParserTestCase.java
+++ b/src/main/java/com/github/lombrozo/testnames/javaparser/JavaParserTestCase.java
@@ -27,7 +27,7 @@ package com.github.lombrozo.testnames.javaparser;
 import com.github.javaparser.ast.Node;
 import com.github.javaparser.ast.NodeList;
 import com.github.javaparser.ast.body.MethodDeclaration;
-import com.github.javaparser.ast.expr.MethodCallExpr;
+import com.github.javaparser.ast.stmt.ExpressionStmt;
 import com.github.javaparser.ast.type.VarType;
 import com.github.lombrozo.testnames.Assertion;
 import com.github.lombrozo.testnames.TestCase;
@@ -124,7 +124,7 @@ final class JavaParserTestCase implements TestCase {
     @Override
     public Collection<String> statements() {
         return this.method.asMethodDeclaration()
-            .findAll(MethodCallExpr.class)
+            .findAll(ExpressionStmt.class)
             .stream()
             .map(Node::toString)
             .collect(Collectors.toList());

--- a/src/main/java/com/github/lombrozo/testnames/javaparser/JavaParserTestCase.java
+++ b/src/main/java/com/github/lombrozo/testnames/javaparser/JavaParserTestCase.java
@@ -24,8 +24,10 @@
 
 package com.github.lombrozo.testnames.javaparser;
 
+import com.github.javaparser.ast.Node;
 import com.github.javaparser.ast.NodeList;
 import com.github.javaparser.ast.body.MethodDeclaration;
+import com.github.javaparser.ast.expr.MethodCallExpr;
 import com.github.javaparser.ast.type.VarType;
 import com.github.lombrozo.testnames.Assertion;
 import com.github.lombrozo.testnames.TestCase;
@@ -116,6 +118,15 @@ final class JavaParserTestCase implements TestCase {
         return this.method.statements()
             .map(JavaParserAssertion::new)
             .filter(ParsedAssertion::isAssertion)
+            .collect(Collectors.toList());
+    }
+
+    @Override
+    public Collection<String> statements() {
+        return this.method.asMethodDeclaration()
+            .findAll(MethodCallExpr.class)
+            .stream()
+            .map(Node::toString)
             .collect(Collectors.toList());
     }
 

--- a/src/main/java/com/github/lombrozo/testnames/javaparser/NumberOfMockitoMocks.java
+++ b/src/main/java/com/github/lombrozo/testnames/javaparser/NumberOfMockitoMocks.java
@@ -1,0 +1,63 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2022-2024 Volodya Lombrozo
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.github.lombrozo.testnames.javaparser;
+
+import com.github.lombrozo.testnames.TestCase;
+import java.util.regex.Pattern;
+import org.cactoos.Scalar;
+
+/**
+ * Number of Mockito mocks in the test case.
+ *
+ * @since 1.3.4
+ */
+public final class NumberOfMockitoMocks implements Scalar<Long> {
+
+    /**
+     * Mockito Mock Pattern.
+     */
+    private static final Pattern MOCK_PATTERN =
+        Pattern.compile("^(mock\\(.*?\\);)|(Mockito\\.mock\\(.*?\\);)$");
+    /**
+     * Test case.
+     */
+    private final TestCase test;
+
+    /**
+     * Ctor.
+     * @param tst Test case
+     */
+    public NumberOfMockitoMocks(final TestCase tst) {
+        this.test = tst;
+    }
+
+    @Override
+    public Long value() {
+        return this.test.statements().stream()
+            .filter(
+                statement ->
+                    NumberOfMockitoMocks.MOCK_PATTERN.matcher(statement).find()
+            ).count();
+    }
+}

--- a/src/main/java/com/github/lombrozo/testnames/rules/RuleCorrectTestCase.java
+++ b/src/main/java/com/github/lombrozo/testnames/rules/RuleCorrectTestCase.java
@@ -48,8 +48,9 @@ public final class RuleCorrectTestCase implements Rule {
      * Ctor.
      *
      * @param test The test case to check
+     * @param max Max number of mocks allowed
      */
-    RuleCorrectTestCase(final TestCase test) {
+    RuleCorrectTestCase(final TestCase test, final int max) {
         this.all = Stream.of(
             new RuleNotCamelCase(test),
             new RuleNotContainsTestWord(test),
@@ -57,7 +58,8 @@ public final class RuleCorrectTestCase implements Rule {
             new RuleNotUsesSpecialCharacters(test),
             new RulePresentTense(test),
             new RuleAssertionMessage(test),
-            new LineHitterRule(test)
+            new LineHitterRule(test),
+            new RuleTestCaseContainsMockery(test, max)
         ).map(rule -> new RuleSuppressed(rule, test)).collect(Collectors.toList());
     }
 

--- a/src/main/java/com/github/lombrozo/testnames/rules/RuleCorrectTestCases.java
+++ b/src/main/java/com/github/lombrozo/testnames/rules/RuleCorrectTestCases.java
@@ -48,6 +48,7 @@ public final class RuleCorrectTestCases implements Rule {
 
     /**
      * Max number of mocks allowed.
+     * @checkstyle MemberNameCheck (3 lines)
      */
     private final int maxNumberOfMocks;
 

--- a/src/main/java/com/github/lombrozo/testnames/rules/RuleCorrectTestCases.java
+++ b/src/main/java/com/github/lombrozo/testnames/rules/RuleCorrectTestCases.java
@@ -47,19 +47,30 @@ public final class RuleCorrectTestCases implements Rule {
     private final TestClass tests;
 
     /**
+     * Max number of mocks allowed.
+     */
+    private final int maxNumberOfMocks;
+
+    /**
      * Ctor.
      *
      * @param cases The cases to check
+     * @param mocks Max number of mocks allowed
      */
-    public RuleCorrectTestCases(final TestClass cases) {
+    public RuleCorrectTestCases(final TestClass cases, final int mocks) {
         this.tests = cases;
+        this.maxNumberOfMocks = mocks;
     }
 
     @Override
     public Collection<Complaint> complaints() {
         final List<Complaint> list = this.tests.all().stream()
-            .map(test -> new RuleSuppressed(new RuleCorrectTestCase(test), test))
-            .map(Rule::complaints)
+            .map(
+                test ->
+                    new RuleSuppressed(
+                        new RuleCorrectTestCase(test, this.maxNumberOfMocks), test
+                    )
+            ).map(Rule::complaints)
             .flatMap(Collection::stream)
             .collect(Collectors.toList());
         final Collection<Complaint> result;

--- a/src/main/java/com/github/lombrozo/testnames/rules/RuleTestCaseContainsMockery.java
+++ b/src/main/java/com/github/lombrozo/testnames/rules/RuleTestCaseContainsMockery.java
@@ -1,0 +1,79 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2022-2024 Volodya Lombrozo
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.github.lombrozo.testnames.rules;
+
+import com.github.lombrozo.testnames.Complaint;
+import com.github.lombrozo.testnames.Rule;
+import com.github.lombrozo.testnames.TestCase;
+import com.github.lombrozo.testnames.complaints.ComplaintLinked;
+import com.github.lombrozo.testnames.javaparser.NumberOfMockitoMocks;
+import java.util.Collection;
+
+/**
+ * Mockery rule.
+ *
+ * @since 1.3.4
+ */
+public final class RuleTestCaseContainsMockery implements Rule {
+
+    /**
+     * Test case.
+     */
+    private final TestCase test;
+
+    /**
+     * Allowed number of mocks.
+     */
+    private final Long allowed;
+
+    /**
+     * Ctor.
+     *
+     * @param tst   Test case
+     * @param allwd Allowed number of mocks.
+     */
+    public RuleTestCaseContainsMockery(final TestCase tst, final Long allwd) {
+        this.test = tst;
+        this.allowed = allwd;
+    }
+
+    @Override
+    public Collection<Complaint> complaints() {
+        final Long mocks = new NumberOfMockitoMocks(this.test).value();
+        return new RuleConditional(
+            () -> mocks > this.allowed,
+            new ComplaintLinked(
+                String.format(
+                    "Test case '%s' contains excessive number of mocks: %s. max allowed: %s",
+                    this.test.name(),
+                    mocks,
+                    this.allowed
+                ),
+                "Simplify mocking in test case",
+                this.getClass(),
+                "mockery.md"
+            )
+        ).complaints();
+    }
+}

--- a/src/main/java/com/github/lombrozo/testnames/rules/RuleTestCaseContainsMockery.java
+++ b/src/main/java/com/github/lombrozo/testnames/rules/RuleTestCaseContainsMockery.java
@@ -34,6 +34,10 @@ import java.util.Collection;
  * Mockery rule.
  *
  * @since 1.3.4
+ * @todo #393:45min Add support for detecting mocks from other frameworks.
+ *  We should add support for detecting not only Mockito mocks, but mocks from
+ *  other frameworks too. We should even try to detect "generic" mocks without
+ *  a need to stick to the specific framework or library.
  */
 public final class RuleTestCaseContainsMockery implements Rule {
 
@@ -45,7 +49,7 @@ public final class RuleTestCaseContainsMockery implements Rule {
     /**
      * Allowed number of mocks.
      */
-    private final Long allowed;
+    private final int allowed;
 
     /**
      * Ctor.
@@ -53,7 +57,7 @@ public final class RuleTestCaseContainsMockery implements Rule {
      * @param tst   Test case
      * @param allwd Allowed number of mocks.
      */
-    public RuleTestCaseContainsMockery(final TestCase tst, final Long allwd) {
+    public RuleTestCaseContainsMockery(final TestCase tst, final int allwd) {
         this.test = tst;
         this.allowed = allwd;
     }
@@ -62,7 +66,7 @@ public final class RuleTestCaseContainsMockery implements Rule {
     public Collection<Complaint> complaints() {
         final Long mocks = new NumberOfMockitoMocks(this.test).value();
         return new RuleConditional(
-            () -> mocks > this.allowed,
+            () -> mocks > (long) this.allowed,
             new ComplaintLinked(
                 String.format(
                     "Test case '%s' contains excessive number of mocks: %s. max allowed: %s",

--- a/src/main/java/com/github/lombrozo/testnames/rules/RuleTestCaseContainsMockery.java
+++ b/src/main/java/com/github/lombrozo/testnames/rules/RuleTestCaseContainsMockery.java
@@ -54,8 +54,8 @@ public final class RuleTestCaseContainsMockery implements Rule {
     /**
      * Ctor.
      *
-     * @param tst   Test case
-     * @param allwd Allowed number of mocks.
+     * @param tst Test case
+     * @param allwd Allowed number of mocks
      */
     public RuleTestCaseContainsMockery(final TestCase tst, final int allwd) {
         this.test = tst;
@@ -69,12 +69,12 @@ public final class RuleTestCaseContainsMockery implements Rule {
             () -> mocks > (long) this.allowed,
             new ComplaintLinked(
                 String.format(
-                    "Test case '%s' contains excessive number of mocks: %s. max allowed: %s",
+                    "Method '%s' contains excessive number of mocks: %s. max allowed: %s",
                     this.test.name(),
                     mocks,
                     this.allowed
                 ),
-                "Simplify mocking in test case",
+                "Simplify mocking in test case or stick to fakes",
                 this.getClass(),
                 "mockery.md"
             )

--- a/src/test/java/com/github/lombrozo/testnames/CopTest.java
+++ b/src/test/java/com/github/lombrozo/testnames/CopTest.java
@@ -39,7 +39,8 @@ final class CopTest {
         MatcherAssert.assertThat(
             "Cop should not find any complaints.",
             new Cop(
-                new Project.Fake(new ProductionClass.Fake(), new TestClass.Fake())
+                new Project.Fake(new ProductionClass.Fake(), new TestClass.Fake()),
+                0
             ).inspection(),
             Matchers.empty()
         );
@@ -53,7 +54,8 @@ final class CopTest {
                 new Project.Fake(
                     new ProductionClass.Fake("CustomClass"),
                     new TestClass.Fake()
-                )
+                ),
+                0
             ).inspection(),
             Matchers.hasSize(1)
         );

--- a/src/test/java/com/github/lombrozo/testnames/javaparser/JavaParserTestCaseTest.java
+++ b/src/test/java/com/github/lombrozo/testnames/javaparser/JavaParserTestCaseTest.java
@@ -309,11 +309,11 @@ final class JavaParserTestCaseTest {
         ).get(0);
         final Collection<String> statements = parser.statements();
         final List<String> expected = new ListOf<>(
-            "Mockito.mock(List.class)",
-            "Mockito.mock(Set.class)",
-            "Mockito.mock(Map.class)",
-            "Mockito.when(list.get(0)).thenReturn(\"jeff\")",
-            "Mockito.when(map.get(\"test\")).thenReturn(\"jeff\")"
+            "final List list = Mockito.mock(List.class);",
+            "final Set set = Mockito.mock(Set.class);",
+            "final Map map = Mockito.mock(Map.class);",
+            "Mockito.when(list.get(0)).thenReturn(\"jeff\");",
+            "Mockito.when(map.get(\"test\")).thenReturn(\"jeff\");"
         );
         MatcherAssert.assertThat(
             String.format(

--- a/src/test/java/com/github/lombrozo/testnames/javaparser/JavaParserTestCaseTest.java
+++ b/src/test/java/com/github/lombrozo/testnames/javaparser/JavaParserTestCaseTest.java
@@ -31,8 +31,10 @@ import com.github.lombrozo.testnames.rules.RuleNotContainsTestWord;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Optional;
+import java.util.Set;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
+import org.hamcrest.core.IsEqual;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -260,6 +262,23 @@ final class JavaParserTestCaseTest {
             "Java enum has to be parsed, but doesn't have to be a JUnit extension",
             JavaTestClasses.ENUM.toTestClass().characteristics().isJUnitExtension(),
             Matchers.is(false)
+        );
+    }
+
+    @Test
+    void parsesMockery() {
+        final JavaParserTestClass parser = JavaTestClasses.MOCKERY_TEST.toTestClass();
+        final int tests = parser.characteristics().numberOfTests();
+        final int expected = 1;
+        MatcherAssert.assertThat(
+            String.format(
+            "Mockery has to be parsed: %s, but number of tests (%s) doesn't match with expected %s",
+                parser.all(),
+                tests,
+                expected
+            ),
+            tests,
+            new IsEqual<>(expected)
         );
     }
 }

--- a/src/test/java/com/github/lombrozo/testnames/javaparser/JavaParserTestCaseTest.java
+++ b/src/test/java/com/github/lombrozo/testnames/javaparser/JavaParserTestCaseTest.java
@@ -32,6 +32,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Optional;
 import java.util.Set;
+import org.cactoos.set.SetOf;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.hamcrest.core.IsEqual;
@@ -278,6 +279,23 @@ final class JavaParserTestCaseTest {
                 expected
             ),
             tests,
+            new IsEqual<>(expected)
+        );
+    }
+
+    @Test
+    void parsesSuppressedMockery() {
+        final JavaParserTestClass parser = JavaTestClasses.MOCKERY_SUPPRESSED.toTestClass();
+        final Collection<String> suppressed = parser.suppressed();
+        final Set<String> expected = new SetOf<>("TestCaseContainsMockery");
+        MatcherAssert.assertThat(
+            String.format(
+            "Suppressed mockery parsed: %s, but suppression (%s) does not match with expected (%s)",
+            parser.all(),
+                suppressed,
+                expected
+            ),
+            suppressed,
             new IsEqual<>(expected)
         );
     }

--- a/src/test/java/com/github/lombrozo/testnames/javaparser/JavaParserTestCaseTest.java
+++ b/src/test/java/com/github/lombrozo/testnames/javaparser/JavaParserTestCaseTest.java
@@ -289,7 +289,7 @@ final class JavaParserTestCaseTest {
     void parsesSuppressedMockery() {
         final JavaParserTestClass parser = JavaTestClasses.MOCKERY_SUPPRESSED.toTestClass();
         final Collection<String> suppressed = parser.suppressed();
-        final Set<String> expected = new SetOf<>("TestCaseContainsMockery");
+        final Set<String> expected = new SetOf<>("RuleTestCaseContainsMockery");
         MatcherAssert.assertThat(
             String.format(
             "Suppressed mockery parsed: %s, but suppression (%s) does not match with expected (%s)",

--- a/src/test/java/com/github/lombrozo/testnames/javaparser/JavaParserTestCaseTest.java
+++ b/src/test/java/com/github/lombrozo/testnames/javaparser/JavaParserTestCaseTest.java
@@ -275,7 +275,7 @@ final class JavaParserTestCaseTest {
         final int expected = 1;
         MatcherAssert.assertThat(
             String.format(
-            "Mockery has to be parsed: %s, but number of tests (%s) doesn't match with expected %s",
+                "Mockery has to be parsed: %s, but number of tests (%s) doesn't match with expected %s",
                 parser.all(),
                 tests,
                 expected
@@ -292,8 +292,8 @@ final class JavaParserTestCaseTest {
         final Set<String> expected = new SetOf<>("RuleTestCaseContainsMockery");
         MatcherAssert.assertThat(
             String.format(
-            "Suppressed mockery parsed: %s, but suppression (%s) does not match with expected (%s)",
-            parser.all(),
+                "Suppressed mockery parsed: %s, but suppression (%s) does not match with expected (%s)",
+                parser.all(),
                 suppressed,
                 expected
             ),
@@ -304,16 +304,13 @@ final class JavaParserTestCaseTest {
 
     @Test
     void parsesStatements() {
-        final TestCase parser = new ListOf<>(
+        final Collection<String> statements = new ListOf<>(
             JavaTestClasses.MOCKERY_TEST.toTestClass().all()
-        ).get(0);
-        final Collection<String> statements = parser.statements();
+        ).get(0).statements();
         final List<String> expected = new ListOf<>(
-            "final List list = Mockito.mock(List.class);",
-            "final Set set = Mockito.mock(Set.class);",
-            "final Map map = Mockito.mock(Map.class);",
-            "Mockito.when(list.get(0)).thenReturn(\"jeff\");",
-            "Mockito.when(map.get(\"test\")).thenReturn(\"jeff\");"
+            "Mockito.when(Mockito.mock(List.class).get(0)).thenReturn(\"jeff\");",
+            "Mockito.when(Mockito.mock(Map.class).get(\"test\")).thenReturn(\"jeff\");",
+            "Mockito.when(Mockito.mock(Set.class).add(1)).thenReturn(true);"
         );
         MatcherAssert.assertThat(
             String.format(

--- a/src/test/java/com/github/lombrozo/testnames/javaparser/JavaParserTestCaseTest.java
+++ b/src/test/java/com/github/lombrozo/testnames/javaparser/JavaParserTestCaseTest.java
@@ -30,8 +30,10 @@ import com.github.lombrozo.testnames.rules.RuleNotCamelCase;
 import com.github.lombrozo.testnames.rules.RuleNotContainsTestWord;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import org.cactoos.list.ListOf;
 import org.cactoos.set.SetOf;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
@@ -296,6 +298,30 @@ final class JavaParserTestCaseTest {
                 expected
             ),
             suppressed,
+            new IsEqual<>(expected)
+        );
+    }
+
+    @Test
+    void parsesStatements() {
+        final TestCase parser = new ListOf<>(
+            JavaTestClasses.MOCKERY_TEST.toTestClass().all()
+        ).get(0);
+        final Collection<String> statements = parser.statements();
+        final List<String> expected = new ListOf<>(
+            "Mockito.mock(List.class)",
+            "Mockito.mock(Set.class)",
+            "Mockito.mock(Map.class)",
+            "Mockito.when(list.get(0)).thenReturn(\"jeff\")",
+            "Mockito.when(map.get(\"test\")).thenReturn(\"jeff\")"
+        );
+        MatcherAssert.assertThat(
+            String.format(
+                "Parsed statements %s do not match with expected %s",
+                statements,
+                expected
+            ),
+            statements,
             new IsEqual<>(expected)
         );
     }

--- a/src/test/java/com/github/lombrozo/testnames/javaparser/JavaTestClasses.java
+++ b/src/test/java/com/github/lombrozo/testnames/javaparser/JavaTestClasses.java
@@ -140,7 +140,17 @@ enum JavaTestClasses {
     /**
      * Assert true line hitter for junit.
      */
-    JUNIT_ASSERT_TRUE_LINE_HITTER("JunitAssertTrueHitter.java");
+    JUNIT_ASSERT_TRUE_LINE_HITTER("JunitAssertTrueHitter.java"),
+
+    /**
+     * Test case with mockery.
+     */
+    MOCKERY_TEST("Mockery.java"),
+
+    /**
+     * Test case with suppressed mockery.
+     */
+    MOCKERY_SUPPRESSED("MockerySuppressed.java");
 
     /**
      * Java file name in resources.

--- a/src/test/java/com/github/lombrozo/testnames/javaparser/JavaTestClasses.java
+++ b/src/test/java/com/github/lombrozo/testnames/javaparser/JavaTestClasses.java
@@ -35,7 +35,7 @@ import org.cactoos.io.ResourceOf;
  * @since 0.1.14
  */
 @SuppressWarnings({"JTCOP.RuleAllTestsHaveProductionClass", "JTCOP.RuleCorrectTestName"})
-enum JavaTestClasses {
+public enum JavaTestClasses {
 
     /**
      * Test class with only suppressed methods.
@@ -170,7 +170,7 @@ enum JavaTestClasses {
      * @param suppressed Rules excluded for entire project.
      * @return Concrete test class implementation - {@link JavaParserTestClass}.
      */
-    JavaParserTestClass toTestClass(final String... suppressed) {
+    public JavaParserTestClass toTestClass(final String... suppressed) {
         return new JavaParserTestClass(
             Paths.get("."),
             this.inputStream(),

--- a/src/test/java/com/github/lombrozo/testnames/javaparser/NumberOfMockitoMocksTest.java
+++ b/src/test/java/com/github/lombrozo/testnames/javaparser/NumberOfMockitoMocksTest.java
@@ -45,7 +45,7 @@ final class NumberOfMockitoMocksTest {
         final long expected = 3L;
         MatcherAssert.assertThat(
             String.format(
-            "Test case parsed: %s, but number of mocks (%s) does not match with expected (%s)",
+                "Test case parsed: %s, but number of mocks (%s) does not match with expected (%s)",
                 test.toString(),
                 mocks,
                 expected

--- a/src/test/java/com/github/lombrozo/testnames/javaparser/NumberOfMockitoMocksTest.java
+++ b/src/test/java/com/github/lombrozo/testnames/javaparser/NumberOfMockitoMocksTest.java
@@ -1,0 +1,57 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2022-2024 Volodya Lombrozo
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.github.lombrozo.testnames.javaparser;
+
+import com.github.lombrozo.testnames.TestCase;
+import org.cactoos.list.ListOf;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.core.IsEqual;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test case for {@link NumberOfMockitoMocks}.
+ *
+ * @since 1.3.4
+ */
+final class NumberOfMockitoMocksTest {
+
+    @Test
+    void returnsNumberOfMocks() throws Exception {
+        final TestCase test = new ListOf<>(
+            JavaTestClasses.MOCKERY_TEST.toTestClass().all()
+        ).get(0);
+        final Long mocks = new NumberOfMockitoMocks(test).value();
+        final long expected = 3L;
+        MatcherAssert.assertThat(
+            String.format(
+            "Test case parsed: %s, but number of mocks (%s) does not match with expected (%s)",
+                test.toString(),
+                mocks,
+                expected
+            ),
+            mocks,
+            new IsEqual<>(expected)
+        );
+    }
+}

--- a/src/test/java/com/github/lombrozo/testnames/rules/RuleCorrectTestCasesTest.java
+++ b/src/test/java/com/github/lombrozo/testnames/rules/RuleCorrectTestCasesTest.java
@@ -76,12 +76,14 @@ final class RuleCorrectTestCasesTest {
                     new TestCase.Fake(
                         "remove",
                         Collections.singletonList("RulePresentTense"),
-                        Collections.singletonList(new Assertion.Fake())
+                        Collections.singletonList(new Assertion.Fake()),
+                        Collections.emptyList()
                     ),
                     new TestCase.Fake(
                         "create",
                         Collections.singletonList("RulePresentTense"),
-                        Collections.singletonList(new Assertion.Fake())
+                        Collections.singletonList(new Assertion.Fake()),
+                        Collections.emptyList()
                     )
                 )
             ).complaints(),

--- a/src/test/java/com/github/lombrozo/testnames/rules/RuleCorrectTestCasesTest.java
+++ b/src/test/java/com/github/lombrozo/testnames/rules/RuleCorrectTestCasesTest.java
@@ -47,7 +47,8 @@ final class RuleCorrectTestCasesTest {
                 new TestClass.Fake(
                     new TestCase.Fake("removes", new Assertion.Fake()),
                     new TestCase.Fake("creates", new Assertion.Fake())
-                )
+                ),
+                0
             ).complaints(),
             Matchers.empty()
         );
@@ -61,7 +62,8 @@ final class RuleCorrectTestCasesTest {
                 new TestClass.Fake(
                     new TestCase.Fake("remove", new Assertion.Fake()),
                     new TestCase.Fake("create", new Assertion.Fake())
-                )
+                ),
+                0
             ).complaints(),
             Matchers.allOf(Matchers.hasSize(1))
         );
@@ -85,7 +87,8 @@ final class RuleCorrectTestCasesTest {
                         Collections.singletonList(new Assertion.Fake()),
                         Collections.emptyList()
                     )
-                )
+                ),
+                0
             ).complaints(),
             Matchers.empty()
         );
@@ -100,7 +103,7 @@ final class RuleCorrectTestCasesTest {
         );
         MatcherAssert.assertThat(
             "Should skip suppressed checks on class level.",
-            new RuleSuppressed(new RuleCorrectTestCases(klass), klass).complaints(),
+            new RuleSuppressed(new RuleCorrectTestCases(klass, 0), klass).complaints(),
             Matchers.empty()
         );
     }

--- a/src/test/java/com/github/lombrozo/testnames/rules/RuleTest.java
+++ b/src/test/java/com/github/lombrozo/testnames/rules/RuleTest.java
@@ -28,7 +28,6 @@ import com.github.lombrozo.testnames.Assertion;
 import com.github.lombrozo.testnames.Complaint;
 import com.github.lombrozo.testnames.TestCase;
 import java.util.Collection;
-import java.util.Collections;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.params.ParameterizedTest;

--- a/src/test/java/com/github/lombrozo/testnames/rules/RuleTest.java
+++ b/src/test/java/com/github/lombrozo/testnames/rules/RuleTest.java
@@ -28,6 +28,7 @@ import com.github.lombrozo.testnames.Assertion;
 import com.github.lombrozo.testnames.Complaint;
 import com.github.lombrozo.testnames.TestCase;
 import java.util.Collection;
+import java.util.Collections;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -75,7 +76,8 @@ final class RuleTest {
     })
     void validatesCorrectly(final String name, final boolean expected) {
         final Collection<Complaint> complaints = new RuleCorrectTestCase(
-            new TestCase.Fake(name, new Assertion.Fake("Some message"))
+            new TestCase.Fake(name, new Assertion.Fake("Some message")),
+            0
         ).complaints();
         MatcherAssert.assertThat(
             complaints.toString(),

--- a/src/test/java/com/github/lombrozo/testnames/rules/RuleTestCaseContainsMockeryTest.java
+++ b/src/test/java/com/github/lombrozo/testnames/rules/RuleTestCaseContainsMockeryTest.java
@@ -44,7 +44,7 @@ final class RuleTestCaseContainsMockeryTest {
             JavaTestClasses.MOCKERY_TEST.toTestClass().all()
         ).get(0);
         final Complaint complaint = new ListOf<>(
-            new RuleTestCaseContainsMockery(test, 2L).complaints()
+            new RuleTestCaseContainsMockery(test, 2).complaints()
         ).get(0);
         final String text =
             "'testsSomething' contains excessive number of mocks: 3. max allowed: 2";

--- a/src/test/java/com/github/lombrozo/testnames/rules/RuleTestCaseContainsMockeryTest.java
+++ b/src/test/java/com/github/lombrozo/testnames/rules/RuleTestCaseContainsMockeryTest.java
@@ -24,7 +24,6 @@
 package com.github.lombrozo.testnames.rules;
 
 import com.github.lombrozo.testnames.Complaint;
-import com.github.lombrozo.testnames.TestCase;
 import com.github.lombrozo.testnames.javaparser.JavaTestClasses;
 import org.cactoos.list.ListOf;
 import org.hamcrest.MatcherAssert;
@@ -40,11 +39,13 @@ final class RuleTestCaseContainsMockeryTest {
 
     @Test
     void complaintsAboutMockery() {
-        final TestCase test = new ListOf<>(
-            JavaTestClasses.MOCKERY_TEST.toTestClass().all()
-        ).get(0);
         final Complaint complaint = new ListOf<>(
-            new RuleTestCaseContainsMockery(test, 2).complaints()
+            new RuleTestCaseContainsMockery(
+                new ListOf<>(
+                    JavaTestClasses.MOCKERY_TEST.toTestClass().all()
+                ).get(0),
+                2
+            ).complaints()
         ).get(0);
         final String text =
             "'testsSomething' contains excessive number of mocks: 3. max allowed: 2";

--- a/src/test/java/com/github/lombrozo/testnames/rules/RuleTestCaseContainsMockeryTest.java
+++ b/src/test/java/com/github/lombrozo/testnames/rules/RuleTestCaseContainsMockeryTest.java
@@ -34,6 +34,9 @@ import org.junit.jupiter.api.Test;
  * Test case for {@link RuleTestCaseContainsMockery}.
  *
  * @since 1.3.4
+ * @todo #393:30min Create #doesNotComplants unit test for positive scenarios too.
+ *  We should introduce a unit test(s) for positive scenarios too. We should
+ *  check allowed number of mocks and if testcase has a respected suppression.
  */
 final class RuleTestCaseContainsMockeryTest {
 

--- a/src/test/java/com/github/lombrozo/testnames/rules/RuleTestCaseContainsMockeryTest.java
+++ b/src/test/java/com/github/lombrozo/testnames/rules/RuleTestCaseContainsMockeryTest.java
@@ -1,0 +1,61 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2022-2024 Volodya Lombrozo
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.github.lombrozo.testnames.rules;
+
+import com.github.lombrozo.testnames.Complaint;
+import com.github.lombrozo.testnames.TestCase;
+import com.github.lombrozo.testnames.javaparser.JavaTestClasses;
+import org.cactoos.list.ListOf;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test case for {@link RuleTestCaseContainsMockeryTest}.
+ *
+ * @since 1.3.4
+ */
+final class RuleTestCaseContainsMockeryTest {
+
+    @Test
+    void complaintsAboutMockery() {
+        final TestCase test = new ListOf<>(
+            JavaTestClasses.MOCKERY_TEST.toTestClass().all()
+        ).get(0);
+        final Complaint complaint = new ListOf<>(
+            new RuleTestCaseContainsMockery(test, 2L).complaints()
+        ).get(0);
+        final String text =
+            "'testsSomething' contains excessive number of mocks: 3. max allowed: 2";
+        MatcherAssert.assertThat(
+            String.format(
+                "Complaint received: %s, but message does not contain text '%s'",
+                complaint,
+                text
+            ),
+            complaint.message(),
+            Matchers.containsString(text)
+        );
+    }
+}

--- a/src/test/java/com/github/lombrozo/testnames/rules/RuleTestCaseContainsMockeryTest.java
+++ b/src/test/java/com/github/lombrozo/testnames/rules/RuleTestCaseContainsMockeryTest.java
@@ -32,7 +32,7 @@ import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
 
 /**
- * Test case for {@link RuleTestCaseContainsMockeryTest}.
+ * Test case for {@link RuleTestCaseContainsMockery}.
  *
  * @since 1.3.4
  */

--- a/src/test/resources/Mockery.java
+++ b/src/test/resources/Mockery.java
@@ -32,10 +32,8 @@ final class MockeryTest {
 
   @Test
   void testsSomething() {
-    final List list = Mockito.mock(List.class);
-    final Set set = Mockito.mock(Set.class);
-    final Map map = Mockito.mock(Map.class);
-    Mockito.when(list.get(0)).thenReturn("jeff");
-    Mockito.when(map.get("test")).thenReturn("jeff");
+    Mockito.when(Mockito.mock(List.class).get(0)).thenReturn("jeff");
+    Mockito.when(Mockito.mock(Map.class).get("test")).thenReturn("jeff");
+    Mockito.when(Mockito.mock(Set.class).add(1)).thenReturn(true);
   }
 }

--- a/src/test/resources/Mockery.java
+++ b/src/test/resources/Mockery.java
@@ -1,0 +1,41 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2022-2024 Volodya Lombrozo
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.cactoos.list.ListOf;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+final class MockeryTest {
+
+  @Test
+  void testsSomething() {
+    final List list = Mockito.mock(List.class);
+    final Set set = Mockito.mock(Set.class);
+    final Map map = Mockito.mock(Map.class);
+    Mockito.when(list.get(0)).thenReturn("jeff");
+    Mockito.when(map.get("test")).thenReturn("jeff");
+  }
+}

--- a/src/test/resources/MockerySuppressed.java
+++ b/src/test/resources/MockerySuppressed.java
@@ -1,0 +1,42 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2022-2024 Volodya Lombrozo
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.cactoos.list.ListOf;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+@SuppressWarnings("JTCOP.TestCaseContainsMockery")
+final class MockeryTest {
+
+  @Test
+  void testsSomething() {
+    final List list = Mockito.mock(List.class);
+    final Set set = Mockito.mock(Set.class);
+    final Map map = Mockito.mock(Map.class);
+    Mockito.when(list.get(0)).thenReturn("jeff");
+    Mockito.when(map.get("test")).thenReturn("jeff");
+  }
+}

--- a/src/test/resources/MockerySuppressed.java
+++ b/src/test/resources/MockerySuppressed.java
@@ -28,7 +28,7 @@ import org.cactoos.list.ListOf;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
-@SuppressWarnings("JTCOP.TestCaseContainsMockery")
+@SuppressWarnings("JTCOP.RuleTestCaseContainsMockery")
 final class MockeryTest {
 
   @Test


### PR DESCRIPTION
In this pull request I've introduced new rule `RuleTestCaseContainsMockery ` for mockery detection with Mockito 
mocking framework.

@volodya-lombrozo take a look, please
closes #393

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces a new rule to limit the number of mocks in test cases. It also adds support for JavaParser and updates dependencies.

### Detailed summary
- Added `maxNumberOfMocks` parameter in `RuleCorrectTestCase` and `Cop` classes
- Updated `JavaParserTestCase` to include `statements()` method
- Added `maxNumberOfMocks` field in `RuleCorrectTestCases` class
- Updated `ValidateMojo` to support `maxNumberOfMocks`
- Refactored `Cop` class to accept `maxNumberOfMocks`
- Added `MockeryTest` and `Mockery.java` for testing mocks

> The following files were skipped due to too many changes: `src/test/resources/Mockery.java`, `src/it/exclusions/src/test/java/MockeryTest.java`, `src/test/resources/MockerySuppressed.java`, `docs/rules/mockery.md`, `src/test/java/com/github/lombrozo/testnames/javaparser/JavaParserTestCaseTest.java`, `src/main/java/com/github/lombrozo/testnames/javaparser/NumberOfMockitoMocks.java`, `src/test/java/com/github/lombrozo/testnames/javaparser/NumberOfMockitoMocksTest.java`, `src/test/java/com/github/lombrozo/testnames/rules/RuleTestCaseContainsMockeryTest.java`, `src/main/java/com/github/lombrozo/testnames/TestCase.java`, `src/main/java/com/github/lombrozo/testnames/rules/RuleTestCaseContainsMockery.java`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->