### PR TITLE
feat(#462): Update Dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -115,7 +115,7 @@ SOFTWARE.
     <dependency>
       <groupId>com.jcabi</groupId>
       <artifactId>jcabi-matchers</artifactId>
-      <version>1.7.0</version>
+      <version>1.8.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -194,7 +194,7 @@ SOFTWARE.
       </plugin>
       <plugin>
         <artifactId>maven-invoker-plugin</artifactId>
-        <version>3.8.1</version>
+        <version>3.9.0</version>
         <configuration>
           <cloneProjectsTo>${project.build.directory}/it</cloneProjectsTo>
           <settingsFile>src/it/settings.xml</settingsFile>
@@ -382,7 +382,7 @@ SOFTWARE.
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-javadoc-plugin</artifactId>
-            <version>3.11.1</version>
+            <version>3.11.2</version>
             <configuration>
               <doclint>none</doclint>
             </configuration>


### PR DESCRIPTION
In this PR I updated:

- `jcabi-matchers:1.8.0`
- `maven-invoker-plugin:3.9.0`
- `maven-javadoc-plugin:3.11.2`

Closes: #462


<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the versions of several dependencies in the `pom.xml` file, ensuring the project uses the latest features and fixes.

### Detailed summary
- Updated `jcabi-matchers` version from `1.7.0` to `1.8.0`.
- Updated `maven-invoker-plugin` version from `3.8.1` to `3.9.0`.
- Updated `maven-javadoc-plugin` version from `3.11.1` to `3.11.2`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->