### PR TITLE
feat(#453): Try to Catch Missed Assertion Messages

### DIFF
--- a/src/it/all-correct/README.md
+++ b/src/it/all-correct/README.md
@@ -1,0 +1,11 @@
+# Correct Test Cases
+
+This integration test contains a set of tests that should pass.
+Use this test to verify that the integration is working as expected.
+Usually, this test is used to check new features or bug fixes.
+
+If you want to run this test, you can use the following command:
+
+```bash
+mvn clean integration-test -Dinvoker.test=all-correct -DskipTests
+```

--- a/src/it/all-correct/pom.xml
+++ b/src/it/all-correct/pom.xml
@@ -51,7 +51,6 @@ SOFTWARE.
       <version>5.11.4</version>
       <scope>test</scope>
     </dependency>
-
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>

--- a/src/it/all-correct/pom.xml
+++ b/src/it/all-correct/pom.xml
@@ -51,6 +51,7 @@ SOFTWARE.
       <version>5.11.4</version>
       <scope>test</scope>
     </dependency>
+
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>

--- a/src/it/all-correct/pom.xml
+++ b/src/it/all-correct/pom.xml
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+MIT License
+
+Copyright (c) 2022-2024 Volodya Lombrozo
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.github.volodya-lombrozo</groupId>
+  <artifactId>jtcop-it</artifactId>
+  <version>@project.version@</version>
+  <packaging>jar</packaging>
+  <description>
+    Integration test that checks correct usage of the plugin.
+    If you need to run only this test, use the following command:
+    "mvn clean integration-test invoker:run -Dinvoker.test=all-correct -DskipTests"
+  </description>
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
+  </properties>
+  <dependencies>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <version>5.11.4</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
+      <version>5.11.4</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <version>5.15.2</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>com.github.volodya-lombrozo</groupId>
+        <artifactId>jtcop-maven-plugin</artifactId>
+        <version>@project.version@</version>
+        <executions>
+          <execution>
+            <id>integration-test</id>
+            <goals>
+              <goal>check</goal>
+            </goals>
+            <configuration>
+              <maxNumberOfMocks>1</maxNumberOfMocks>
+              <failOnError>true</failOnError>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/src/it/all-correct/src/test/java/CorrectTests.java
+++ b/src/it/all-correct/src/test/java/CorrectTests.java
@@ -22,10 +22,17 @@
  * SOFTWARE.
  */
 
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Stream;
+
 /**
  * Test class.
  * @since 1.4
  */
+@SuppressWarnings("JTCOP.RuleAllTestsHaveProductionClass")
 public class CorrectTests {
 
     /**

--- a/src/it/all-correct/src/test/java/CorrectTests.java
+++ b/src/it/all-correct/src/test/java/CorrectTests.java
@@ -1,0 +1,54 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2022-2024 Volodya Lombrozo
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+/**
+ * Test class.
+ * @since 1.4
+ */
+public class CorrectTests {
+
+    /**
+     * This is test for the issur #453.
+     * You can read more about the issue right here:
+     * https://github.com/volodya-lombrozo/jtcop/issues/453
+     */
+    @Test
+    void generatesSyntaxForGrammar() {
+        final List<String> definitions = new ArrayList<>(0);
+        final String top = "rule";
+        String[] programs = definitions.stream().toArray(String[]::new);
+        String message = "We expect that the randomly generated code will be verified without errors";
+        try {
+            Assertions.assertDoesNotThrow(
+                () -> Stream.generate(() -> top)
+                    .limit(50)
+                    .peek(System.out::println)
+                    .count(),
+                message
+            );
+        } catch (Exception exception) {
+            Assertions.fail(message, exception);
+        }
+    }
+}

--- a/src/it/all-correct/src/test/java/CorrectTests.java
+++ b/src/it/all-correct/src/test/java/CorrectTests.java
@@ -27,6 +27,12 @@ import org.junit.jupiter.api.Test;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Stream;
+import java.nio.file.Path;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import java.util.Arrays;
+import org.junit.jupiter.params.ParameterizedTest;
 
 /**
  * Test class.
@@ -40,10 +46,13 @@ public class CorrectTests {
      * You can read more about the issue right here:
      * https://github.com/volodya-lombrozo/jtcop/issues/453
      */
-    @Test
-    void generatesSyntaxForGrammar() {
-        final List<String> definitions = new ArrayList<>(0);
-        final String top = "rule";
+    @ParameterizedTest(name = "Generates programs for {0} grammar with top rule {1}")
+    @MethodSource("syntax")
+    void generatesSyntaxForGrammar(
+        final List<String> definitions,
+        final String top,
+        @TempDir final Path tmp
+    ) {
         String[] programs = definitions.stream().toArray(String[]::new);
         String message = "We expect that the randomly generated code will be verified without errors";
         try {
@@ -57,5 +66,13 @@ public class CorrectTests {
         } catch (Exception exception) {
             Assertions.fail(message, exception);
         }
+    }
+
+    static Stream<Arguments> syntax() {
+        return Stream.of(
+            Arguments.of(Arrays.asList("rule", "rule", "rule"), "rule"),
+            Arguments.of(Arrays.asList("rule", "rule", "rule"), "rule"),
+            Arguments.of(Arrays.asList("rule", "rule", "rule"), "rule")
+        );
     }
 }

--- a/src/test/java/com/github/lombrozo/testnames/javaparser/AssertionOfJUnitTest.java
+++ b/src/test/java/com/github/lombrozo/testnames/javaparser/AssertionOfJUnitTest.java
@@ -37,6 +37,7 @@ import org.junit.jupiter.api.Test;
  *
  * @since 0.1.15
  */
+@SuppressWarnings("PMD.TooManyMethods")
 final class AssertionOfJUnitTest {
 
     /**

--- a/src/test/java/com/github/lombrozo/testnames/javaparser/AssertionOfJUnitTest.java
+++ b/src/test/java/com/github/lombrozo/testnames/javaparser/AssertionOfJUnitTest.java
@@ -184,6 +184,20 @@ final class AssertionOfJUnitTest {
         );
     }
 
+    @Test
+    void findsAssertionMessages() {
+        MatcherAssert.assertThat(
+            "All assertions should have explanation assertions",
+            JavaTestClasses.TEST_WITH_JUNIT_ASSERTIONS
+                .testCase("generatesSyntaxForGrammar")
+                .assertions()
+                .stream()
+                .map(Assertion::explanation)
+                .allMatch(Optional::isPresent),
+            Matchers.is(true)
+        );
+    }
+
     /**
      * Return assertions from method by name.
      *

--- a/src/test/resources/TestWithJUnitAssertions.java
+++ b/src/test/resources/TestWithJUnitAssertions.java
@@ -25,6 +25,7 @@
 package com.github.lombrozo.testnames;
 
 import java.time.Duration;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.function.Supplier;
 import org.junit.jupiter.api.Assertions;
@@ -206,5 +207,29 @@ class TestWithJUnitAssertions {
             () -> {
             }
         );
+    }
+
+    /**
+     * This is test for the issur #453.
+     * You can read more about the issue right here:
+     * https://github.com/volodya-lombrozo/jtcop/issues/453
+     */
+    @Test
+    void generatesSyntaxForGrammar() {
+        final List<String> definitions = new ArrayList<>(0);
+        final String top = "rule";
+        String[] programs = definitions.stream().toArray(String[]::new);
+        String message = "We expect that the randomly generated code will be verified without errors";
+        try {
+            Assertions.assertDoesNotThrow(
+                () -> Stream.generate(() -> top)
+                    .limit(50)
+                    .peek(System.out::println)
+                    .count(),
+                message
+            );
+        } catch (Exception exception) {
+            Assertions.fail(message, exception);
+        }
     }
 }


### PR DESCRIPTION
In this PR I've made several attempts to find the bug related to the #453 issue and failed.
It means, that `jtcop` works well for these examples. Thus, I close the issue.

Closes: #453.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces new integration tests and updates existing unit tests for better assertion handling. It adds a README for running tests and enhances the structure of test classes to ensure correct functionality of the plugin.

### Detailed summary
- Added `README.md` for integration test instructions.
- Introduced `findsAssertionMessages` test in `AssertionOfJUnitTest`.
- Added `generatesSyntaxForGrammar` test in `TestWithJUnitAssertions`.
- Created `CorrectTests` class with parameterized tests.
- Included MIT License in `CorrectTests.java` and `pom.xml`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->