### PR TITLE
feat(#471): Allow `MatcherAssert.assertThat("msg", true)` cases in the `RuleAssertionMessage`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -125,9 +125,9 @@ SOFTWARE.
       <scope>compile</scope>
     </dependency>
     <dependency>
-        <groupId>com.github.javaparser</groupId>
-        <artifactId>javaparser-symbol-solver-core</artifactId>
-        <version>3.26.3</version>
+      <groupId>com.github.javaparser</groupId>
+      <artifactId>javaparser-symbol-solver-core</artifactId>
+      <version>3.26.3</version>
     </dependency>
     <dependency>
       <groupId>org.javassist</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -125,6 +125,11 @@ SOFTWARE.
       <scope>compile</scope>
     </dependency>
     <dependency>
+        <groupId>com.github.javaparser</groupId>
+        <artifactId>javaparser-symbol-solver-core</artifactId>
+        <version>3.26.3</version>
+    </dependency>
+    <dependency>
       <groupId>org.javassist</groupId>
       <artifactId>javassist</artifactId>
       <version>3.30.2-GA</version>

--- a/src/it/all-correct/pom.xml
+++ b/src/it/all-correct/pom.xml
@@ -40,6 +40,12 @@ SOFTWARE.
   </properties>
   <dependencies>
     <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest</artifactId>
+      <version>3.0</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-api</artifactId>
       <version>5.11.4</version>

--- a/src/it/all-correct/src/test/java/CorrectTests.java
+++ b/src/it/all-correct/src/test/java/CorrectTests.java
@@ -33,6 +33,7 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import java.util.Arrays;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.hamcrest.MatcherAssert;
 
 /**
  * Test class.

--- a/src/it/all-correct/src/test/java/CorrectTests.java
+++ b/src/it/all-correct/src/test/java/CorrectTests.java
@@ -42,7 +42,20 @@ import org.junit.jupiter.params.ParameterizedTest;
 public class CorrectTests {
 
     /**
-     * This is test for the issur #453.
+     * This is the test for the issue #471.
+     * You can read more about the issue right here:
+     * https://github.com/volodya-lombrozo/jtcop/issues/471
+     */
+    @Test
+    void routesNotWhenNotMatchAndNoSpareCmd() {
+        MatcherAssert.assertThat(
+            "Routes to command that not matched",
+            true
+        );
+    }
+
+    /**
+     * This is test for the issue #453.
      * You can read more about the issue right here:
      * https://github.com/volodya-lombrozo/jtcop/issues/453
      */

--- a/src/it/all-incorrect/README.md
+++ b/src/it/all-incorrect/README.md
@@ -1,0 +1,10 @@
+# All Incorrect Tests
+
+This test checks that `jtcop` might find incorrect tests and prints correct
+human-readable messages.
+
+To run this test, execute the following command:
+
+```bash
+mvn clean integration-test -Dinvoker.test=all-incorrect -DskipTests
+```

--- a/src/it/all-incorrect/pom.xml
+++ b/src/it/all-incorrect/pom.xml
@@ -40,6 +40,12 @@ SOFTWARE.
   </properties>
   <dependencies>
     <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest</artifactId>
+      <version>3.0</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-api</artifactId>
       <version>5.11.4</version>

--- a/src/it/all-incorrect/src/test/java/HamcrestAssertionsTest.java
+++ b/src/it/all-incorrect/src/test/java/HamcrestAssertionsTest.java
@@ -1,0 +1,38 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2022-2024 Volodya Lombrozo
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+import org.junit.jupiter.api.Test;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+
+final class HamcrestAssertionsTest {
+
+    @Test
+    void checksAssertionWithoutMessage() {
+        MatcherAssert.assertThat(
+            "1",
+            Matchers.equalTo("1")
+        );
+    }
+}

--- a/src/it/all-incorrect/verify.groovy
+++ b/src/it/all-incorrect/verify.groovy
@@ -40,5 +40,6 @@ String log = new File(basedir, 'build.log').text;
   "Method 'containsLineHitter' contains line hitter anti-pattern",
   "The test class 'UsesInheritenceTest.java' has the parent class 'AbstractTest'. Inheritance in tests is dangerous for maintainability",
   "Method 'testsSomething' contains excessive number of mocks: 3. max allowed: 1.",
+  "Method 'checksAssertionWithoutMessage' has assertion without message",
 ].each { assert log.contains(it): "Log doesn't contain ['$it']" }
 true

