### PR TITLE
feat(#318): Add Documentation for `RuleInheritanceInTests` Check

### DIFF
--- a/docs/rules/all-have-production-class.md
+++ b/docs/rules/all-have-production-class.md
@@ -1,4 +1,4 @@
-# All Tests Have Production Class
+**# All Tests Have Production Class
 
 Rule codename: _RuleAllTestsHaveProductionClass_
 ___
@@ -15,8 +15,12 @@ name. If this instruction does not provide the necessary information,
 frustration can ensue, particularly if the project is not one's own. Ultimately,
 the name of the test class is the last hope for obtaining this information.
 
-Exceptions: Annotations, Interfaces, 
+### Exceptions
+
+Annotations, Interfaces,
 `@SuppressedWarnings("JTCOP.RuleAllTestsHaveProductionClass")`.
 
+### Rationale
+
 You can read more about that
-rule [here](https://www.yegor256.com/2023/01/19/layout-of-tests.html#test-classes).
+rule [here](https://www.yegor256.com/2023/01/19/layout-of-tests.html#test-classes).**

--- a/docs/rules/camel-case.md
+++ b/docs/rules/camel-case.md
@@ -2,7 +2,7 @@
 
 Each test name has to be written by using [camel case](https://en.wikipedia.org/wiki/Camel_case).
 
-Correct examples:
+Correct:
 ```java
 public class UserTest {
     @Test
@@ -21,7 +21,7 @@ public class UserTest {
     }
 }
 ```
-Incorrect examples:
+Incorrect:
 ```java
 public class UserTest {
     @Test

--- a/docs/rules/inheritance-in-tests.md
+++ b/docs/rules/inheritance-in-tests.md
@@ -25,7 +25,7 @@ state or behavior from parent classes, leading to subtle bugs and making it
 harder to refactor tests in the future. Every test should clearly express its
 intent without relying on external hierarchy.
 
-### Exceptions
+### Ignoring the Rule
 
 To ignore this rule, annotate the test class
 with `@SuppressedWarnings("JTCOP.RuleInheritanceInTests")`.

--- a/docs/rules/inheritance-in-tests.md
+++ b/docs/rules/inheritance-in-tests.md
@@ -1,6 +1,31 @@
-# Inheritance in tests
+# Inheritance in Tests
 
-@todo #314:90min Add documentation for the RuleInheritenceInTests.java.
-The documentation should be added to the `docs/rules/inheritance-in-tests.md` file.
-The documentation should contain the description of the rule and the
-examples of the correct and incorrect code.
+Rule codename: _RuleInheritanceInTests_
+___
+The test class should not extend any other class. Test inheritance can lead to
+increased complexity, making tests harder to understand and maintain. Each test
+class should be self-contained and focused solely on testing the functionality
+of the production code it targets.
+
+* Correct: A test class without a parent:
+  ```java
+  public class UserTest {
+      // test methods
+  }
+  ```
+* Wrong: A test class that extends another class:
+  ```java
+    public class UserTest extends BaseTest {
+        // test methods
+    }
+  ```
+
+Inheritance in tests can obscure the context of the test by introducing shared
+state or behavior from parent classes, leading to subtle bugs and making it
+harder to refactor tests in the future. Every test should clearly express its
+intent without relying on external hierarchy.
+
+### Exceptions
+
+To ignore this rule, annotate the test class
+with `@SuppressedWarnings("JTCOP.RuleInheritanceInTests")`.

--- a/pom.xml
+++ b/pom.xml
@@ -204,7 +204,7 @@ SOFTWARE.
           <streamLogsOnFailures>true</streamLogsOnFailures>
           <showErrors>true</showErrors>
           <skipInvocation>${skipITs}</skipInvocation>
-          <parallelThreads>4</parallelThreads>
+          <parallelThreads>9</parallelThreads>
         </configuration>
         <executions>
           <execution>

--- a/src/main/java/com/github/lombrozo/testnames/rules/RuleInheritanceInTests.java
+++ b/src/main/java/com/github/lombrozo/testnames/rules/RuleInheritanceInTests.java
@@ -34,6 +34,7 @@ import java.util.Collections;
  * The rule that checks a test class doesn't use inheritance.
  * @since 1.2.0
  */
+@SuppressWarnings("PMD.TestClassWithoutTestCases")
 public final class RuleInheritanceInTests implements Rule {
 
     /**

--- a/src/main/java/com/github/lombrozo/testnames/rules/RuleInheritanceInTests.java
+++ b/src/main/java/com/github/lombrozo/testnames/rules/RuleInheritanceInTests.java
@@ -34,7 +34,6 @@ import java.util.Collections;
  * The rule that checks a test class doesn't use inheritance.
  * @since 1.2.0
  */
-@SuppressWarnings("PMD.TestClassWithoutTestCases")
 public final class RuleInheritanceInTests implements Rule {
 
     /**


### PR DESCRIPTION
In this PR I added documentation to the `RuleInheritanceInTests` check.
Additionally I increased parallelism for integration tests up to `9` threads to speed up the build.

Closes: #318.


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the `pom.xml` configuration and enhancing the documentation for test naming conventions and rules regarding inheritance in tests. It adjusts settings and adds clarity to the guidelines for writing tests.

### Detailed summary
- Updated `<parallelThreads>` from `4` to `9` in `pom.xml`.
- Improved documentation in `docs/rules/camel-case.md` with clearer examples for correct and incorrect test names.
- Expanded `docs/rules/all-have-production-class.md` with a new section on exceptions and rationale.
- Added a new rule in `docs/rules/inheritance-in-tests.md` emphasizing that test classes should not extend other classes, with examples and rationale.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->