### PR TITLE
feat(#413): Assertions Inside Try Statements

### DIFF
--- a/src/it/assertions/src/test/java/AssertionsTest.java
+++ b/src/it/assertions/src/test/java/AssertionsTest.java
@@ -237,6 +237,31 @@ class AssertionsTest {
         );
     }
 
+    @Test
+    void findsAssertionsInBlockOfTryStatement() {
+        try {
+            MatcherAssert.assertThat(
+                "Message",
+                "1",
+                Matchers.equalTo("1")
+            );
+        } catch (RuntimeException e) {
+        }
+    }
+
+    @Test
+    void findsAssertionsInCatchOfTryStatement() {
+        try {
+            System.out.println("Hello");
+        } catch (RuntimeException e) {
+            MatcherAssert.assertThat(
+                message(),
+                "1",
+                Matchers.equalTo("1")
+            );
+        }
+    }
+
     private String message() {
         return "Message";
     }

--- a/src/main/java/com/github/lombrozo/testnames/javaparser/JavaParserMethod.java
+++ b/src/main/java/com/github/lombrozo/testnames/javaparser/JavaParserMethod.java
@@ -36,6 +36,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
@@ -150,12 +151,33 @@ final class JavaParserMethod {
                     } else {
                         result = JavaParserMethod.flatStatements(expression);
                     }
+                } else if (statement.isTryStmt()) {
+                    final List<Statement> statements = JavaParserMethod.statements(
+                        (Node) statement);
+                    result = statements.stream();
                 } else {
                     result = Stream.of(statement);
                 }
                 return result;
             }
         );
