### PR TITLE
feat(#472): Use `Central` Repo for Publishing

### DIFF
--- a/.github/workflows/maven.release.yml
+++ b/.github/workflows/maven.release.yml
@@ -12,7 +12,7 @@ jobs:
         with:
           java-version: '11'
           distribution: 'adopt'
-          server-id: ossrh
+          server-id: central
           server-username: MAVEN_USERNAME
           server-password: MAVEN_PASSWORD
           gpg-private-key: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }}

--- a/pom.xml
+++ b/pom.xml
@@ -424,14 +424,15 @@ SOFTWARE.
             </executions>
           </plugin>
           <plugin>
-            <groupId>org.sonatype.plugins</groupId>
-            <artifactId>nexus-staging-maven-plugin</artifactId>
-            <version>1.7.0</version>
+            <groupId>org.sonatype.central</groupId>
+            <artifactId>central-publishing-maven-plugin</artifactId>
+            <version>0.7.0</version>
             <extensions>true</extensions>
             <configuration>
-              <serverId>ossrh</serverId>
-              <nexusUrl>https://oss.sonatype.org/</nexusUrl>
-              <autoReleaseAfterClose>true</autoReleaseAfterClose>
+              <publishingServerId>central</publishingServerId>
+              <tokenAuth>true</tokenAuth>
+              <autoPublish>true</autoPublish>
+              <waitUntil>published</waitUntil>
             </configuration>
           </plugin>
         </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -367,17 +367,6 @@ SOFTWARE.
       <activation>
         <activeByDefault>false</activeByDefault>
       </activation>
-      <distributionManagement>
-        <snapshotRepository>
-          <id>ossrh</id>
-          <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-        </snapshotRepository>
-        <repository>
-          <id>ossrh</id>
-          <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/
-          </url>
-        </repository>
-      </distributionManagement>
       <build>
         <plugins>
           <plugin>

--- a/src/it/all-correct/pom.xml
+++ b/src/it/all-correct/pom.xml
@@ -25,7 +25,7 @@ SOFTWARE.
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.github.volodya-lombrozo</groupId>
-  <artifactId>jtcop-it</artifactId>
+  <artifactId>jtcop-it-all-correct</artifactId>
   <version>@project.version@</version>
   <packaging>jar</packaging>
   <description>

--- a/src/it/all-have-production-class/pom.xml
+++ b/src/it/all-have-production-class/pom.xml
@@ -25,7 +25,7 @@ SOFTWARE.
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.github.volodya-lombrozo</groupId>
-  <artifactId>jtcop-it</artifactId>
+  <artifactId>jtcop-it-all-have-production-class</artifactId>
   <version>@project.version@</version>
   <packaging>jar</packaging>
   <description>Integration test</description>

--- a/src/it/all-incorrect/pom.xml
+++ b/src/it/all-incorrect/pom.xml
@@ -25,7 +25,7 @@ SOFTWARE.
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.github.volodya-lombrozo</groupId>
-  <artifactId>jtcop-it</artifactId>
+  <artifactId>jtcop-it-all-incorrect</artifactId>
   <version>@project.version@</version>
   <packaging>jar</packaging>
   <description>

--- a/src/it/all-incorrect/verify.groovy
+++ b/src/it/all-incorrect/verify.groovy
@@ -23,7 +23,7 @@
  */
 String log = new File(basedir, 'build.log').text;
 [
-  'Test name \'test\' doesn\'t follow naming rules, because test name doesn\'t have to contain the word \'test\'',
+  "Test name 'test' doesn't follow naming rules, because test name doesn't have to contain the word 'test'",
   "Test name 'test' doesn't follow naming rules, because the test name has to be written using present tense",
   "Test name 'test1' doesn't follow naming rules, because test name doesn't have to contain the word 'test'",
   "Test name 'test1' doesn't follow naming rules, because the test name has to be written using present tense",

--- a/src/it/assertions/pom.xml
+++ b/src/it/assertions/pom.xml
@@ -25,7 +25,7 @@ SOFTWARE.
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.github.volodya-lombrozo</groupId>
-  <artifactId>jtcop-it</artifactId>
+  <artifactId>jtcop-it-assertions</artifactId>
   <version>@project.version@</version>
   <packaging>jar</packaging>
   <description>Integration test</description>

--- a/src/it/correct-test-names/pom.xml
+++ b/src/it/correct-test-names/pom.xml
@@ -25,7 +25,7 @@ SOFTWARE.
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.github.volodya-lombrozo</groupId>
-  <artifactId>jtcop-it</artifactId>
+  <artifactId>jtcop-it-correct-test-names</artifactId>
   <version>@project.version@</version>
   <packaging>jar</packaging>
   <description>Integration test</description>

--- a/src/it/empty-project/pom.xml
+++ b/src/it/empty-project/pom.xml
@@ -25,7 +25,7 @@ SOFTWARE.
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.github.volodya-lombrozo</groupId>
-  <artifactId>jtcop-it</artifactId>
+  <artifactId>jtcop-it-empty-project</artifactId>
   <version>@project.version@</version>
   <packaging>jar</packaging>
   <description>Integration test</description>

--- a/src/it/exclusions/pom.xml
+++ b/src/it/exclusions/pom.xml
@@ -25,7 +25,7 @@ SOFTWARE.
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.github.volodya-lombrozo</groupId>
-  <artifactId>jtcop-it</artifactId>
+  <artifactId>jtcop-it-exclusions</artifactId>
   <version>@project.version@</version>
   <packaging>jar</packaging>
   <description>Integration test</description>

--- a/src/it/parallel/pom.xml
+++ b/src/it/parallel/pom.xml
@@ -25,7 +25,7 @@ SOFTWARE.
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.github.volodya-lombrozo</groupId>
-  <artifactId>jtcop-it</artifactId>
+  <artifactId>jtcop-it-parallel</artifactId>
   <version>@project.version@</version>
   <packaging>jar</packaging>
   <description>

--- a/src/it/skip/pom.xml
+++ b/src/it/skip/pom.xml
@@ -25,7 +25,7 @@ SOFTWARE.
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.github.volodya-lombrozo</groupId>
-  <artifactId>jtcop-it</artifactId>
+  <artifactId>jtcop-it-skip</artifactId>
   <version>@project.version@</version>
   <packaging>jar</packaging>
   <description>Integration test</description>


### PR DESCRIPTION
In this PR I switched from the `nexus` publishing plugin to the `central` plugin.

Related to #472.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the Maven configuration and artifact identifiers for various integration test projects. It changes the server ID from `ossrh` to `central`, modifies artifact IDs to reflect their specific purposes, and updates the Maven plugin for publishing.

### Detailed summary
- Changed `server-id` from `ossrh` to `central` in `.github/workflows/maven.release.yml`.
- Updated artifact IDs in multiple `pom.xml` files:
  - `jtcop-it` to `jtcop-it-parallel`
  - `jtcop-it` to `jtcop-it-all-correct`
  - `jtcop-it` to `jtcop-it-all-incorrect`
  - `jtcop-it` to `jtcop-it-skip`
  - `jtcop-it` to `jtcop-it-assertions`
  - `jtcop-it` to `jtcop-it-exclusions`
  - `jtcop-it` to `jtcop-it-empty-project`
  - `jtcop-it` to `jtcop-it-correct-test-names`
  - `jtcop-it` to `jtcop-it-all-have-production-class`
- Updated error message formatting in `verify.groovy`.
- Removed `distributionManagement` section from `pom.xml`.
- Changed Maven plugin from `nexus-staging-maven-plugin` to `central-publishing-maven-plugin` with updated configuration options.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->