### PR TITLE
feat(#480): Ignore Classes Without Tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -107,6 +107,11 @@ SOFTWARE.
       <version>0.56.1</version>
     </dependency>
     <dependency>
+        <groupId>commons-io</groupId>
+        <artifactId>commons-io</artifactId>
+        <version>2.18.0</version>
+    </dependency>
+    <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-engine</artifactId>
       <version>5.11.4</version>

--- a/pom.xml
+++ b/pom.xml
@@ -172,6 +172,18 @@ SOFTWARE.
     </pluginManagement>
     <plugins>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.13.0</version>
+        <dependencies>
+          <dependency>
+            <groupId>org.apache.maven.shared</groupId>
+            <artifactId>maven-shared-incremental</artifactId>
+            <version>1.1</version>
+          </dependency>
+        </dependencies>
+      </plugin>
+      <plugin>
         <artifactId>maven-plugin-plugin</artifactId>
         <version>3.15.1</version>
         <executions>

--- a/pom.xml
+++ b/pom.xml
@@ -107,11 +107,6 @@ SOFTWARE.
       <version>0.56.1</version>
     </dependency>
     <dependency>
-        <groupId>commons-io</groupId>
-        <artifactId>commons-io</artifactId>
-        <version>2.18.0</version>
-    </dependency>
-    <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-engine</artifactId>
       <version>5.11.4</version>

--- a/src/it/all-correct/src/test/java/NotTest.java
+++ b/src/it/all-correct/src/test/java/NotTest.java
@@ -1,0 +1,27 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2022-2024 Volodya Lombrozo
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+public class NotTest {
+    // This is not a test
+}

--- a/src/main/java/com/github/lombrozo/testnames/javaparser/JavaParserClass.java
+++ b/src/main/java/com/github/lombrozo/testnames/javaparser/JavaParserClass.java
@@ -135,36 +135,8 @@ final class JavaParserClass {
     boolean isTest() {
         return !this.isAnnotation()
             && !this.isInterface()
-            && !this.isPackageInfo();
-    }
-
-    /**
-     * Checks if the class is an annotation.
-     *
-     * @return True if an annotation
-     */
-    boolean isAnnotation() {
-        return this.klass instanceof AnnotationDeclaration;
-    }
-
-    /**
-     * Checks if the class is an interface.
-     *
-     * @return True if an interface
-     */
-    boolean isInterface() {
-        return this.klass instanceof ClassOrInterfaceDeclaration
-            && this.cast().isInterface();
-    }
-
-    /**
-     * Checks if the class is a package-info.java.
-     *
-     * @return True if a package-info.java
-     */
-    boolean isPackageInfo() {
-        return this.klass instanceof ClassOrInterfaceDeclaration
-            && "empty".equals(this.cast().getNameAsString());
+            && !this.isPackageInfo()
+            && this.hasTests();
     }
 
     /**
@@ -225,6 +197,44 @@ final class JavaParserClass {
             );
         return unit.getPackageDeclaration()
             .map(NodeWithName::getNameAsString);
+    }
+
+    /**
+     * Whether the class has tests.
+     *
+     * @return True if the class has tests.
+     */
+    private boolean hasTests() {
+        return this.methods(new TestsOnly()).findAny().isPresent();
+    }
+
+    /**
+     * Checks if the class is an annotation.
+     *
+     * @return True if an annotation
+     */
+    private boolean isAnnotation() {
+        return this.klass instanceof AnnotationDeclaration;
+    }
+
+    /**
+     * Checks if the class is an interface.
+     *
+     * @return True if an interface
+     */
+    private boolean isInterface() {
+        return this.klass instanceof ClassOrInterfaceDeclaration
+            && this.cast().isInterface();
+    }
+
+    /**
+     * Checks if the class is a package-info.java.
+     *
+     * @return True if a package-info.java
+     */
+    private boolean isPackageInfo() {
+        return this.klass instanceof ClassOrInterfaceDeclaration
+            && "empty".equals(this.cast().getNameAsString());
     }
 
     /**

--- a/src/main/java/com/github/lombrozo/testnames/javaparser/JavaParserClass.java
+++ b/src/main/java/com/github/lombrozo/testnames/javaparser/JavaParserClass.java
@@ -126,7 +126,6 @@ final class JavaParserClass {
             .map(JavaParserMethod::new);
     }
 
-
     /**
      * Whether the class is a test.
      *
@@ -153,7 +152,8 @@ final class JavaParserClass {
                 res = def;
             } else {
                 res = definition.getExtendedTypes()
-                    .stream().findFirst()
+                    .stream()
+                    .findFirst()
                     .map(ClassOrInterfaceType::getNameAsString)
                     .orElse(def);
             }
@@ -313,10 +313,10 @@ final class JavaParserClass {
      * @param unit Compilation unit.
      * @return Node with class.
      * @todo #187:90min Provide refactoring for JavaParserClass and TestClassJavaParser.
-     * The JavaParserClass and TestClassJavaParser classes are very similar. They share some logic
-     * and have similar methods. The refactoring should be provided to make the code more
-     * readable and maintainable. Also we have to count the different cases like records and
-     * package-info classes, inner classes and so on. For each case we must have a test.
+     *  The JavaParserClass and TestClassJavaParser classes are very similar. They share some logic
+     *  and have similar methods. The refactoring should be provided to make the code more
+     *  readable and maintainable. Also we have to count the different cases like records and
+     *  package-info classes, inner classes and so on. For each case we must have a test.
      */
     private static Node fromCompilation(final CompilationUnit unit) {
         final Queue<Node> all = unit.getChildNodes()

--- a/src/main/java/com/github/lombrozo/testnames/javaparser/JavaParserClass.java
+++ b/src/main/java/com/github/lombrozo/testnames/javaparser/JavaParserClass.java
@@ -126,6 +126,18 @@ final class JavaParserClass {
             .map(JavaParserMethod::new);
     }
 
+
+    /**
+     * Whether the class is a test.
+     *
+     * @return True if the class is a test.
+     */
+    boolean isTest() {
+        return !this.isAnnotation()
+            && !this.isInterface()
+            && !this.isPackageInfo();
+    }
+
     /**
      * Checks if the class is an annotation.
      *
@@ -291,10 +303,10 @@ final class JavaParserClass {
      * @param unit Compilation unit.
      * @return Node with class.
      * @todo #187:90min Provide refactoring for JavaParserClass and TestClassJavaParser.
-     *  The JavaParserClass and TestClassJavaParser classes are very similar. They share some logic
-     *  and have similar methods. The refactoring should be provided to make the code more
-     *  readable and maintainable. Also we have to count the different cases like records and
-     *  package-info classes, inner classes and so on. For each case we must have a test.
+     * The JavaParserClass and TestClassJavaParser classes are very similar. They share some logic
+     * and have similar methods. The refactoring should be provided to make the code more
+     * readable and maintainable. Also we have to count the different cases like records and
+     * package-info classes, inner classes and so on. For each case we must have a test.
      */
     private static Node fromCompilation(final CompilationUnit unit) {
         final Queue<Node> all = unit.getChildNodes()

--- a/src/main/java/com/github/lombrozo/testnames/javaparser/JavaParserProject.java
+++ b/src/main/java/com/github/lombrozo/testnames/javaparser/JavaParserProject.java
@@ -143,10 +143,10 @@ public final class JavaParserProject implements Project {
      * Resolver for JavaParser.
      *
      * @return Symbol resolver.
-     * @todo #482:30min Refactor {@link JavaParserProject#resolver()} ()} method.
-     * Currently we use this method in tests. We should invent more simple way to
-     * create resolver for tests. Moreover, we duplicate SymbolResolver parameter
-     * in many methods. We should refactor it.
+     * @todo #482:30min Refactor {@link JavaParserProject#resolver()} method.
+     *  Currently we use this method in tests. We should invent more simple way to
+     *  create resolver for tests. Moreover, we duplicate SymbolResolver parameter
+     *  in many methods. We should refactor it.
      */
     static SymbolResolver resolver() {
         return new JavaSymbolSolver(

--- a/src/main/java/com/github/lombrozo/testnames/javaparser/JavaParserProject.java
+++ b/src/main/java/com/github/lombrozo/testnames/javaparser/JavaParserProject.java
@@ -121,17 +121,7 @@ public final class JavaParserProject implements Project {
                     .filter(Files::exists)
                     .filter(Files::isRegularFile)
                     .filter(path -> path.toString().endsWith(".java"))
-                    .filter(
-                        path -> {
-                            final JavaParserClass parsed = new JavaParserClass(
-                                path,
-                                this.projectResolver()
-                            );
-                            return !parsed.isAnnotation()
-                                && !parsed.isInterface()
-                                && !parsed.isPackageInfo();
-                        }
-                    )
+                    .filter(path -> new JavaParserClass(path, this.projectResolver()).isTest())
                     .map(
                         klass -> new JavaParserTestClass(
                             klass,
@@ -154,9 +144,9 @@ public final class JavaParserProject implements Project {
      *
      * @return Symbol resolver.
      * @todo #482:30min Refactor {@link JavaParserProject#resolver()} ()} method.
-     *  Currently we use this method in tests. We should invent more simple way to
-     *  create resolver for tests. Moreover, we duplicate SymbolResolver parameter
-     *  in many methods. We should refactor it.
+     * Currently we use this method in tests. We should invent more simple way to
+     * create resolver for tests. Moreover, we duplicate SymbolResolver parameter
+     * in many methods. We should refactor it.
      */
     static SymbolResolver resolver() {
         return new JavaSymbolSolver(
@@ -169,6 +159,7 @@ public final class JavaParserProject implements Project {
 
     /**
      * Resolver for JavaParser.
+     *
      * @return Symbol resolver.
      */
     private SymbolResolver projectResolver() {

--- a/src/main/java/com/github/lombrozo/testnames/javaparser/TestsOnly.java
+++ b/src/main/java/com/github/lombrozo/testnames/javaparser/TestsOnly.java
@@ -41,11 +41,17 @@ final class TestsOnly implements Predicate<MethodDeclaration> {
 
     @Override
     public boolean test(final MethodDeclaration declaration) {
-        return !declaration.isPrivate()
-            &&
-            (
-                declaration.isAnnotationPresent("Test")
-                    || declaration.isAnnotationPresent("ParameterizedTest")
-            );
+        return !declaration.isPrivate() && TestsOnly.withTestAnnotation(declaration);
+    }
+
+    /**
+     * Check if the method has a test annotation.
+     *
+     * @param declaration The method declaration.
+     * @return True if the method has a test annotation.
+     */
+    private static boolean withTestAnnotation(final MethodDeclaration declaration) {
+        return declaration.isAnnotationPresent("Test")
+            || declaration.isAnnotationPresent("ParameterizedTest");
     }
 }

--- a/src/test/java/com/github/lombrozo/testnames/javaparser/JavaParserProjectTest.java
+++ b/src/test/java/com/github/lombrozo/testnames/javaparser/JavaParserProjectTest.java
@@ -74,26 +74,13 @@ final class JavaParserProjectTest {
     }
 
     @Test
-    void returnsNotProductionClasses(@TempDir final Path tmp) throws IOException {
+    void ignoresClassesWithoutTests(@TempDir final Path tmp) throws IOException {
         final String name = "TestClass.java";
         Files.write(tmp.resolve(name), "final class TestClass{}".getBytes(StandardCharsets.UTF_8));
-        final Collection<TestClass> classes = new JavaParserProject(
-            tmp,
-            tmp
-        ).testClasses();
         MatcherAssert.assertThat(
-            String.format("Project has to have exactly one test class, but was %d", classes.size()),
-            classes,
-            Matchers.hasSize(1)
-        );
-        MatcherAssert.assertThat(
-            String.format(
-                "Test class name is wrong. Expected: %s, but was: %s",
-                name,
-                classes.iterator().next().name()
-            ),
-            classes.iterator().next().name(),
-            Matchers.equalTo(name)
+            "We expect that project has to ignore classes without tests",
+            new JavaParserProject(tmp, tmp).testClasses(),
+            Matchers.empty()
         );
     }
 
@@ -194,35 +181,23 @@ final class JavaParserProjectTest {
             JavaTestClasses.JUNIT_CALLBACK.inputStream(),
             temp.resolve("JUnitCallback.java")
         );
-        final Collection<TestClass> classes = new JavaParserProject(temp, temp).testClasses();
         MatcherAssert.assertThat(
-            String.format("Project has to return exactly one class, but was: %s", classes),
-            classes,
-            Matchers.hasSize(1)
-        );
-        MatcherAssert.assertThat(
-            "Class has to be JUnit extension, but was not",
-            classes.iterator().next().characteristics().isJUnitExtension(),
-            Matchers.is(true)
+            "We expect that JUnit callback class won't be returned as a test class",
+            new JavaParserProject(temp, temp).testClasses(),
+            Matchers.empty()
         );
     }
 
     @Test
-    void returnsClassParentsForJUnitExtension(@TempDir final Path temp) throws IOException {
+    void ignoresJUnitExtension(@TempDir final Path temp) throws IOException {
         Files.copy(
             JavaTestClasses.JUNIT_CONDITION.inputStream(),
             temp.resolve("JUnitCondition.java")
         );
-        final Collection<TestClass> classes = new JavaParserProject(temp, temp).testClasses();
         MatcherAssert.assertThat(
-            String.format("Project has to return exactly one class, but was: %s", classes),
-            classes,
-            Matchers.hasSize(1)
-        );
-        MatcherAssert.assertThat(
-            "Class has to be JUnit extension, but was not",
-            classes.iterator().next().characteristics().isJUnitExtension(),
-            Matchers.is(true)
+            "We expect that JUnit execution condition won't be returned as a test class",
+            new JavaParserProject(temp, temp).testClasses(),
+            Matchers.empty()
         );
     }
 }


### PR DESCRIPTION
In this PR I've added the filter that checks if a class has test methods. If there are none of them, we just skip this class.

Related to #480

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing the functionality of the Java parser to better identify test classes and methods, while also updating the `pom.xml` to include the `maven-compiler-plugin`. Additionally, it improves test case naming and organization for clarity.

### Detailed summary
- Added `maven-compiler-plugin` to `pom.xml`.
- Refactored `test` method in `TestsOnly` to use `withTestAnnotation`.
- Introduced `withTestAnnotation` method for better annotation checking.
- Updated `JavaParserClass` to include `isTest` method.
- Added `hasTests` method to check for test methods.
- Renamed test methods for clarity in `JavaParserProjectTest`.
- Improved comments and documentation throughout the code.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->