+    }
+
+    /**
+     * Extract statements from node.
+     * @param node Node to extract statements from.
+     * @return List of statements.
+     */
+    private static List<Statement> statements(final Node node) {
+        final List<Statement> res = new ArrayList<>(0);
+        if (node instanceof Statement) {
+            res.add((Statement) node);
+        }
+        node.getChildNodes()
+            .stream()
+            .map(JavaParserMethod::statements)
+            .forEach(res::addAll);
+        return res;
     }
 
     /**

--- a/src/main/java/com/github/lombrozo/testnames/javaparser/JavaParserMethod.java
+++ b/src/main/java/com/github/lombrozo/testnames/javaparser/JavaParserMethod.java
@@ -36,7 +36,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
@@ -152,8 +151,7 @@ final class JavaParserMethod {
                         result = JavaParserMethod.flatStatements(expression);
                     }
                 } else if (statement.isTryStmt()) {
-                    final List<Statement> statements = JavaParserMethod.statements(
-                        (Node) statement);
+                    final List<Statement> statements = JavaParserMethod.statements(statement);
                     result = statements.stream();
                 } else {
                     result = Stream.of(statement);

--- a/src/test/java/com/github/lombrozo/testnames/javaparser/JavaParserTestCaseTest.java
+++ b/src/test/java/com/github/lombrozo/testnames/javaparser/JavaParserTestCaseTest.java
@@ -250,6 +250,24 @@ final class JavaParserTestCaseTest {
     }
 
     @Test
+    void parsesAssertionInsideTryStatement(){
+        final JavaParserTestClass parser = JavaTestClasses.TEST_WITH_ASSERTIONS.toTestClass();
+        final String method = "checksTheCaseFrom413issueWithAssertionInTryStatement";
+        final TestCase tested = parser.all().stream()
+            .filter(test -> method.equals(test.name()))
+            .findFirst()
+            .orElseThrow(() -> new AssertionError(String.format("Method %s not found", method)));
+        final Assertion assertion = tested.assertions().stream()
+            .findFirst()
+            .orElseThrow(() -> new AssertionError("Assertion not found"));
+        MatcherAssert.assertThat(
+            String.format("The '%s' assertion has to contain an explanation", assertion),
+            assertion.explanation().isPresent(),
+            Matchers.is(true)
+        );
+    }
+
+    @Test
     void parsesPackageJava() {
         final JavaParserTestClass parser = JavaTestClasses.PACKAGE_INFO.toTestClass();
         MatcherAssert.assertThat(

--- a/src/test/java/com/github/lombrozo/testnames/javaparser/JavaParserTestCaseTest.java
+++ b/src/test/java/com/github/lombrozo/testnames/javaparser/JavaParserTestCaseTest.java
@@ -268,6 +268,24 @@ final class JavaParserTestCaseTest {
     }
 
     @Test
+    void parsesAssertionInsideCatchBlock(){
+        final JavaParserTestClass parser = JavaTestClasses.TEST_WITH_ASSERTIONS.toTestClass();
+        final String method = "checksTheCaseFrom413issueWithAssertionInCatchBlock";
+        final TestCase tested = parser.all().stream()
+            .filter(test -> method.equals(test.name()))
+            .findFirst()
+            .orElseThrow(() -> new AssertionError(String.format("Method %s not found", method)));
+        final Assertion assertion = tested.assertions().stream()
+            .findFirst()
+            .orElseThrow(() -> new AssertionError("Assertion not found"));
+        MatcherAssert.assertThat(
+            String.format("The '%s' assertion has to contain an explanation", assertion),
+            assertion.explanation().isPresent(),
+            Matchers.is(true)
+        );
+    }
+
+    @Test
     void parsesPackageJava() {
         final JavaParserTestClass parser = JavaTestClasses.PACKAGE_INFO.toTestClass();
         MatcherAssert.assertThat(

--- a/src/test/java/com/github/lombrozo/testnames/javaparser/JavaParserTestCaseTest.java
+++ b/src/test/java/com/github/lombrozo/testnames/javaparser/JavaParserTestCaseTest.java
@@ -48,6 +48,21 @@ import org.junit.jupiter.api.Test;
 @SuppressWarnings("PMD.TooManyMethods")
 final class JavaParserTestCaseTest {
 
+    /**
+     * Message for assertion.
+     */
+    private static final String MESSAGE = "The '%s' assertion has to contain an explanation";
+
+    /**
+     * Not found message for assertions.
+     */
+    private static final String NOT_FOUND = "Assertion not found";
+
+    /**
+     * Method not found message.
+     */
+    private static final String METHOD_NFOUND = "Method %s not found";
+
     @Test
     void convertsToString() {
         final String name = "name";
@@ -162,7 +177,7 @@ final class JavaParserTestCaseTest {
         );
         final Assertion assertion = assertions.iterator().next();
         MatcherAssert.assertThat(
-            String.format("The '%s' assertion has to contain an explanation", assertion),
+            String.format(JavaParserTestCaseTest.MESSAGE, assertion),
             assertion.explanation().isPresent(),
             Matchers.is(true)
         );
@@ -181,12 +196,16 @@ final class JavaParserTestCaseTest {
         final TestCase tested = parser.all().stream()
             .filter(test -> method.equals(test.name()))
             .findFirst()
-            .orElseThrow(() -> new AssertionError(String.format("Method %s not found", method)));
+            .orElseThrow(
+                () -> new AssertionError(
+                    String.format(JavaParserTestCaseTest.METHOD_NFOUND, method)
+                )
+            );
         final Assertion assertion = tested.assertions().stream()
             .findFirst()
-            .orElseThrow(() -> new AssertionError("Assertion not found"));
+            .orElseThrow(() -> new AssertionError(JavaParserTestCaseTest.NOT_FOUND));
         MatcherAssert.assertThat(
-            String.format("The '%s' assertion has to contain an explanation", assertion),
+            String.format(JavaParserTestCaseTest.MESSAGE, assertion),
             assertion.explanation().isPresent(),
             Matchers.is(true)
         );
@@ -200,10 +219,14 @@ final class JavaParserTestCaseTest {
         final TestCase tested = parser.all().stream()
             .filter(test -> method.equals(test.name()))
             .findFirst()
-            .orElseThrow(() -> new AssertionError(String.format("Method %s not found", method)));
+            .orElseThrow(
+                () -> new AssertionError(
+                    String.format(JavaParserTestCaseTest.METHOD_NFOUND, method)
+                )
+            );
         final Assertion assertion = tested.assertions().stream()
             .findFirst()
-            .orElseThrow(() -> new AssertionError("Assertion not found"));
+            .orElseThrow(() -> new AssertionError(JavaParserTestCaseTest.NOT_FOUND));
         MatcherAssert.assertThat(
             String.format("The '%s' assertion has to contain some explanation", assertion),
             assertion.explanation().isPresent(),
@@ -219,12 +242,16 @@ final class JavaParserTestCaseTest {
         final TestCase tested = parser.all().stream()
             .filter(test -> method.equals(test.name()))
             .findFirst()
-            .orElseThrow(() -> new AssertionError(String.format("Method %s not found", method)));
+            .orElseThrow(
+                () -> new AssertionError(
+                    String.format(JavaParserTestCaseTest.METHOD_NFOUND, method)
+                )
+            );
         final Assertion assertion = tested.assertions().stream()
             .findFirst()
-            .orElseThrow(() -> new AssertionError("Assertion not found"));
+            .orElseThrow(() -> new AssertionError(JavaParserTestCaseTest.NOT_FOUND));
         MatcherAssert.assertThat(
-            String.format("The '%s' assertion has to contain an explanation", assertion),
+            String.format(JavaParserTestCaseTest.MESSAGE, assertion),
             assertion.explanation().isPresent(),
             Matchers.is(true)
         );
@@ -238,49 +265,61 @@ final class JavaParserTestCaseTest {
         final TestCase tested = parser.all().stream()
             .filter(test -> method.equals(test.name()))
             .findFirst()
-            .orElseThrow(() -> new AssertionError(String.format("Method %s not found", method)));
+            .orElseThrow(
+                () -> new AssertionError(
+                    String.format(JavaParserTestCaseTest.METHOD_NFOUND, method)
+                )
+            );
         final Assertion assertion = tested.assertions().stream()
             .findFirst()
-            .orElseThrow(() -> new AssertionError("Assertion not found"));
+            .orElseThrow(() -> new AssertionError(JavaParserTestCaseTest.NOT_FOUND));
         MatcherAssert.assertThat(
-            String.format("The '%s' assertion has to contain an explanation", assertion),
+            String.format(JavaParserTestCaseTest.MESSAGE, assertion),
             assertion.explanation().isPresent(),
             Matchers.is(true)
         );
     }
 
     @Test
-    void parsesAssertionInsideTryStatement(){
+    void parsesAssertionInsideTryStatement() {
         final JavaParserTestClass parser = JavaTestClasses.TEST_WITH_ASSERTIONS.toTestClass();
         final String method = "checksTheCaseFrom413issueWithAssertionInTryStatement";
         final TestCase tested = parser.all().stream()
             .filter(test -> method.equals(test.name()))
             .findFirst()
-            .orElseThrow(() -> new AssertionError(String.format("Method %s not found", method)));
-        final Assertion assertion = tested.assertions().stream()
+            .orElseThrow(
+                () -> new AssertionError(
+                    String.format(JavaParserTestCaseTest.METHOD_NFOUND, method)
+                )
+            );
+        final Assertion assrtion = tested.assertions().stream()
             .findFirst()
-            .orElseThrow(() -> new AssertionError("Assertion not found"));
+            .orElseThrow(() -> new AssertionError(JavaParserTestCaseTest.NOT_FOUND));
         MatcherAssert.assertThat(
-            String.format("The '%s' assertion has to contain an explanation", assertion),
-            assertion.explanation().isPresent(),
+            String.format(JavaParserTestCaseTest.MESSAGE, assrtion),
+            assrtion.explanation().isPresent(),
             Matchers.is(true)
         );
     }
 
     @Test
-    void parsesAssertionInsideCatchBlock(){
+    void parsesAssertionInsideCatchBlock() {
         final JavaParserTestClass parser = JavaTestClasses.TEST_WITH_ASSERTIONS.toTestClass();
         final String method = "checksTheCaseFrom413issueWithAssertionInCatchBlock";
         final TestCase tested = parser.all().stream()
             .filter(test -> method.equals(test.name()))
             .findFirst()
-            .orElseThrow(() -> new AssertionError(String.format("Method %s not found", method)));
-        final Assertion assertion = tested.assertions().stream()
+            .orElseThrow(
+                () -> new AssertionError(
+                    String.format(JavaParserTestCaseTest.METHOD_NFOUND, method)
+                )
+            );
+        final Assertion assrtion = tested.assertions().stream()
             .findFirst()
-            .orElseThrow(() -> new AssertionError("Assertion not found"));
+            .orElseThrow(() -> new AssertionError(JavaParserTestCaseTest.NOT_FOUND));
         MatcherAssert.assertThat(
-            String.format("The '%s' assertion has to contain an explanation", assertion),
-            assertion.explanation().isPresent(),
+            String.format(JavaParserTestCaseTest.MESSAGE, assrtion),
+            assrtion.explanation().isPresent(),
             Matchers.is(true)
         );
     }

--- a/src/test/resources/TestWithAssertions.java
+++ b/src/test/resources/TestWithAssertions.java
@@ -150,4 +150,19 @@ class TestWithAssertions {
         }
     }
 
+    @Test
+    void checksTheCaseFrom413issueWithAssertionInCatchBlock() {
+        // https://github.com/volodya-lombrozo/jtcop/issues/413
+        try {
+            System.nanoTime();
+        } catch (RuntimeException e) {
+            MatcherAssert.assertThat(
+                "Assertion inside try statement",
+                "1",
+                Matchers.equalTo("1")
+            );
+            e.printStackTrace();
+        }
+    }
+
 }

--- a/src/test/resources/TestWithAssertions.java
+++ b/src/test/resources/TestWithAssertions.java
@@ -135,4 +135,19 @@ class TestWithAssertions {
             );
         }).limit(1).forEach(Runnable::run);
     }
+
+    @Test
+    void checksTheCaseFrom413issueWithAssertionInTryStatement() {
+        // https://github.com/volodya-lombrozo/jtcop/issues/413
+        try {
+            MatcherAssert.assertThat(
+                "Assertion inside try statement",
+                "1",
+                Matchers.equalTo("1")
+            );
+        } catch (RuntimeException e) {
+            e.printStackTrace();
+        }
+    }
+
 }


### PR DESCRIPTION
In this PR I fix the problem related to assertions in try statements. jtcop used to skip assertions in try statements. Now it finds them well.

Related to #413.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces enhancements to JavaParserMethod for better statement extraction. It also adds tests for finding assertions inside try-catch blocks.

### Detailed summary
- Added methods to extract statements from JavaParserMethod
- Added tests for finding assertions inside try-catch blocks in JavaParserTestCaseTest

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->