### PR TITLE
feat(#436): Thread Safe Execution

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -204,6 +204,7 @@ SOFTWARE.
           <streamLogsOnFailures>true</streamLogsOnFailures>
           <showErrors>true</showErrors>
           <skipInvocation>${skipITs}</skipInvocation>
+          <parallelThreads>4</parallelThreads>
         </configuration>
         <executions>
           <execution>

--- a/src/it/parallel/README.md
+++ b/src/it/parallel/README.md
@@ -1,0 +1,10 @@
+# Parallel Execution
+
+This integration test is used to test the parallel execution of the 
+`jtcop-maven-plugin`. 
+
+To run the test, execute the following command:
+
+```bash
+mvn clean integration-test -Dinvoker.test=parallel -DskipTests
+```

--- a/src/it/parallel/invoker.properties
+++ b/src/it/parallel/invoker.properties
@@ -1,0 +1,22 @@
+# MIT License
+#
+# Copyright (c) 2022-2024 Volodya Lombrozo
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+invoker.goals = clean install -T 2C

--- a/src/it/parallel/invoker.properties
+++ b/src/it/parallel/invoker.properties
@@ -25,4 +25,4 @@
 # mvn -T 4 clean install # Builds with 4 threads
 # mvn -T 1C clean install # 1 thread per cpu core
 # mvn -T 1.5C clean install # 1.5 thread per cpu core
-invoker.goals = clean install -T 4
+invoker.goals = clean validate -T 4

--- a/src/it/parallel/invoker.properties
+++ b/src/it/parallel/invoker.properties
@@ -19,4 +19,10 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
-invoker.goals = clean install -T 2C
+
+# From: https://cwiki.apache.org/confluence/display/MAVEN/Parallel+builds+in+Maven+3
+# Maven 3.x has the capability to perform parallel builds. The command is as follows:
+# mvn -T 4 clean install # Builds with 4 threads
+# mvn -T 1C clean install # 1 thread per cpu core
+# mvn -T 1.5C clean install # 1.5 thread per cpu core
+invoker.goals = clean install -T 4

--- a/src/it/parallel/pom.xml
+++ b/src/it/parallel/pom.xml
@@ -37,6 +37,7 @@ SOFTWARE.
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.execution.parallel>true</maven.execution.parallel>
   </properties>
   <dependencies>
     <dependency>

--- a/src/it/parallel/pom.xml
+++ b/src/it/parallel/pom.xml
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+MIT License
+
+Copyright (c) 2022-2024 Volodya Lombrozo
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.github.volodya-lombrozo</groupId>
+  <artifactId>jtcop-it</artifactId>
+  <version>@project.version@</version>
+  <packaging>jar</packaging>
+  <description>
+    Integration test that checks correct usage of the plugin in concurrent environment.
+    If you need to run only this test, use the following command:
+    "mvn clean integration-test invoker:run -Dinvoker.test=parallel -DskipTests"
+  </description>
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
+  </properties>
+  <dependencies>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <version>5.11.4</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
+      <version>5.11.4</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <version>5.15.2</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>com.github.volodya-lombrozo</groupId>
+        <artifactId>jtcop-maven-plugin</artifactId>
+        <version>@project.version@</version>
+        <executions>
+          <execution>
+            <id>integration-test</id>
+            <goals>
+              <goal>check</goal>
+            </goals>
+            <configuration>
+              <maxNumberOfMocks>1</maxNumberOfMocks>
+              <failOnError>true</failOnError>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/src/it/parallel/src/main/java/Production.java
+++ b/src/it/parallel/src/main/java/Production.java
@@ -1,0 +1,30 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2022-2024 Volodya Lombrozo
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.github.lombrozo.testnames;
+
+public class Production {
+    public static void main(String[] args) {
+        System.out.println("Hello, World!");
+    }
+}

--- a/src/it/parallel/src/test/java/ProductionTest.java
+++ b/src/it/parallel/src/test/java/ProductionTest.java
@@ -1,0 +1,34 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2022-2024 Volodya Lombrozo
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.github.lombrozo.testnames;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Assertions;
+
+public class ProductionTest {
+    @Test
+    public void runsMain() {
+        Assertions.assertDoesNotThrow(() -> Production.main(new String[0]), "All works fine");
+    }
+}

--- a/src/it/parallel/verify.groovy
+++ b/src/it/parallel/verify.groovy
@@ -22,6 +22,5 @@
  * SOFTWARE.
  */
 String log = new File(basedir, 'build.log').text;
-assert log.contains("BUILD SUCCESS")
-assert log.contains("Hello, World!")
+assert log.contains("All tests are valid")
 true

--- a/src/it/parallel/verify.groovy
+++ b/src/it/parallel/verify.groovy
@@ -22,5 +22,17 @@
  * SOFTWARE.
  */
 String log = new File(basedir, 'build.log').text;
-assert log.contains("All tests are valid")
+assert log.contains("All tests are valid"): "Some tests are invalid"
+String unexpected = '''
+[WARNING] *****************************************************************
+[WARNING] * Your build is requesting parallel execution, but this         *
+[WARNING] * project contains the following plugin(s) that have goals not  *
+[WARNING] * marked as thread-safe to support parallel execution.          *
+[WARNING] * While this /may/ work fine, please look for plugin updates    *
+[WARNING] * and/or request plugins be made thread-safe.                   *
+[WARNING] * If reporting an issue, report it against the plugin in        *
+[WARNING] * question, not against Apache Maven.                           *
+[WARNING] *****************************************************************
+'''
+assert !log.contains(unexpected): "Unexpected warning: $unexpected"
 true

--- a/src/it/parallel/verify.groovy
+++ b/src/it/parallel/verify.groovy
@@ -1,0 +1,27 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2022-2024 Volodya Lombrozo
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+String log = new File(basedir, 'build.log').text;
+assert log.contains("BUILD SUCCESS")
+assert log.contains("Hello, World!")
+true

--- a/src/main/java/com/github/lombrozo/testnames/ValidateMojo.java
+++ b/src/main/java/com/github/lombrozo/testnames/ValidateMojo.java
@@ -53,7 +53,7 @@ import org.apache.maven.project.MavenProject;
  *  We also have to add integration tests for the RuleAllTestsHaveProductionClass that will be
  *  able to check the test names in the compiled classes.
  */
-@Mojo(name = "check", defaultPhase = LifecyclePhase.VALIDATE)
+@Mojo(name = "check", defaultPhase = LifecyclePhase.VALIDATE, threadSafe = true)
 public final class ValidateMojo extends AbstractMojo {
 
     /**


### PR DESCRIPTION
In this PR I'm trying to ensure `jtcop-maven-plugin` thread safety.

Related to: #436

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing the `jtcop-maven-plugin` to support parallel execution in integration tests. It introduces configurations for parallel threads and updates various files to implement and document this feature.

### Detailed summary
- Added `<parallelThreads>4</parallelThreads>` to `pom.xml`.
- Created `src/it/parallel/README.md` to document usage of parallel execution.
- Updated `@Mojo` annotation in `ValidateMojo.java` to include `threadSafe = true`.
- Added `Production.java` and `ProductionTest.java` with MIT License and basic functionality.
- Updated `invoker.properties` for parallel build configuration.
- Added a `verify.groovy` script to assert test validity and check for warnings.
- Created a new `pom.xml` in `src/it/parallel/` for integration tests with dependencies and configurations for parallel execution.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->