### PR TITLE
feat(#429): deep profile for deep testing

### DIFF
--- a/.github/workflows/codecov.yaml
+++ b/.github/workflows/codecov.yaml
@@ -20,7 +20,7 @@ jobs:
           key: maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
             maven-
-      - run: mvn clean install -Pqulice --errors --batch-mode
+      - run: mvn clean install -P"deep,qulice" --errors --batch-mode
       - uses: codecov/codecov-action@v4
         with:
           files: ./target/site/jacoco/jacoco.xml

--- a/.github/workflows/maven.test.yaml
+++ b/.github/workflows/maven.test.yaml
@@ -27,4 +27,4 @@ jobs:
           key: ${{ runner.os }}-jdk-${{ matrix.java }}-maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
             ${{ runner.os }}-jdk-${{ matrix.java }}-maven-
-      - run: mvn clean install -Pqulice --errors --batch-mode
+      - run: mvn clean install -P"deep,qulice" --errors --batch-mode

--- a/.rultor.yml
+++ b/.rultor.yml
@@ -10,4 +10,4 @@ release:
     [[ "${tag}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || exit -1
     mvn versions:set "-DnewVersion=${tag}" "-DprocessPlugins=false"
     git commit -am "${tag}"
-    mvn clean install -Pqulice --errors --batch-mode
+    mvn clean install -P"deep,qulice" --errors --batch-mode

--- a/pom.xml
+++ b/pom.xml
@@ -184,6 +184,7 @@ SOFTWARE.
         <artifactId>maven-surefire-plugin</artifactId>
         <version>3.5.0</version>
         <configuration>
+          <excludedGroups>slow</excludedGroups>
           <excludes>
             <exclude>
               generated/**
@@ -430,6 +431,31 @@ SOFTWARE.
               <serverId>ossrh</serverId>
               <nexusUrl>https://oss.sonatype.org/</nexusUrl>
               <autoReleaseAfterClose>true</autoReleaseAfterClose>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
+      <!-- Deep Testing: https://www.yegor256.com/2023/08/22/fast-vs-deep-testing.html -->
+      <id>deep</id>
+      <activation>
+        <activeByDefault>false</activeByDefault>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <version>3.5.0</version>
+            <configuration>
+              <!-- In order to include slow tests too -->
+              <excludedGroups>nothing-to-exclude</excludedGroups>
+              <excludes>
+                <exclude>
+                  generated/**
+                </exclude>
+              </excludes>
             </configuration>
           </plugin>
         </plugins>


### PR DESCRIPTION
In this pull I've introduced new maven profile: `deep` in order to run slow tests (that can be added in the future) only on the CI, while only fast tests will be executed by default.

closes #429


<!-- start pr-codex -->

---

## PR-Codex overview
This PR improves testing by adding a new Maven profile for deep testing, including slow tests.

### Detailed summary
- Added a new Maven profile `deep` for deep testing
- Updated `.rultor.yml` to include `deep` profile in Maven command
- Updated workflows to use `deep` profile in Maven commands
- Added exclusion for slow tests in `pom.xml` under the `deep` profile

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->