--- a/src/main/java/com/github/lombrozo/testnames/javaparser/AssertionOfHamcrest.java
+++ b/src/main/java/com/github/lombrozo/testnames/javaparser/AssertionOfHamcrest.java
@@ -26,7 +26,6 @@ package com.github.lombrozo.testnames.javaparser;
 import com.github.javaparser.ast.NodeList;
 import com.github.javaparser.ast.expr.Expression;
 import com.github.javaparser.ast.expr.MethodCallExpr;
-import com.github.javaparser.resolution.types.ResolvedType;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -75,8 +74,8 @@ public final class AssertionOfHamcrest implements ParsedAssertion {
             result = new StingExpression(first.get()).asString();
         } else if (arguments.size() == 2 && first.isPresent()) {
             final Optional<Expression> last = arguments.getLast();
-            if (last.isPresent() && last.get().calculateResolvedType().describe()
-                .equals("boolean")) {
+            if (last.isPresent() && "boolean"
+                .equals(last.get().calculateResolvedType().describe())) {
                 result = new StingExpression(first.get()).asString();
             } else {
                 result = Optional.empty();
@@ -84,14 +83,6 @@ public final class AssertionOfHamcrest implements ParsedAssertion {
         } else {
             result = Optional.empty();
         }
-//        final String describe = resolved.describe();
-//
-//        if (arguments.size() > 2 && first.isPresent()) {
-//            final ResolvedType type = first.get().calculateResolvedType();
-//            result = new StingExpression(first.get()).asString();
-//        } else {
-//            result = Optional.empty();
-//        }
         return result;
     }
 
@@ -122,13 +113,9 @@ public final class AssertionOfHamcrest implements ParsedAssertion {
      * @param type Type of hitter
      * @return True if contains hitter
      */
-    private static boolean containsHitter(
-        final Collection<String> args,
-        final String type
-    ) {
-        return (
-            args.contains(String.format("equalTo(%s)", type))
-                || args.contains(String.format("Matchers.equalTo(%s)", type))
-        ) && args.contains(type);
+    private static boolean containsHitter(final Collection<String> args, final String type) {
+        final String shortened = String.format("equalTo(%s)", type);
+        final String full = String.format("Matchers.equalTo(%s)", type);
+        return (args.contains(shortened) || args.contains(full)) && args.contains(type);
     }
 }

--- a/src/main/java/com/github/lombrozo/testnames/javaparser/AssertionOfHamcrest.java
+++ b/src/main/java/com/github/lombrozo/testnames/javaparser/AssertionOfHamcrest.java
@@ -26,6 +26,7 @@ package com.github.lombrozo.testnames.javaparser;
 import com.github.javaparser.ast.NodeList;
 import com.github.javaparser.ast.expr.Expression;
 import com.github.javaparser.ast.expr.MethodCallExpr;
+import com.github.javaparser.resolution.types.ResolvedType;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -72,9 +73,25 @@ public final class AssertionOfHamcrest implements ParsedAssertion {
         final Optional<Expression> first = arguments.getFirst();
         if (arguments.size() > 2 && first.isPresent()) {
             result = new StingExpression(first.get()).asString();
+        } else if (arguments.size() == 2 && first.isPresent()) {
+            final Optional<Expression> last = arguments.getLast();
+            if (last.isPresent() && last.get().calculateResolvedType().describe()
+                .equals("boolean")) {
+                result = new StingExpression(first.get()).asString();
+            } else {
+                result = Optional.empty();
+            }
         } else {
             result = Optional.empty();
         }
+//        final String describe = resolved.describe();
+//
+//        if (arguments.size() > 2 && first.isPresent()) {
+//            final ResolvedType type = first.get().calculateResolvedType();
+//            result = new StingExpression(first.get()).asString();
+//        } else {
+//            result = Optional.empty();
+//        }
         return result;
     }
 
@@ -112,6 +129,6 @@ public final class AssertionOfHamcrest implements ParsedAssertion {
         return (
             args.contains(String.format("equalTo(%s)", type))
                 || args.contains(String.format("Matchers.equalTo(%s)", type))
-            ) && args.contains(type);
+        ) && args.contains(type);
     }
 }

--- a/src/main/java/com/github/lombrozo/testnames/javaparser/JavaParserClass.java
+++ b/src/main/java/com/github/lombrozo/testnames/javaparser/JavaParserClass.java
@@ -36,6 +36,11 @@ import com.github.javaparser.ast.nodeTypes.NodeWithImplements;
 import com.github.javaparser.ast.nodeTypes.NodeWithMembers;
 import com.github.javaparser.ast.nodeTypes.NodeWithName;
 import com.github.javaparser.ast.type.ClassOrInterfaceType;
+import com.github.javaparser.resolution.SymbolResolver;
+import com.github.javaparser.symbolsolver.JavaSymbolSolver;
+import com.github.javaparser.symbolsolver.resolution.typesolvers.ClassLoaderTypeSolver;
+import com.github.javaparser.symbolsolver.resolution.typesolvers.CombinedTypeSolver;
+import com.github.javaparser.symbolsolver.resolution.typesolvers.ReflectionTypeSolver;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
@@ -296,6 +301,16 @@ final class JavaParserClass {
     private static CompilationUnit parse(final Path path) {
         try {
             StaticJavaParser.getParserConfiguration()
+                .setSymbolResolver(
+                    new JavaSymbolSolver(
+                        new CombinedTypeSolver(
+                            new ReflectionTypeSolver(),
+                            new ClassLoaderTypeSolver(
+                                JavaParserClass.class.getClassLoader()
+                            )
+                        )
+                    )
+                )
                 .setLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17);
             return JavaParserClass.parse(Files.newInputStream(path));
         } catch (final IOException ex) {
@@ -313,6 +328,12 @@ final class JavaParserClass {
      */
     private static CompilationUnit parse(final InputStream stream) {
         StaticJavaParser.getParserConfiguration()
+            .setSymbolResolver(new JavaSymbolSolver(new CombinedTypeSolver(
+                new ReflectionTypeSolver(),
+                new ClassLoaderTypeSolver(
+                    JavaParserClass.class.getClassLoader()
+                )
+            )))
             .setLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17);
         return StaticJavaParser.parse(stream);
     }

--- a/src/main/java/com/github/lombrozo/testnames/javaparser/JavaParserClass.java
+++ b/src/main/java/com/github/lombrozo/testnames/javaparser/JavaParserClass.java
@@ -301,16 +301,7 @@ final class JavaParserClass {
     private static CompilationUnit parse(final Path path) {
         try {
             StaticJavaParser.getParserConfiguration()
-                .setSymbolResolver(
-                    new JavaSymbolSolver(
-                        new CombinedTypeSolver(
-                            new ReflectionTypeSolver(),
-                            new ClassLoaderTypeSolver(
-                                JavaParserClass.class.getClassLoader()
-                            )
-                        )
-                    )
-                )
+                .setSymbolResolver(JavaParserClass.resolver())
                 .setLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17);
             return JavaParserClass.parse(Files.newInputStream(path));
         } catch (final IOException ex) {
@@ -328,13 +319,21 @@ final class JavaParserClass {
      */
     private static CompilationUnit parse(final InputStream stream) {
         StaticJavaParser.getParserConfiguration()
-            .setSymbolResolver(new JavaSymbolSolver(new CombinedTypeSolver(
-                new ReflectionTypeSolver(),
-                new ClassLoaderTypeSolver(
-                    JavaParserClass.class.getClassLoader()
-                )
-            )))
+            .setSymbolResolver(JavaParserClass.resolver())
             .setLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17);
         return StaticJavaParser.parse(stream);
+    }
+
+    /**
+     * Resolver for JavaParser.
+     * @return Symbol resolver.
+     */
+    private static SymbolResolver resolver() {
+        return new JavaSymbolSolver(
+            new CombinedTypeSolver(
+                new ReflectionTypeSolver(),
+                new ClassLoaderTypeSolver(Thread.currentThread().getContextClassLoader())
+            )
+        );
     }
 }

--- a/src/test/java/com/github/lombrozo/testnames/javaparser/AssertionOfHamcrestTest.java
+++ b/src/test/java/com/github/lombrozo/testnames/javaparser/AssertionOfHamcrestTest.java
@@ -141,6 +141,21 @@ final class AssertionOfHamcrestTest {
         );
     }
 
+    @Test
+    void findsExplanationMessageForBooleanCheck() {
+        final AssertionOfHamcrest first = JavaTestClasses.TEST_WITH_HAMCREST_ASSERTIONS
+            .method("checksTheCaseFrom471issue")
+            .statements()
+            .map(AssertionOfHamcrest::new)
+            .filter(AssertionOfHamcrest::isAssertion)
+            .findFirst().orElseThrow(() -> new AssertionError("not found assertion"));
+        MatcherAssert.assertThat(
+            String.format("We expect that assertion has a valid known message", first),
+            first.explanation().orElseThrow(() -> new AssertionError("explanation not found")),
+            Matchers.equalTo("Routes to command that not matched")
+        );
+    }
+
     @SuppressWarnings("PMD.JUnitTestContainsTooManyAsserts")
     @Test
     void checksCorrectlyOnLineHitters() {

--- a/src/test/resources/TestWithHamcrestAssertions.java
+++ b/src/test/resources/TestWithHamcrestAssertions.java
@@ -98,4 +98,12 @@ class TestWithHamcrestAssertions {
             "JUnit explanation"
         );
     }
+
+    @Test
+    void checksTheCaseFrom471issue(){
+        MatcherAssert.assertThat(
+            "Routes to command that not matched",
+            true
+        );
+    }
 }


### PR DESCRIPTION
In this PR, I fixed the bug related to Hamcrest assertions that take `boolean` as the last parameter.
Long story short, the following assertions used to be treated as invalid:

```java
MatcherAssert.assertThat(  
  "Routes to command that not matched",  
  new RouteFork<>(  
    new FkMatch(false),  
    new FkCmd(new FkSend())  
  ).route(new FkWrap()).isEmpty()
);  
```

Now, `jtcop` understands, that there is a message.


<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces new tests using `Hamcrest` assertions, updates dependencies for testing, and adds documentation for incorrect tests. It enhances the test suite by checking specific cases related to the issue #471 and improves the `JavaParserClass` with a new `SymbolResolver`.

### Detailed summary
- Added a new test method `checksTheCaseFrom471issue` in `TestWithHamcrestAssertions.java`.
- Updated `pom.xml` to include `javaparser-symbol-solver-core`.
- Added `hamcrest` dependency in `all-correct` and `all-incorrect` `pom.xml` files.
- Enhanced README in `all-incorrect` folder with test execution instructions.
- Improved `CorrectTests.java` to include a test for issue #471.
- Added `checksAssertionWithoutMessage` test in `HamcrestAssertionsTest.java`.
- Updated `JavaParserClass.java` to include a new `resolver` method for `SymbolResolver`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->