### PR TITLE
feat(#482): Use Project Classes for Symbol Resolution

### DIFF
--- a/src/it/all-correct/src/main/java/BooleanScalar.java
+++ b/src/it/all-correct/src/main/java/BooleanScalar.java
@@ -1,0 +1,17 @@
+public class BooleanScalar {
+
+    private final boolean val;
+
+    public BooleanScalar() {
+        this(true);
+    }
+
+    public BooleanScalar(final boolean val) {
+        this.val = val;
+    }
+
+    public boolean value() {
+        return val;
+    }
+
+}

--- a/src/it/all-correct/src/test/java/CorrectTests.java
+++ b/src/it/all-correct/src/test/java/CorrectTests.java
@@ -37,6 +37,7 @@ import org.hamcrest.MatcherAssert;
 
 /**
  * Test class.
+ *
  * @since 1.4
  */
 @SuppressWarnings("JTCOP.RuleAllTestsHaveProductionClass")
@@ -52,6 +53,19 @@ public class CorrectTests {
         MatcherAssert.assertThat(
             "Routes to command that not matched",
             true
+        );
+    }
+
+    /**
+     * This is the test for the issue #482.
+     * You can read more about the issue right here:
+     * https://github.com/volodya-lombrozo/jtcop/issues/482
+     */
+    @Test
+    void determinesTypesCorrectly() {
+        MatcherAssert.assertThat(
+            "Routes to command that not matched",
+            new BooleanScalar().value()
         );
     }
 

--- a/src/main/java/com/github/lombrozo/testnames/javaparser/JavaParserClass.java
+++ b/src/main/java/com/github/lombrozo/testnames/javaparser/JavaParserClass.java
@@ -37,11 +37,6 @@ import com.github.javaparser.ast.nodeTypes.NodeWithMembers;
 import com.github.javaparser.ast.nodeTypes.NodeWithName;
 import com.github.javaparser.ast.type.ClassOrInterfaceType;
 import com.github.javaparser.resolution.SymbolResolver;
-import com.github.javaparser.symbolsolver.JavaSymbolSolver;
-import com.github.javaparser.symbolsolver.resolution.typesolvers.ClassLoaderTypeSolver;
-import com.github.javaparser.symbolsolver.resolution.typesolvers.CombinedTypeSolver;
-import com.github.javaparser.symbolsolver.resolution.typesolvers.JavaParserTypeSolver;
-import com.github.javaparser.symbolsolver.resolution.typesolvers.ReflectionTypeSolver;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
@@ -74,6 +69,7 @@ final class JavaParserClass {
      * Ctor.
      *
      * @param path Input stream with java class.
+     * @param resolver Symbol resolver.
      */
     JavaParserClass(final Path path, final SymbolResolver resolver) {
         this(JavaParserClass.parse(path, resolver));
@@ -83,6 +79,7 @@ final class JavaParserClass {
      * Ctor.
      *
      * @param stream Input stream with java class.
+     * @param resolver Symbol resolver.
      */
     JavaParserClass(final InputStream stream, final SymbolResolver resolver) {
         this(JavaParserClass.parse(stream, resolver));
@@ -294,10 +291,10 @@ final class JavaParserClass {
      * @param unit Compilation unit.
      * @return Node with class.
      * @todo #187:90min Provide refactoring for JavaParserClass and TestClassJavaParser.
-     * The JavaParserClass and TestClassJavaParser classes are very similar. They share some logic
-     * and have similar methods. The refactoring should be provided to make the code more
-     * readable and maintainable. Also we have to count the different cases like records and
-     * package-info classes, inner classes and so on. For each case we must have a test.
+     *  The JavaParserClass and TestClassJavaParser classes are very similar. They share some logic
+     *  and have similar methods. The refactoring should be provided to make the code more
+     *  readable and maintainable. Also we have to count the different cases like records and
+     *  package-info classes, inner classes and so on. For each case we must have a test.
      */
     private static Node fromCompilation(final CompilationUnit unit) {
         final Queue<Node> all = unit.getChildNodes()
@@ -314,9 +311,10 @@ final class JavaParserClass {
      * Parse java by path.
      *
      * @param path Path to java file
+     * @param resolver Symbol resolver.
      * @return Compilation unit.
      */
-    private static CompilationUnit parse(final Path path, SymbolResolver resolver) {
+    private static CompilationUnit parse(final Path path, final SymbolResolver resolver) {
         try {
             StaticJavaParser.getParserConfiguration()
                 .setSymbolResolver(resolver)
@@ -334,6 +332,7 @@ final class JavaParserClass {
      * Parse java by input stream.
      *
      * @param stream Input stream.
+     * @param resolver Symbol resolver.
      * @return Compilation unit.
      */
     private static CompilationUnit parse(final InputStream stream, final SymbolResolver resolver) {

--- a/src/main/java/com/github/lombrozo/testnames/javaparser/JavaParserProject.java
+++ b/src/main/java/com/github/lombrozo/testnames/javaparser/JavaParserProject.java
@@ -149,24 +149,14 @@ public final class JavaParserProject implements Project {
         return res;
     }
 
-    private SymbolResolver projectResolver() {
-        final List<TypeSolver> solvers = new ArrayList(0);
-        solvers.add(new ReflectionTypeSolver());
-        solvers.add(new ClassLoaderTypeSolver(Thread.currentThread().getContextClassLoader()));
-        if (Files.exists(this.main)) {
-            solvers.add(new JavaParserTypeSolver(this.main));
-        }
-        if (Files.exists(this.test)) {
-            solvers.add(new JavaParserTypeSolver(this.test));
-        }
-
-        return new JavaSymbolSolver(new CombinedTypeSolver(solvers.toArray(new TypeSolver[0])));
-    }
-
     /**
      * Resolver for JavaParser.
      *
      * @return Symbol resolver.
+     * @todo #482:30min Refactor {@link JavaParserProject#resolver()} ()} method.
+     *  Currently we use this method in tests. We should invent more simple way to
+     *  create resolver for tests. Moreover, we duplicate SymbolResolver parameter
+     *  in many methods. We should refactor it.
      */
     static SymbolResolver resolver() {
         return new JavaSymbolSolver(
@@ -177,4 +167,20 @@ public final class JavaParserProject implements Project {
         );
     }
 
+    /**
+     * Resolver for JavaParser.
+     * @return Symbol resolver.
+     */
+    private SymbolResolver projectResolver() {
+        final List<TypeSolver> solvers = new ArrayList(0);
+        solvers.add(new ReflectionTypeSolver());
+        solvers.add(new ClassLoaderTypeSolver(Thread.currentThread().getContextClassLoader()));
+        if (Files.exists(this.main)) {
+            solvers.add(new JavaParserTypeSolver(this.main));
+        }
+        if (Files.exists(this.test)) {
+            solvers.add(new JavaParserTypeSolver(this.test));
+        }
+        return new JavaSymbolSolver(new CombinedTypeSolver(solvers.toArray(new TypeSolver[0])));
+    }
 }

--- a/src/main/java/com/github/lombrozo/testnames/javaparser/JavaParserTestClass.java
+++ b/src/main/java/com/github/lombrozo/testnames/javaparser/JavaParserTestClass.java
@@ -25,6 +25,7 @@
 package com.github.lombrozo.testnames.javaparser;
 
 import com.github.javaparser.ParseProblemException;
+import com.github.javaparser.resolution.SymbolResolver;
 import com.github.lombrozo.testnames.TestCase;
 import com.github.lombrozo.testnames.TestClass;
 import com.github.lombrozo.testnames.TestClassCharacteristics;
@@ -67,17 +68,19 @@ public final class JavaParserTestClass implements TestClass {
      * @param klass Path to the class
      */
     JavaParserTestClass(final Path klass) {
-        this(klass, JavaParserTestClass.parse(klass));
+        this(klass, JavaParserTestClass.parse(klass, JavaParserProject.resolver()));
     }
 
     /**
      * Ctor.
      *
      * @param klass Path to the class
-     * @param exclusions Rules excluded for entire project.
+     * @param exclusions Rules excluded for an entire project.
      */
-    JavaParserTestClass(final Path klass, final Collection<String> exclusions) {
-        this(klass, JavaParserTestClass.parse(klass), exclusions);
+    JavaParserTestClass(
+        final Path klass, final SymbolResolver resolver, final Collection<String> exclusions
+    ) {
+        this(klass, JavaParserTestClass.parse(klass, resolver), exclusions);
     }
 
     /**
@@ -86,8 +89,8 @@ public final class JavaParserTestClass implements TestClass {
      * @param klass Path to the class
      * @param stream Parsed Java class
      */
-    JavaParserTestClass(final Path klass, final InputStream stream) {
-        this(klass, JavaParserTestClass.parse(stream));
+    JavaParserTestClass(final Path klass, final SymbolResolver resolver, final InputStream stream) {
+        this(klass, JavaParserTestClass.parse(stream, resolver));
     }
 
     /**
@@ -105,14 +108,15 @@ public final class JavaParserTestClass implements TestClass {
      *
      * @param klass Path to the class
      * @param stream Parsed Java class
-     * @param exclusions Rules excluded for entire project.
+     * @param exclusions Rules excluded for an entire project.
      */
     JavaParserTestClass(
         final Path klass,
+        final SymbolResolver resolver,
         final InputStream stream,
         final Collection<String> exclusions
     ) {
-        this(klass, JavaParserTestClass.parse(stream), exclusions);
+        this(klass, JavaParserTestClass.parse(stream, resolver), exclusions);
     }
 
     /**
@@ -132,6 +136,7 @@ public final class JavaParserTestClass implements TestClass {
 
     /**
      * Constructor.
+     *
      * @param path Path to the class
      * @param unit Parsed class.
      * @param exclusions Rules excluded for entire project.
@@ -186,19 +191,23 @@ public final class JavaParserTestClass implements TestClass {
 
     /**
      * Parse Java class.
+     *
      * @param path Path to the class
      * @return Parsed class.
      */
-    private static Sticky<JavaParserClass> parse(final Path path) {
-        return new Sticky<>(() -> new JavaParserClass(path));
+    private static Sticky<JavaParserClass> parse(final Path path, final SymbolResolver resolver) {
+        return new Sticky<>(() -> new JavaParserClass(path, resolver));
     }
 
     /**
      * Parse Java class.
+     *
      * @param stream Raw class.
      * @return Parsed class.
      */
-    private static Sticky<JavaParserClass> parse(final InputStream stream) {
-        return new Sticky<>(() -> new JavaParserClass(stream));
+    private static Sticky<JavaParserClass> parse(
+        final InputStream stream, final SymbolResolver resolver
+    ) {
+        return new Sticky<>(() -> new JavaParserClass(stream, resolver));
     }
 }

--- a/src/main/java/com/github/lombrozo/testnames/javaparser/JavaParserTestClass.java
+++ b/src/main/java/com/github/lombrozo/testnames/javaparser/JavaParserTestClass.java
@@ -75,6 +75,7 @@ public final class JavaParserTestClass implements TestClass {
      * Ctor.
      *
      * @param klass Path to the class
+     * @param resolver Symbol resolver.
      * @param exclusions Rules excluded for an entire project.
      */
     JavaParserTestClass(
@@ -87,6 +88,7 @@ public final class JavaParserTestClass implements TestClass {
      * Ctor.
      *
      * @param klass Path to the class
+     * @param resolver Symbol resolver.
      * @param stream Parsed Java class
      */
     JavaParserTestClass(final Path klass, final SymbolResolver resolver, final InputStream stream) {
@@ -106,9 +108,11 @@ public final class JavaParserTestClass implements TestClass {
     /**
      * Ctor.
      *
-     * @param klass Path to the class
-     * @param stream Parsed Java class
+     * @param klass Path to the class.
+     * @param resolver Symbol resolver.
+     * @param stream Parsed Java class.
      * @param exclusions Rules excluded for an entire project.
+     * @checkstyle ParameterNumberCheck (5 lines)
      */
     JavaParserTestClass(
         final Path klass,
@@ -192,7 +196,8 @@ public final class JavaParserTestClass implements TestClass {
     /**
      * Parse Java class.
      *
-     * @param path Path to the class
+     * @param path Path to the class.
+     * @param resolver Symbol resolver.
      * @return Parsed class.
      */
     private static Sticky<JavaParserClass> parse(final Path path, final SymbolResolver resolver) {
@@ -203,6 +208,7 @@ public final class JavaParserTestClass implements TestClass {
      * Parse Java class.
      *
      * @param stream Raw class.
+     * @param resolver Symbol resolver.
      * @return Parsed class.
      */
     private static Sticky<JavaParserClass> parse(

--- a/src/test/java/com/github/lombrozo/testnames/javaparser/JavaParserTestClassTest.java
+++ b/src/test/java/com/github/lombrozo/testnames/javaparser/JavaParserTestClassTest.java
@@ -117,7 +117,11 @@ final class JavaParserTestClassTest {
     void throwsExceptionIfFileIsNotJava(@TempDir final Path temp) {
         Assertions.assertThrows(
             IllegalStateException.class,
-            () -> new JavaParserTestClass(temp, new InputStreamOf("Not Java")).all(),
+            () -> new JavaParserTestClass(
+                temp,
+                JavaParserProject.resolver(),
+                new InputStreamOf("Not Java")
+            ).all(),
             String.format(
                 "We expected that exception will be thrown, because file %s is not Java",
                 temp

--- a/src/test/java/com/github/lombrozo/testnames/javaparser/JavaTestClasses.java
+++ b/src/test/java/com/github/lombrozo/testnames/javaparser/JavaTestClasses.java
@@ -178,6 +178,7 @@ public enum JavaTestClasses {
     public JavaParserTestClass toTestClass(final String... suppressed) {
         return new JavaParserTestClass(
             Paths.get("."),
+            JavaParserProject.resolver(),
             this.inputStream(),
             Arrays.asList(suppressed)
         );
@@ -189,7 +190,7 @@ public enum JavaTestClasses {
      * @return Method.
      */
     JavaParserMethod method(final String name) {
-        return new JavaParserClass(this.inputStream())
+        return new JavaParserClass(this.inputStream(), JavaParserProject.resolver())
             .methods(new ByName(name))
             .findFirst()
             .orElseThrow(() -> new MethodNotFound(name));


### PR DESCRIPTION
In this PR I've changed `SymbolResolver` creation. Now it reads project classes to use them during symbol resolution.

Related to #482


<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces a new `BooleanScalar` class, enhances the `JavaParser` classes with a `SymbolResolver` parameter, and adds tests for issue #482. The changes improve type resolution and exception handling in the Java parsing process.

### Detailed summary
- Added `BooleanScalar` class with a constructor and `value()` method.
- Updated `JavaParserTestClass` constructors to accept a `SymbolResolver`.
- Modified `JavaParserClass` constructors to accept a `SymbolResolver`.
- Enhanced `JavaParserProject` with a static `resolver()` method.
- Updated parsing methods to use a `SymbolResolver`.
- Added a test method for issue #482 in `CorrectTests.java`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->