### PR TITLE
feat(#248): start with requirements in disabled test

### DIFF
--- a/src/test/java/com/github/lombrozo/testnames/rules/ml/RulePresentSimpleMlTest.java
+++ b/src/test/java/com/github/lombrozo/testnames/rules/ml/RulePresentSimpleMlTest.java
@@ -91,7 +91,7 @@ final class RulePresentSimpleMlTest {
     }
 
     /**
-     * Test case for present tense on plural in test methods.
+     * Test case for present tense on plural with subject at the beginning.
      * @param name Test method name
      * @todo #248:25min Enable passesOnPlural test when plural speech detection will
      *  be implemented in {@link RulePresentSimpleMl}. Let's test that the following
@@ -103,13 +103,40 @@ final class RulePresentSimpleMlTest {
             "theyBuildModel",
             "theyPassTest",
             "robotsDoGood",
-            "documentsServePeople"
+            "documentsServePeople",
+            "humansCraftSolutions",
+            "machinesLearnPatterns",
+            "usersTrustSystem",
+            "algorithmsPredictOutcome",
+            "clientsReceiveNotifications",
+            "serversHandleRequest",
+            "employeesSubmitReport",
+            "devicesSyncData",
+            "botsRespondInstantly",
+            "studentsCompleteAssignments",
+            "applicationsRunSmoothly",
+            "tasksGenerateResults",
+            "administratorsManageAccess",
+            "dataDrivesDecisions",
+            "systemsProcessInput",
+            "dogsBark",
+            "catsPurr",
+            "birdsSing",
+            "fishSwim",
+            "treesGrow",
+            "riversFlow",
+            "carsRace",
+            "childrenPlay",
+            "studentsStudy"
         }
     )
     @ParameterizedTest
-    void passesOnPlural(final String name) {
+    void passesOnPluralWithSubjectAtTheBeginning(final String name) {
         MatcherAssert.assertThat(
-            String.format("Name '%s' has to be correct", name),
+            String.format(
+                "Test name with subject at the beginning should be correct, but it wasn't ('%s')",
+                name
+            ),
             new RulePresentSimpleMl(
                 RulePresentSimpleMlTest.model,
                 new TestCase.Fake(name)

--- a/src/test/java/com/github/lombrozo/testnames/rules/ml/RulePresentSimpleMlTest.java
+++ b/src/test/java/com/github/lombrozo/testnames/rules/ml/RulePresentSimpleMlTest.java
@@ -28,6 +28,7 @@ import opennlp.tools.postag.POSTaggerME;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 
@@ -79,6 +80,32 @@ final class RulePresentSimpleMlTest {
     })
     @ParameterizedTest
     void checksCorrectNames(final String name) {
+        MatcherAssert.assertThat(
+            String.format("Name '%s' has to be correct", name),
+            new RulePresentSimpleMl(
+                RulePresentSimpleMlTest.model,
+                new TestCase.Fake(name)
+            ).complaints(),
+            Matchers.empty()
+        );
+    }
+
+    /**
+     * @todo #248:25min Enable passesOnPlural test when plural speech detection will
+     *  be implemented in {@link RulePresentSimpleMl}. Let's test that the following
+     *  pattern: <PLURAL NOUN><PLURAL VERB>... passes.
+     */
+    @Disabled
+    @CsvSource(
+        {
+            "theyBuildModel",
+            "theyPassTest",
+            "robotsDoGood",
+            "documentsServePeople"
+        }
+    )
+    @ParameterizedTest
+    void passesOnPlural(final String name) {
         MatcherAssert.assertThat(
             String.format("Name '%s' has to be correct", name),
             new RulePresentSimpleMl(

--- a/src/test/java/com/github/lombrozo/testnames/rules/ml/RulePresentSimpleMlTest.java
+++ b/src/test/java/com/github/lombrozo/testnames/rules/ml/RulePresentSimpleMlTest.java
@@ -93,7 +93,7 @@ final class RulePresentSimpleMlTest {
     /**
      * @todo #248:25min Enable passesOnPlural test when plural speech detection will
      *  be implemented in {@link RulePresentSimpleMl}. Let's test that the following
-     *  pattern: <PLURAL NOUN><PLURAL VERB>... passes.
+     *  pattern: $pluralNoun_$pluralVerb... passes.
      */
     @Disabled
     @CsvSource(

--- a/src/test/java/com/github/lombrozo/testnames/rules/ml/RulePresentSimpleMlTest.java
+++ b/src/test/java/com/github/lombrozo/testnames/rules/ml/RulePresentSimpleMlTest.java
@@ -91,6 +91,8 @@ final class RulePresentSimpleMlTest {
     }
 
     /**
+     * Test case for present tense on plural in test methods.
+     * @param name Test method name
      * @todo #248:25min Enable passesOnPlural test when plural speech detection will
      *  be implemented in {@link RulePresentSimpleMl}. Let's test that the following
      *  pattern: $pluralNoun_$pluralVerb... passes.


### PR DESCRIPTION
In this pull I've created unit test as requirements start for #248.

related to #248

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds a new test case `passesOnPluralWithSubjectAtTheBeginning` to `RulePresentSimpleMlTest` for plural subject at the beginning, using `@CsvSource` and `@ParameterizedTest`.

### Detailed summary
- Added new parameterized test `passesOnPluralWithSubjectAtTheBeginning`
- Test checks for correct present tense with plural subjects at the beginning
- Uses `@CsvSource` for test data
- Disabled test until plural speech detection is implemented

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->