### PR TITLE
chore: Use `macos-14` For CI Pipelines

### DIFF
--- a/.github/workflows/maven.test.yaml
+++ b/.github/workflows/maven.test.yaml
@@ -12,7 +12,7 @@ jobs:
     name: Tests
     strategy:
       matrix:
-        os: [ubuntu-20.04, windows-2022, macos-12]
+        os: [ubuntu-20.04, windows-2022, macos-14]
         java: [11, 17]
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
In this PR I just switch from `macos-12` to `macos-14` for CI pipelines.
`macos-12` is deprecated.


<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the `os` version used in the GitHub Actions workflow for testing Java applications. It changes the macOS version from `macos-12` to `macos-14`.

### Detailed summary
- Updated the `os` version in `.github/workflows/maven.test.yaml` from `macos-12` to `macos-14`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->