### PR TITLE
chore: update license

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2022-2024 Volodya Lombrozo
+Copyright (c) 2022-2025 Volodya Lombrozo
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
 <!--
 MIT License
 
-Copyright (c) 2022-2024 Volodya Lombrozo
+Copyright (c) 2022-2025 Volodya Lombrozo
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/it/all-correct/pom.xml
+++ b/src/it/all-correct/pom.xml
@@ -2,7 +2,7 @@
 <!--
 MIT License
 
-Copyright (c) 2022-2024 Volodya Lombrozo
+Copyright (c) 2022-2025 Volodya Lombrozo
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/it/all-correct/src/test/java/CorrectTests.java
+++ b/src/it/all-correct/src/test/java/CorrectTests.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2022-2024 Volodya Lombrozo
+ * Copyright (c) 2022-2025 Volodya Lombrozo
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/it/all-correct/src/test/java/NotTest.java
+++ b/src/it/all-correct/src/test/java/NotTest.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2022-2024 Volodya Lombrozo
+ * Copyright (c) 2022-2025 Volodya Lombrozo
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/it/all-have-production-class/pom.xml
+++ b/src/it/all-have-production-class/pom.xml
@@ -2,7 +2,7 @@
 <!--
 MIT License
 
-Copyright (c) 2022-2024 Volodya Lombrozo
+Copyright (c) 2022-2025 Volodya Lombrozo
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/it/all-have-production-class/src/main/java/ComplaintClass.java
+++ b/src/it/all-have-production-class/src/main/java/ComplaintClass.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2022-2024 Volodya Lombrozo
+ * Copyright (c) 2022-2025 Volodya Lombrozo
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/it/all-have-production-class/src/test/java/CorrectTest.java
+++ b/src/it/all-have-production-class/src/test/java/CorrectTest.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2022-2024 Volodya Lombrozo
+ * Copyright (c) 2022-2025 Volodya Lombrozo
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/it/all-have-production-class/src/test/java/EOorg/EOeolang/EOboolEOnotTest.java
+++ b/src/it/all-have-production-class/src/test/java/EOorg/EOeolang/EOboolEOnotTest.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2022-2024 Volodya Lombrozo
+ * Copyright (c) 2022-2025 Volodya Lombrozo
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/it/all-have-production-class/src/test/java/JUnitAfterAllCallback.java
+++ b/src/it/all-have-production-class/src/test/java/JUnitAfterAllCallback.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2022-2024 Volodya Lombrozo
+ * Copyright (c) 2022-2025 Volodya Lombrozo
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/it/all-have-production-class/src/test/java/JUnitAfterEachCallback.java
+++ b/src/it/all-have-production-class/src/test/java/JUnitAfterEachCallback.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2022-2024 Volodya Lombrozo
+ * Copyright (c) 2022-2025 Volodya Lombrozo
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/it/all-have-production-class/src/test/java/JUnitBeforeAllCallback.java
+++ b/src/it/all-have-production-class/src/test/java/JUnitBeforeAllCallback.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2022-2024 Volodya Lombrozo
+ * Copyright (c) 2022-2025 Volodya Lombrozo
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/it/all-have-production-class/src/test/java/JUnitBeforeEachCallback.java
+++ b/src/it/all-have-production-class/src/test/java/JUnitBeforeEachCallback.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2022-2024 Volodya Lombrozo
+ * Copyright (c) 2022-2025 Volodya Lombrozo
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/it/all-have-production-class/src/test/java/JUnitCondition.java
+++ b/src/it/all-have-production-class/src/test/java/JUnitCondition.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2022-2024 Volodya Lombrozo
+ * Copyright (c) 2022-2025 Volodya Lombrozo
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/it/all-have-production-class/src/test/java/JUnitParameterResolver.java
+++ b/src/it/all-have-production-class/src/test/java/JUnitParameterResolver.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2022-2024 Volodya Lombrozo
+ * Copyright (c) 2022-2025 Volodya Lombrozo
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/it/all-have-production-class/src/test/java/JavaGeneratedTest.java
+++ b/src/it/all-have-production-class/src/test/java/JavaGeneratedTest.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2022-2024 Volodya Lombrozo
+ * Copyright (c) 2022-2025 Volodya Lombrozo
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/it/all-have-production-class/src/test/java/MyAnnotation.java
+++ b/src/it/all-have-production-class/src/test/java/MyAnnotation.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2022-2024 Volodya Lombrozo
+ * Copyright (c) 2022-2025 Volodya Lombrozo
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/it/all-have-production-class/src/test/java/MyInterface.java
+++ b/src/it/all-have-production-class/src/test/java/MyInterface.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2022-2024 Volodya Lombrozo
+ * Copyright (c) 2022-2025 Volodya Lombrozo
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/it/all-have-production-class/src/test/java/RuleNameTest.java
+++ b/src/it/all-have-production-class/src/test/java/RuleNameTest.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2022-2024 Volodya Lombrozo
+ * Copyright (c) 2022-2025 Volodya Lombrozo
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/it/all-have-production-class/src/test/java/SuppressedAnnotation.java
+++ b/src/it/all-have-production-class/src/test/java/SuppressedAnnotation.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2022-2024 Volodya Lombrozo
+ * Copyright (c) 2022-2025 Volodya Lombrozo
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/it/all-have-production-class/src/test/java/SuppressedInterface.java
+++ b/src/it/all-have-production-class/src/test/java/SuppressedInterface.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2022-2024 Volodya Lombrozo
+ * Copyright (c) 2022-2025 Volodya Lombrozo
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/it/all-have-production-class/src/test/java/SuppressedTest.java
+++ b/src/it/all-have-production-class/src/test/java/SuppressedTest.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2022-2024 Volodya Lombrozo
+ * Copyright (c) 2022-2025 Volodya Lombrozo
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/it/all-have-production-class/src/test/java/it/CorrectITCase.java
+++ b/src/it/all-have-production-class/src/test/java/it/CorrectITCase.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2022-2024 Volodya Lombrozo
+ * Copyright (c) 2022-2025 Volodya Lombrozo
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/it/all-have-production-class/src/test/java/package-info.java
+++ b/src/it/all-have-production-class/src/test/java/package-info.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2022-2024 Volodya Lombrozo
+ * Copyright (c) 2022-2025 Volodya Lombrozo
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/it/all-have-production-class/target/generated-sources/com/github/lombrozo/testnames/JavaGenerated.java
+++ b/src/it/all-have-production-class/target/generated-sources/com/github/lombrozo/testnames/JavaGenerated.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2022-2024 Volodya Lombrozo
+ * Copyright (c) 2022-2025 Volodya Lombrozo
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/it/all-have-production-class/verify.groovy
+++ b/src/it/all-have-production-class/verify.groovy
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2022-2024 Volodya Lombrozo
+ * Copyright (c) 2022-2025 Volodya Lombrozo
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/it/all-incorrect/pom.xml
+++ b/src/it/all-incorrect/pom.xml
@@ -2,7 +2,7 @@
 <!--
 MIT License
 
-Copyright (c) 2022-2024 Volodya Lombrozo
+Copyright (c) 2022-2025 Volodya Lombrozo
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/it/all-incorrect/src/test/java/AbstractTest.java
+++ b/src/it/all-incorrect/src/test/java/AbstractTest.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2022-2024 Volodya Lombrozo
+ * Copyright (c) 2022-2025 Volodya Lombrozo
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/it/all-incorrect/src/test/java/ForbiddenWordTest.java
+++ b/src/it/all-incorrect/src/test/java/ForbiddenWordTest.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2022-2024 Volodya Lombrozo
+ * Copyright (c) 2022-2025 Volodya Lombrozo
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/it/all-incorrect/src/test/java/HamcrestAssertionsTest.java
+++ b/src/it/all-incorrect/src/test/java/HamcrestAssertionsTest.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2022-2024 Volodya Lombrozo
+ * Copyright (c) 2022-2025 Volodya Lombrozo
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/it/all-incorrect/src/test/java/LineHitterTest.java
+++ b/src/it/all-incorrect/src/test/java/LineHitterTest.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2022-2024 Volodya Lombrozo
+ * Copyright (c) 2022-2025 Volodya Lombrozo
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/it/all-incorrect/src/test/java/MockeryTest.java
+++ b/src/it/all-incorrect/src/test/java/MockeryTest.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2022-2024 Volodya Lombrozo
+ * Copyright (c) 2022-2025 Volodya Lombrozo
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/it/all-incorrect/src/test/java/UsesInheritenceTest.java
+++ b/src/it/all-incorrect/src/test/java/UsesInheritenceTest.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2022-2024 Volodya Lombrozo
+ * Copyright (c) 2022-2025 Volodya Lombrozo
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/it/all-incorrect/verify.groovy
+++ b/src/it/all-incorrect/verify.groovy
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2022-2024 Volodya Lombrozo
+ * Copyright (c) 2022-2025 Volodya Lombrozo
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/it/assertions/pom.xml
+++ b/src/it/assertions/pom.xml
@@ -2,7 +2,7 @@
 <!--
 MIT License
 
-Copyright (c) 2022-2024 Volodya Lombrozo
+Copyright (c) 2022-2025 Volodya Lombrozo
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/it/assertions/src/test/java/AssertionsTest.java
+++ b/src/it/assertions/src/test/java/AssertionsTest.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2022-2024 Volodya Lombrozo
+ * Copyright (c) 2022-2025 Volodya Lombrozo
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/it/assertions/verify.groovy
+++ b/src/it/assertions/verify.groovy
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2022-2024 Volodya Lombrozo
+ * Copyright (c) 2022-2025 Volodya Lombrozo
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/it/correct-test-names/pom.xml
+++ b/src/it/correct-test-names/pom.xml
@@ -2,7 +2,7 @@
 <!--
 MIT License
 
-Copyright (c) 2022-2024 Volodya Lombrozo
+Copyright (c) 2022-2025 Volodya Lombrozo
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/it/correct-test-names/src/test/java/CorrectNameIT.java
+++ b/src/it/correct-test-names/src/test/java/CorrectNameIT.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2022-2024 Volodya Lombrozo
+ * Copyright (c) 2022-2025 Volodya Lombrozo
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/it/correct-test-names/src/test/java/CorrectNameITCase.java
+++ b/src/it/correct-test-names/src/test/java/CorrectNameITCase.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2022-2024 Volodya Lombrozo
+ * Copyright (c) 2022-2025 Volodya Lombrozo
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/it/correct-test-names/src/test/java/CorrectNameTest.java
+++ b/src/it/correct-test-names/src/test/java/CorrectNameTest.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2022-2024 Volodya Lombrozo
+ * Copyright (c) 2022-2025 Volodya Lombrozo
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/it/correct-test-names/src/test/java/CorrectNameTestCase.java
+++ b/src/it/correct-test-names/src/test/java/CorrectNameTestCase.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2022-2024 Volodya Lombrozo
+ * Copyright (c) 2022-2025 Volodya Lombrozo
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/it/correct-test-names/src/test/java/CorrectNameTests.java
+++ b/src/it/correct-test-names/src/test/java/CorrectNameTests.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2022-2024 Volodya Lombrozo
+ * Copyright (c) 2022-2025 Volodya Lombrozo
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/it/correct-test-names/src/test/java/ITCaseCorrectName.java
+++ b/src/it/correct-test-names/src/test/java/ITCaseCorrectName.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2022-2024 Volodya Lombrozo
+ * Copyright (c) 2022-2025 Volodya Lombrozo
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/it/correct-test-names/src/test/java/ITCorrectName.java
+++ b/src/it/correct-test-names/src/test/java/ITCorrectName.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2022-2024 Volodya Lombrozo
+ * Copyright (c) 2022-2025 Volodya Lombrozo
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/it/correct-test-names/src/test/java/IncorrectITCaseName.java
+++ b/src/it/correct-test-names/src/test/java/IncorrectITCaseName.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2022-2024 Volodya Lombrozo
+ * Copyright (c) 2022-2025 Volodya Lombrozo
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/it/correct-test-names/src/test/java/IncorrectITName.java
+++ b/src/it/correct-test-names/src/test/java/IncorrectITName.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2022-2024 Volodya Lombrozo
+ * Copyright (c) 2022-2025 Volodya Lombrozo
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/it/correct-test-names/src/test/java/IncorrectName.java
+++ b/src/it/correct-test-names/src/test/java/IncorrectName.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2022-2024 Volodya Lombrozo
+ * Copyright (c) 2022-2025 Volodya Lombrozo
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/it/correct-test-names/src/test/java/IncorrectTestCaseName.java
+++ b/src/it/correct-test-names/src/test/java/IncorrectTestCaseName.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2022-2024 Volodya Lombrozo
+ * Copyright (c) 2022-2025 Volodya Lombrozo
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/it/correct-test-names/src/test/java/IncorrectTestName.java
+++ b/src/it/correct-test-names/src/test/java/IncorrectTestName.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2022-2024 Volodya Lombrozo
+ * Copyright (c) 2022-2025 Volodya Lombrozo
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/it/correct-test-names/src/test/java/IncorrectTestsName.java
+++ b/src/it/correct-test-names/src/test/java/IncorrectTestsName.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2022-2024 Volodya Lombrozo
+ * Copyright (c) 2022-2025 Volodya Lombrozo
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/it/correct-test-names/src/test/java/TestCaseCorrectName.java
+++ b/src/it/correct-test-names/src/test/java/TestCaseCorrectName.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2022-2024 Volodya Lombrozo
+ * Copyright (c) 2022-2025 Volodya Lombrozo
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/it/correct-test-names/src/test/java/TestCorrectName.java
+++ b/src/it/correct-test-names/src/test/java/TestCorrectName.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2022-2024 Volodya Lombrozo
+ * Copyright (c) 2022-2025 Volodya Lombrozo
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/it/correct-test-names/src/test/java/TestsCorrectName.java
+++ b/src/it/correct-test-names/src/test/java/TestsCorrectName.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2022-2024 Volodya Lombrozo
+ * Copyright (c) 2022-2025 Volodya Lombrozo
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/it/correct-test-names/verify.groovy
+++ b/src/it/correct-test-names/verify.groovy
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2022-2024 Volodya Lombrozo
+ * Copyright (c) 2022-2025 Volodya Lombrozo
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/it/empty-project/pom.xml
+++ b/src/it/empty-project/pom.xml
@@ -2,7 +2,7 @@
 <!--
 MIT License
 
-Copyright (c) 2022-2024 Volodya Lombrozo
+Copyright (c) 2022-2025 Volodya Lombrozo
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/it/empty-project/target/generated-test-sources/com/github/lombrozo/testnames/CorrectNameIT.java
+++ b/src/it/empty-project/target/generated-test-sources/com/github/lombrozo/testnames/CorrectNameIT.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2022-2024 Volodya Lombrozo
+ * Copyright (c) 2022-2025 Volodya Lombrozo
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/it/empty-project/verify.groovy
+++ b/src/it/empty-project/verify.groovy
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2022-2024 Volodya Lombrozo
+ * Copyright (c) 2022-2025 Volodya Lombrozo
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/it/exclusions/pom.xml
+++ b/src/it/exclusions/pom.xml
@@ -2,7 +2,7 @@
 <!--
 MIT License
 
-Copyright (c) 2022-2024 Volodya Lombrozo
+Copyright (c) 2022-2025 Volodya Lombrozo
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/it/exclusions/src/test/java/MockeryTest.java
+++ b/src/it/exclusions/src/test/java/MockeryTest.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2022-2024 Volodya Lombrozo
+ * Copyright (c) 2022-2025 Volodya Lombrozo
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/it/exclusions/src/test/java/TestDoesntHaveProductionClass.java
+++ b/src/it/exclusions/src/test/java/TestDoesntHaveProductionClass.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2022-2024 Volodya Lombrozo
+ * Copyright (c) 2022-2025 Volodya Lombrozo
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/it/exclusions/verify.groovy
+++ b/src/it/exclusions/verify.groovy
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2022-2024 Volodya Lombrozo
+ * Copyright (c) 2022-2025 Volodya Lombrozo
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/it/parallel/invoker.properties
+++ b/src/it/parallel/invoker.properties
@@ -1,6 +1,6 @@
 # MIT License
 #
-# Copyright (c) 2022-2024 Volodya Lombrozo
+# Copyright (c) 2022-2025 Volodya Lombrozo
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/src/it/parallel/pom.xml
+++ b/src/it/parallel/pom.xml
@@ -2,7 +2,7 @@
 <!--
 MIT License
 
-Copyright (c) 2022-2024 Volodya Lombrozo
+Copyright (c) 2022-2025 Volodya Lombrozo
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/it/parallel/src/main/java/Production.java
+++ b/src/it/parallel/src/main/java/Production.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2022-2024 Volodya Lombrozo
+ * Copyright (c) 2022-2025 Volodya Lombrozo
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/it/parallel/src/test/java/ProductionTest.java
+++ b/src/it/parallel/src/test/java/ProductionTest.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2022-2024 Volodya Lombrozo
+ * Copyright (c) 2022-2025 Volodya Lombrozo
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/it/parallel/verify.groovy
+++ b/src/it/parallel/verify.groovy
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2022-2024 Volodya Lombrozo
+ * Copyright (c) 2022-2025 Volodya Lombrozo
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/it/settings.xml
+++ b/src/it/settings.xml
@@ -2,7 +2,7 @@
 <!--
 MIT License
 
-Copyright (c) 2022-2024 Volodya Lombrozo
+Copyright (c) 2022-2025 Volodya Lombrozo
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/it/skip/pom.xml
+++ b/src/it/skip/pom.xml
@@ -2,7 +2,7 @@
 <!--
 MIT License
 
-Copyright (c) 2022-2024 Volodya Lombrozo
+Copyright (c) 2022-2025 Volodya Lombrozo
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/it/skip/verify.groovy
+++ b/src/it/skip/verify.groovy
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2022-2024 Volodya Lombrozo
+ * Copyright (c) 2022-2025 Volodya Lombrozo
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/github/lombrozo/testnames/Assertion.java
+++ b/src/main/java/com/github/lombrozo/testnames/Assertion.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2022-2024 Volodya Lombrozo
+ * Copyright (c) 2022-2025 Volodya Lombrozo
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/github/lombrozo/testnames/Complaint.java
+++ b/src/main/java/com/github/lombrozo/testnames/Complaint.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2022-2024 Volodya Lombrozo
+ * Copyright (c) 2022-2025 Volodya Lombrozo
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/github/lombrozo/testnames/Cop.java
+++ b/src/main/java/com/github/lombrozo/testnames/Cop.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2022-2024 Volodya Lombrozo
+ * Copyright (c) 2022-2025 Volodya Lombrozo
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/github/lombrozo/testnames/JUnitExtension.java
+++ b/src/main/java/com/github/lombrozo/testnames/JUnitExtension.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2022-2024 Volodya Lombrozo
+ * Copyright (c) 2022-2025 Volodya Lombrozo
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/github/lombrozo/testnames/Parameters.java
+++ b/src/main/java/com/github/lombrozo/testnames/Parameters.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2022-2024 Volodya Lombrozo
+ * Copyright (c) 2022-2025 Volodya Lombrozo
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/github/lombrozo/testnames/ProductionClass.java
+++ b/src/main/java/com/github/lombrozo/testnames/ProductionClass.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2022-2024 Volodya Lombrozo
+ * Copyright (c) 2022-2025 Volodya Lombrozo
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/github/lombrozo/testnames/Project.java
+++ b/src/main/java/com/github/lombrozo/testnames/Project.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2022-2024 Volodya Lombrozo
+ * Copyright (c) 2022-2025 Volodya Lombrozo
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/github/lombrozo/testnames/ProjectWithoutJUnitExtensions.java
+++ b/src/main/java/com/github/lombrozo/testnames/ProjectWithoutJUnitExtensions.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2022-2024 Volodya Lombrozo
+ * Copyright (c) 2022-2025 Volodya Lombrozo
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/github/lombrozo/testnames/Rule.java
+++ b/src/main/java/com/github/lombrozo/testnames/Rule.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2022-2024 Volodya Lombrozo
+ * Copyright (c) 2022-2025 Volodya Lombrozo
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/github/lombrozo/testnames/RuleName.java
+++ b/src/main/java/com/github/lombrozo/testnames/RuleName.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2022-2024 Volodya Lombrozo
+ * Copyright (c) 2022-2025 Volodya Lombrozo
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/github/lombrozo/testnames/Suspect.java
+++ b/src/main/java/com/github/lombrozo/testnames/Suspect.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2022-2024 Volodya Lombrozo
+ * Copyright (c) 2022-2025 Volodya Lombrozo
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/github/lombrozo/testnames/TestCase.java
+++ b/src/main/java/com/github/lombrozo/testnames/TestCase.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2022-2024 Volodya Lombrozo
+ * Copyright (c) 2022-2025 Volodya Lombrozo
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/github/lombrozo/testnames/TestClass.java
+++ b/src/main/java/com/github/lombrozo/testnames/TestClass.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2022-2024 Volodya Lombrozo
+ * Copyright (c) 2022-2025 Volodya Lombrozo
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/github/lombrozo/testnames/TestClassCharacteristics.java
+++ b/src/main/java/com/github/lombrozo/testnames/TestClassCharacteristics.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2022-2024 Volodya Lombrozo
+ * Copyright (c) 2022-2025 Volodya Lombrozo
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/github/lombrozo/testnames/ValidateMojo.java
+++ b/src/main/java/com/github/lombrozo/testnames/ValidateMojo.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2022-2024 Volodya Lombrozo
+ * Copyright (c) 2022-2025 Volodya Lombrozo
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/github/lombrozo/testnames/bytecode/BytecodeClass.java
+++ b/src/main/java/com/github/lombrozo/testnames/bytecode/BytecodeClass.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2022-2024 Volodya Lombrozo
+ * Copyright (c) 2022-2025 Volodya Lombrozo
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/github/lombrozo/testnames/bytecode/BytecodeProductionClass.java
+++ b/src/main/java/com/github/lombrozo/testnames/bytecode/BytecodeProductionClass.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2022-2024 Volodya Lombrozo
+ * Copyright (c) 2022-2025 Volodya Lombrozo
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/github/lombrozo/testnames/bytecode/BytecodeProject.java
+++ b/src/main/java/com/github/lombrozo/testnames/bytecode/BytecodeProject.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2022-2024 Volodya Lombrozo
+ * Copyright (c) 2022-2025 Volodya Lombrozo
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/github/lombrozo/testnames/bytecode/BytecodeTestClass.java
+++ b/src/main/java/com/github/lombrozo/testnames/bytecode/BytecodeTestClass.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2022-2024 Volodya Lombrozo
+ * Copyright (c) 2022-2025 Volodya Lombrozo
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/github/lombrozo/testnames/bytecode/BytecodeTestClassCharacteristics.java
+++ b/src/main/java/com/github/lombrozo/testnames/bytecode/BytecodeTestClassCharacteristics.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2022-2024 Volodya Lombrozo
+ * Copyright (c) 2022-2025 Volodya Lombrozo
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/github/lombrozo/testnames/bytecode/package-info.java
+++ b/src/main/java/com/github/lombrozo/testnames/bytecode/package-info.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2022-2024 Volodya Lombrozo
+ * Copyright (c) 2022-2025 Volodya Lombrozo
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/github/lombrozo/testnames/complaints/ComplaintClass.java
+++ b/src/main/java/com/github/lombrozo/testnames/complaints/ComplaintClass.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2022-2024 Volodya Lombrozo
+ * Copyright (c) 2022-2025 Volodya Lombrozo
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/github/lombrozo/testnames/complaints/ComplaintCompound.java
+++ b/src/main/java/com/github/lombrozo/testnames/complaints/ComplaintCompound.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2022-2024 Volodya Lombrozo
+ * Copyright (c) 2022-2025 Volodya Lombrozo
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/github/lombrozo/testnames/complaints/ComplaintLinked.java
+++ b/src/main/java/com/github/lombrozo/testnames/complaints/ComplaintLinked.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2022-2024 Volodya Lombrozo
+ * Copyright (c) 2022-2025 Volodya Lombrozo
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/github/lombrozo/testnames/complaints/ComplaintWrongTestName.java
+++ b/src/main/java/com/github/lombrozo/testnames/complaints/ComplaintWrongTestName.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2022-2024 Volodya Lombrozo
+ * Copyright (c) 2022-2025 Volodya Lombrozo
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/github/lombrozo/testnames/complaints/package-info.java
+++ b/src/main/java/com/github/lombrozo/testnames/complaints/package-info.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2022-2024 Volodya Lombrozo
+ * Copyright (c) 2022-2025 Volodya Lombrozo
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/github/lombrozo/testnames/javaparser/AssertionOfHamcrest.java
+++ b/src/main/java/com/github/lombrozo/testnames/javaparser/AssertionOfHamcrest.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2022-2024 Volodya Lombrozo
+ * Copyright (c) 2022-2025 Volodya Lombrozo
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/github/lombrozo/testnames/javaparser/AssertionOfJUnit.java
+++ b/src/main/java/com/github/lombrozo/testnames/javaparser/AssertionOfJUnit.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2022-2024 Volodya Lombrozo
+ * Copyright (c) 2022-2025 Volodya Lombrozo
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/github/lombrozo/testnames/javaparser/ByName.java
+++ b/src/main/java/com/github/lombrozo/testnames/javaparser/ByName.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2022-2024 Volodya Lombrozo
+ * Copyright (c) 2022-2025 Volodya Lombrozo
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/github/lombrozo/testnames/javaparser/JavaParserAssertion.java
+++ b/src/main/java/com/github/lombrozo/testnames/javaparser/JavaParserAssertion.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2022-2024 Volodya Lombrozo
+ * Copyright (c) 2022-2025 Volodya Lombrozo
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/github/lombrozo/testnames/javaparser/JavaParserCharacteristics.java
+++ b/src/main/java/com/github/lombrozo/testnames/javaparser/JavaParserCharacteristics.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2022-2024 Volodya Lombrozo
+ * Copyright (c) 2022-2025 Volodya Lombrozo
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/github/lombrozo/testnames/javaparser/JavaParserClass.java
+++ b/src/main/java/com/github/lombrozo/testnames/javaparser/JavaParserClass.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2022-2024 Volodya Lombrozo
+ * Copyright (c) 2022-2025 Volodya Lombrozo
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/github/lombrozo/testnames/javaparser/JavaParserMethod.java
+++ b/src/main/java/com/github/lombrozo/testnames/javaparser/JavaParserMethod.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2022-2024 Volodya Lombrozo
+ * Copyright (c) 2022-2025 Volodya Lombrozo
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/github/lombrozo/testnames/javaparser/JavaParserProductionClass.java
+++ b/src/main/java/com/github/lombrozo/testnames/javaparser/JavaParserProductionClass.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2022-2024 Volodya Lombrozo
+ * Copyright (c) 2022-2025 Volodya Lombrozo
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/github/lombrozo/testnames/javaparser/JavaParserProject.java
+++ b/src/main/java/com/github/lombrozo/testnames/javaparser/JavaParserProject.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2022-2024 Volodya Lombrozo
+ * Copyright (c) 2022-2025 Volodya Lombrozo
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/github/lombrozo/testnames/javaparser/JavaParserTestCase.java
+++ b/src/main/java/com/github/lombrozo/testnames/javaparser/JavaParserTestCase.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2022-2024 Volodya Lombrozo
+ * Copyright (c) 2022-2025 Volodya Lombrozo
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/github/lombrozo/testnames/javaparser/JavaParserTestClass.java
+++ b/src/main/java/com/github/lombrozo/testnames/javaparser/JavaParserTestClass.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2022-2024 Volodya Lombrozo
+ * Copyright (c) 2022-2025 Volodya Lombrozo
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/github/lombrozo/testnames/javaparser/NumberOfMockitoMocks.java
+++ b/src/main/java/com/github/lombrozo/testnames/javaparser/NumberOfMockitoMocks.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2022-2024 Volodya Lombrozo
+ * Copyright (c) 2022-2025 Volodya Lombrozo
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/github/lombrozo/testnames/javaparser/ParsedAssertion.java
+++ b/src/main/java/com/github/lombrozo/testnames/javaparser/ParsedAssertion.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2022-2024 Volodya Lombrozo
+ * Copyright (c) 2022-2025 Volodya Lombrozo
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/github/lombrozo/testnames/javaparser/StingExpression.java
+++ b/src/main/java/com/github/lombrozo/testnames/javaparser/StingExpression.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2022-2024 Volodya Lombrozo
+ * Copyright (c) 2022-2025 Volodya Lombrozo
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/github/lombrozo/testnames/javaparser/SuppressedAnnotations.java
+++ b/src/main/java/com/github/lombrozo/testnames/javaparser/SuppressedAnnotations.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2022-2024 Volodya Lombrozo
+ * Copyright (c) 2022-2025 Volodya Lombrozo
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/github/lombrozo/testnames/javaparser/TestsOnly.java
+++ b/src/main/java/com/github/lombrozo/testnames/javaparser/TestsOnly.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2022-2024 Volodya Lombrozo
+ * Copyright (c) 2022-2025 Volodya Lombrozo
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/github/lombrozo/testnames/javaparser/UnknownMessage.java
+++ b/src/main/java/com/github/lombrozo/testnames/javaparser/UnknownMessage.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2022-2024 Volodya Lombrozo
+ * Copyright (c) 2022-2025 Volodya Lombrozo
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/github/lombrozo/testnames/javaparser/package-info.java
+++ b/src/main/java/com/github/lombrozo/testnames/javaparser/package-info.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2022-2024 Volodya Lombrozo
+ * Copyright (c) 2022-2025 Volodya Lombrozo
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/github/lombrozo/testnames/package-info.java
+++ b/src/main/java/com/github/lombrozo/testnames/package-info.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2022-2024 Volodya Lombrozo
+ * Copyright (c) 2022-2025 Volodya Lombrozo
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/github/lombrozo/testnames/rules/LineHitterRule.java
+++ b/src/main/java/com/github/lombrozo/testnames/rules/LineHitterRule.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2022-2024 Volodya Lombrozo
+ * Copyright (c) 2022-2025 Volodya Lombrozo
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/github/lombrozo/testnames/rules/RuleAllTestsHaveProductionClass.java
+++ b/src/main/java/com/github/lombrozo/testnames/rules/RuleAllTestsHaveProductionClass.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2022-2024 Volodya Lombrozo
+ * Copyright (c) 2022-2025 Volodya Lombrozo
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/github/lombrozo/testnames/rules/RuleAssertionMessage.java
+++ b/src/main/java/com/github/lombrozo/testnames/rules/RuleAssertionMessage.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2022-2024 Volodya Lombrozo
+ * Copyright (c) 2022-2025 Volodya Lombrozo
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/github/lombrozo/testnames/rules/RuleConditional.java
+++ b/src/main/java/com/github/lombrozo/testnames/rules/RuleConditional.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2022-2024 Volodya Lombrozo
+ * Copyright (c) 2022-2025 Volodya Lombrozo
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/github/lombrozo/testnames/rules/RuleCorrectTestCase.java
+++ b/src/main/java/com/github/lombrozo/testnames/rules/RuleCorrectTestCase.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2022-2024 Volodya Lombrozo
+ * Copyright (c) 2022-2025 Volodya Lombrozo
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/github/lombrozo/testnames/rules/RuleCorrectTestCases.java
+++ b/src/main/java/com/github/lombrozo/testnames/rules/RuleCorrectTestCases.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2022-2024 Volodya Lombrozo
+ * Copyright (c) 2022-2025 Volodya Lombrozo
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/github/lombrozo/testnames/rules/RuleCorrectTestName.java
+++ b/src/main/java/com/github/lombrozo/testnames/rules/RuleCorrectTestName.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2022-2024 Volodya Lombrozo
+ * Copyright (c) 2022-2025 Volodya Lombrozo
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/github/lombrozo/testnames/rules/RuleInheritanceInTests.java
+++ b/src/main/java/com/github/lombrozo/testnames/rules/RuleInheritanceInTests.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2022-2024 Volodya Lombrozo
+ * Copyright (c) 2022-2025 Volodya Lombrozo
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/github/lombrozo/testnames/rules/RuleNotCamelCase.java
+++ b/src/main/java/com/github/lombrozo/testnames/rules/RuleNotCamelCase.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2022-2024 Volodya Lombrozo
+ * Copyright (c) 2022-2025 Volodya Lombrozo
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/github/lombrozo/testnames/rules/RuleNotContainsTestWord.java
+++ b/src/main/java/com/github/lombrozo/testnames/rules/RuleNotContainsTestWord.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2022-2024 Volodya Lombrozo
+ * Copyright (c) 2022-2025 Volodya Lombrozo
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/github/lombrozo/testnames/rules/RuleNotSpam.java
+++ b/src/main/java/com/github/lombrozo/testnames/rules/RuleNotSpam.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2022-2024 Volodya Lombrozo
+ * Copyright (c) 2022-2025 Volodya Lombrozo
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/github/lombrozo/testnames/rules/RuleNotUsesSpecialCharacters.java
+++ b/src/main/java/com/github/lombrozo/testnames/rules/RuleNotUsesSpecialCharacters.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2022-2024 Volodya Lombrozo
+ * Copyright (c) 2022-2025 Volodya Lombrozo
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/github/lombrozo/testnames/rules/RuleOnlyTestMethods.java
+++ b/src/main/java/com/github/lombrozo/testnames/rules/RuleOnlyTestMethods.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2022-2024 Volodya Lombrozo
+ * Copyright (c) 2022-2025 Volodya Lombrozo
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/github/lombrozo/testnames/rules/RulePresentTense.java
+++ b/src/main/java/com/github/lombrozo/testnames/rules/RulePresentTense.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2022-2024 Volodya Lombrozo
+ * Copyright (c) 2022-2025 Volodya Lombrozo
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/github/lombrozo/testnames/rules/RuleSuppressed.java
+++ b/src/main/java/com/github/lombrozo/testnames/rules/RuleSuppressed.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2022-2024 Volodya Lombrozo
+ * Copyright (c) 2022-2025 Volodya Lombrozo
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/github/lombrozo/testnames/rules/RuleTestCaseContainsMockery.java
+++ b/src/main/java/com/github/lombrozo/testnames/rules/RuleTestCaseContainsMockery.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2022-2024 Volodya Lombrozo
+ * Copyright (c) 2022-2025 Volodya Lombrozo
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/github/lombrozo/testnames/rules/ml/CachedModelSource.java
+++ b/src/main/java/com/github/lombrozo/testnames/rules/ml/CachedModelSource.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2022-2024 Volodya Lombrozo
+ * Copyright (c) 2022-2025 Volodya Lombrozo
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/github/lombrozo/testnames/rules/ml/ModelSource.java
+++ b/src/main/java/com/github/lombrozo/testnames/rules/ml/ModelSource.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2022-2024 Volodya Lombrozo
+ * Copyright (c) 2022-2025 Volodya Lombrozo
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/github/lombrozo/testnames/rules/ml/ModelSourceFileSystem.java
+++ b/src/main/java/com/github/lombrozo/testnames/rules/ml/ModelSourceFileSystem.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2022-2024 Volodya Lombrozo
+ * Copyright (c) 2022-2025 Volodya Lombrozo
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/github/lombrozo/testnames/rules/ml/ModelSourceInternet.java
+++ b/src/main/java/com/github/lombrozo/testnames/rules/ml/ModelSourceInternet.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2022-2024 Volodya Lombrozo
+ * Copyright (c) 2022-2025 Volodya Lombrozo
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/github/lombrozo/testnames/rules/ml/RulePresentSimpleMl.java
+++ b/src/main/java/com/github/lombrozo/testnames/rules/ml/RulePresentSimpleMl.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2022-2024 Volodya Lombrozo
+ * Copyright (c) 2022-2025 Volodya Lombrozo
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/github/lombrozo/testnames/rules/ml/Tag.java
+++ b/src/main/java/com/github/lombrozo/testnames/rules/ml/Tag.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2022-2024 Volodya Lombrozo
+ * Copyright (c) 2022-2025 Volodya Lombrozo
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/github/lombrozo/testnames/rules/ml/package-info.java
+++ b/src/main/java/com/github/lombrozo/testnames/rules/ml/package-info.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2022-2024 Volodya Lombrozo
+ * Copyright (c) 2022-2025 Volodya Lombrozo
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/github/lombrozo/testnames/rules/package-info.java
+++ b/src/main/java/com/github/lombrozo/testnames/rules/package-info.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2022-2024 Volodya Lombrozo
+ * Copyright (c) 2022-2025 Volodya Lombrozo
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/com/github/lombrozo/testnames/CopTest.java
+++ b/src/test/java/com/github/lombrozo/testnames/CopTest.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2022-2024 Volodya Lombrozo
+ * Copyright (c) 2022-2025 Volodya Lombrozo
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/com/github/lombrozo/testnames/ParametersTest.java
+++ b/src/test/java/com/github/lombrozo/testnames/ParametersTest.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2022-2024 Volodya Lombrozo
+ * Copyright (c) 2022-2025 Volodya Lombrozo
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/com/github/lombrozo/testnames/ProjectTest.java
+++ b/src/test/java/com/github/lombrozo/testnames/ProjectTest.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2022-2024 Volodya Lombrozo
+ * Copyright (c) 2022-2025 Volodya Lombrozo
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/com/github/lombrozo/testnames/ProjectWithoutJUnitExtensionsTest.java
+++ b/src/test/java/com/github/lombrozo/testnames/ProjectWithoutJUnitExtensionsTest.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2022-2024 Volodya Lombrozo
+ * Copyright (c) 2022-2025 Volodya Lombrozo
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/com/github/lombrozo/testnames/bytecode/BytecodeProjectTest.java
+++ b/src/test/java/com/github/lombrozo/testnames/bytecode/BytecodeProjectTest.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2022-2024 Volodya Lombrozo
+ * Copyright (c) 2022-2025 Volodya Lombrozo
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/com/github/lombrozo/testnames/bytecode/BytecodeTestClassCharacteristicsTest.java
+++ b/src/test/java/com/github/lombrozo/testnames/bytecode/BytecodeTestClassCharacteristicsTest.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2022-2024 Volodya Lombrozo
+ * Copyright (c) 2022-2025 Volodya Lombrozo
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/com/github/lombrozo/testnames/bytecode/BytecodeTestClassTest.java
+++ b/src/test/java/com/github/lombrozo/testnames/bytecode/BytecodeTestClassTest.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2022-2024 Volodya Lombrozo
+ * Copyright (c) 2022-2025 Volodya Lombrozo
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/com/github/lombrozo/testnames/bytecode/package-info.java
+++ b/src/test/java/com/github/lombrozo/testnames/bytecode/package-info.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2022-2024 Volodya Lombrozo
+ * Copyright (c) 2022-2025 Volodya Lombrozo
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/com/github/lombrozo/testnames/complaints/ComplaintClassTest.java
+++ b/src/test/java/com/github/lombrozo/testnames/complaints/ComplaintClassTest.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2022-2024 Volodya Lombrozo
+ * Copyright (c) 2022-2025 Volodya Lombrozo
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/com/github/lombrozo/testnames/complaints/ComplaintWrongTestNameTest.java
+++ b/src/test/java/com/github/lombrozo/testnames/complaints/ComplaintWrongTestNameTest.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2022-2024 Volodya Lombrozo
+ * Copyright (c) 2022-2025 Volodya Lombrozo
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/com/github/lombrozo/testnames/complaints/package-info.java
+++ b/src/test/java/com/github/lombrozo/testnames/complaints/package-info.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2022-2024 Volodya Lombrozo
+ * Copyright (c) 2022-2025 Volodya Lombrozo
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/com/github/lombrozo/testnames/javaparser/AssertionOfHamcrestTest.java
+++ b/src/test/java/com/github/lombrozo/testnames/javaparser/AssertionOfHamcrestTest.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2022-2024 Volodya Lombrozo
+ * Copyright (c) 2022-2025 Volodya Lombrozo
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/com/github/lombrozo/testnames/javaparser/AssertionOfJUnitTest.java
+++ b/src/test/java/com/github/lombrozo/testnames/javaparser/AssertionOfJUnitTest.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2022-2024 Volodya Lombrozo
+ * Copyright (c) 2022-2025 Volodya Lombrozo
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/com/github/lombrozo/testnames/javaparser/JavaParserAssertionTest.java
+++ b/src/test/java/com/github/lombrozo/testnames/javaparser/JavaParserAssertionTest.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2022-2024 Volodya Lombrozo
+ * Copyright (c) 2022-2025 Volodya Lombrozo
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/com/github/lombrozo/testnames/javaparser/JavaParserCharacteristicsTest.java
+++ b/src/test/java/com/github/lombrozo/testnames/javaparser/JavaParserCharacteristicsTest.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2022-2024 Volodya Lombrozo
+ * Copyright (c) 2022-2025 Volodya Lombrozo
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/com/github/lombrozo/testnames/javaparser/JavaParserProductionClassTest.java
+++ b/src/test/java/com/github/lombrozo/testnames/javaparser/JavaParserProductionClassTest.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2022-2024 Volodya Lombrozo
+ * Copyright (c) 2022-2025 Volodya Lombrozo
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/com/github/lombrozo/testnames/javaparser/JavaParserProjectTest.java
+++ b/src/test/java/com/github/lombrozo/testnames/javaparser/JavaParserProjectTest.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2022-2024 Volodya Lombrozo
+ * Copyright (c) 2022-2025 Volodya Lombrozo
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/com/github/lombrozo/testnames/javaparser/JavaParserTestCaseTest.java
+++ b/src/test/java/com/github/lombrozo/testnames/javaparser/JavaParserTestCaseTest.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2022-2024 Volodya Lombrozo
+ * Copyright (c) 2022-2025 Volodya Lombrozo
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/com/github/lombrozo/testnames/javaparser/JavaParserTestClassTest.java
+++ b/src/test/java/com/github/lombrozo/testnames/javaparser/JavaParserTestClassTest.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2022-2024 Volodya Lombrozo
+ * Copyright (c) 2022-2025 Volodya Lombrozo
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/com/github/lombrozo/testnames/javaparser/JavaTestClasses.java
+++ b/src/test/java/com/github/lombrozo/testnames/javaparser/JavaTestClasses.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2022-2024 Volodya Lombrozo
+ * Copyright (c) 2022-2025 Volodya Lombrozo
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/com/github/lombrozo/testnames/javaparser/NumberOfMockitoMocksTest.java
+++ b/src/test/java/com/github/lombrozo/testnames/javaparser/NumberOfMockitoMocksTest.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2022-2024 Volodya Lombrozo
+ * Copyright (c) 2022-2025 Volodya Lombrozo
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/com/github/lombrozo/testnames/javaparser/package-info.java
+++ b/src/test/java/com/github/lombrozo/testnames/javaparser/package-info.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2022-2024 Volodya Lombrozo
+ * Copyright (c) 2022-2025 Volodya Lombrozo
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/com/github/lombrozo/testnames/package-info.java
+++ b/src/test/java/com/github/lombrozo/testnames/package-info.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2022-2024 Volodya Lombrozo
+ * Copyright (c) 2022-2025 Volodya Lombrozo
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/com/github/lombrozo/testnames/rules/LineHitterRuleTest.java
+++ b/src/test/java/com/github/lombrozo/testnames/rules/LineHitterRuleTest.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2022-2024 Volodya Lombrozo
+ * Copyright (c) 2022-2025 Volodya Lombrozo
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/com/github/lombrozo/testnames/rules/RuleAllTestsHaveProductionClassTest.java
+++ b/src/test/java/com/github/lombrozo/testnames/rules/RuleAllTestsHaveProductionClassTest.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2022-2024 Volodya Lombrozo
+ * Copyright (c) 2022-2025 Volodya Lombrozo
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/com/github/lombrozo/testnames/rules/RuleAssertionMessageTest.java
+++ b/src/test/java/com/github/lombrozo/testnames/rules/RuleAssertionMessageTest.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2022-2024 Volodya Lombrozo
+ * Copyright (c) 2022-2025 Volodya Lombrozo
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/com/github/lombrozo/testnames/rules/RuleCorrectTestCasesTest.java
+++ b/src/test/java/com/github/lombrozo/testnames/rules/RuleCorrectTestCasesTest.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2022-2024 Volodya Lombrozo
+ * Copyright (c) 2022-2025 Volodya Lombrozo
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/com/github/lombrozo/testnames/rules/RuleCorrectTestNameTest.java
+++ b/src/test/java/com/github/lombrozo/testnames/rules/RuleCorrectTestNameTest.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2022-2024 Volodya Lombrozo
+ * Copyright (c) 2022-2025 Volodya Lombrozo
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/com/github/lombrozo/testnames/rules/RuleInheritanceInTestsTest.java
+++ b/src/test/java/com/github/lombrozo/testnames/rules/RuleInheritanceInTestsTest.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2022-2024 Volodya Lombrozo
+ * Copyright (c) 2022-2025 Volodya Lombrozo
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/com/github/lombrozo/testnames/rules/RuleNotContainsTestWordTest.java
+++ b/src/test/java/com/github/lombrozo/testnames/rules/RuleNotContainsTestWordTest.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2022-2024 Volodya Lombrozo
+ * Copyright (c) 2022-2025 Volodya Lombrozo
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/com/github/lombrozo/testnames/rules/RuleOnlyTestMethodsTest.java
+++ b/src/test/java/com/github/lombrozo/testnames/rules/RuleOnlyTestMethodsTest.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2022-2024 Volodya Lombrozo
+ * Copyright (c) 2022-2025 Volodya Lombrozo
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/com/github/lombrozo/testnames/rules/RuleTest.java
+++ b/src/test/java/com/github/lombrozo/testnames/rules/RuleTest.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2022-2024 Volodya Lombrozo
+ * Copyright (c) 2022-2025 Volodya Lombrozo
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/com/github/lombrozo/testnames/rules/RuleTestCaseContainsMockeryTest.java
+++ b/src/test/java/com/github/lombrozo/testnames/rules/RuleTestCaseContainsMockeryTest.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2022-2024 Volodya Lombrozo
+ * Copyright (c) 2022-2025 Volodya Lombrozo
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/com/github/lombrozo/testnames/rules/ml/CachedModelSourceTest.java
+++ b/src/test/java/com/github/lombrozo/testnames/rules/ml/CachedModelSourceTest.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2022-2024 Volodya Lombrozo
+ * Copyright (c) 2022-2025 Volodya Lombrozo
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/com/github/lombrozo/testnames/rules/ml/ModelSourceFileSystemTest.java
+++ b/src/test/java/com/github/lombrozo/testnames/rules/ml/ModelSourceFileSystemTest.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2022-2024 Volodya Lombrozo
+ * Copyright (c) 2022-2025 Volodya Lombrozo
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/com/github/lombrozo/testnames/rules/ml/RulePresentSimpleMlTest.java
+++ b/src/test/java/com/github/lombrozo/testnames/rules/ml/RulePresentSimpleMlTest.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2022-2024 Volodya Lombrozo
+ * Copyright (c) 2022-2025 Volodya Lombrozo
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/com/github/lombrozo/testnames/rules/ml/package-info.java
+++ b/src/test/java/com/github/lombrozo/testnames/rules/ml/package-info.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2022-2024 Volodya Lombrozo
+ * Copyright (c) 2022-2025 Volodya Lombrozo
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/com/github/lombrozo/testnames/rules/package-info.java
+++ b/src/test/java/com/github/lombrozo/testnames/rules/package-info.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2022-2024 Volodya Lombrozo
+ * Copyright (c) 2022-2025 Volodya Lombrozo
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/resources/AnnotationDeclaration.java
+++ b/src/test/resources/AnnotationDeclaration.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2022-2024 Volodya Lombrozo
+ * Copyright (c) 2022-2025 Volodya Lombrozo
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/resources/EnumInTests.java
+++ b/src/test/resources/EnumInTests.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2022-2024 Volodya Lombrozo
+ * Copyright (c) 2022-2025 Volodya Lombrozo
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/resources/HamcrestAssertTrueHitter.java
+++ b/src/test/resources/HamcrestAssertTrueHitter.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2022-2024 Volodya Lombrozo
+ * Copyright (c) 2022-2025 Volodya Lombrozo
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/resources/IntegrationTest.java
+++ b/src/test/resources/IntegrationTest.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2022-2024 Volodya Lombrozo
+ * Copyright (c) 2022-2025 Volodya Lombrozo
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/resources/JUnitAfterAllCallback.java
+++ b/src/test/resources/JUnitAfterAllCallback.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2022-2024 Volodya Lombrozo
+ * Copyright (c) 2022-2025 Volodya Lombrozo
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/resources/JUnitCondition.java
+++ b/src/test/resources/JUnitCondition.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2022-2024 Volodya Lombrozo
+ * Copyright (c) 2022-2025 Volodya Lombrozo
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/resources/Java17Test.java
+++ b/src/test/resources/Java17Test.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2022-2024 Volodya Lombrozo
+ * Copyright (c) 2022-2025 Volodya Lombrozo
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/resources/JunitAssertTrueHitter.java
+++ b/src/test/resources/JunitAssertTrueHitter.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2022-2024 Volodya Lombrozo
+ * Copyright (c) 2022-2025 Volodya Lombrozo
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/resources/Mockery.java
+++ b/src/test/resources/Mockery.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2022-2024 Volodya Lombrozo
+ * Copyright (c) 2022-2025 Volodya Lombrozo
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/resources/MockerySuppressed.java
+++ b/src/test/resources/MockerySuppressed.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2022-2024 Volodya Lombrozo
+ * Copyright (c) 2022-2025 Volodya Lombrozo
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/resources/MockeryValidTest.java
+++ b/src/test/resources/MockeryValidTest.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2022-2024 Volodya Lombrozo
+ * Copyright (c) 2022-2025 Volodya Lombrozo
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/resources/SuppressedAnnotation.java
+++ b/src/test/resources/SuppressedAnnotation.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2022-2024 Volodya Lombrozo
+ * Copyright (c) 2022-2025 Volodya Lombrozo
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/resources/SuppressedInterface.java
+++ b/src/test/resources/SuppressedInterface.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2022-2024 Volodya Lombrozo
+ * Copyright (c) 2022-2025 Volodya Lombrozo
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/resources/TestOnlyMethodsSuppressed.java
+++ b/src/test/resources/TestOnlyMethodsSuppressed.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2022-2024 Volodya Lombrozo
+ * Copyright (c) 2022-2025 Volodya Lombrozo
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/resources/TestParameterized.java
+++ b/src/test/resources/TestParameterized.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2022-2024 Volodya Lombrozo
+ * Copyright (c) 2022-2025 Volodya Lombrozo
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/resources/TestSimple.java
+++ b/src/test/resources/TestSimple.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2022-2024 Volodya Lombrozo
+ * Copyright (c) 2022-2025 Volodya Lombrozo
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/resources/TestWithAssertions.java
+++ b/src/test/resources/TestWithAssertions.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2022-2024 Volodya Lombrozo
+ * Copyright (c) 2022-2025 Volodya Lombrozo
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/resources/TestWithHamcrestAssertions.java
+++ b/src/test/resources/TestWithHamcrestAssertions.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2022-2024 Volodya Lombrozo
+ * Copyright (c) 2022-2025 Volodya Lombrozo
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/resources/TestWithJUnitAssertions.java
+++ b/src/test/resources/TestWithJUnitAssertions.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2022-2024 Volodya Lombrozo
+ * Copyright (c) 2022-2025 Volodya Lombrozo
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/resources/TestWithLotsOfSuppressed.java
+++ b/src/test/resources/TestWithLotsOfSuppressed.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2022-2024 Volodya Lombrozo
+ * Copyright (c) 2022-2025 Volodya Lombrozo
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/resources/TestWithSuppressed.java
+++ b/src/test/resources/TestWithSuppressed.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2022-2024 Volodya Lombrozo
+ * Copyright (c) 2022-2025 Volodya Lombrozo
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/resources/TestWithoutTests.java
+++ b/src/test/resources/TestWithoutTests.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2022-2024 Volodya Lombrozo
+ * Copyright (c) 2022-2025 Volodya Lombrozo
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/resources/TestWrongName.java
+++ b/src/test/resources/TestWrongName.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2022-2024 Volodya Lombrozo
+ * Copyright (c) 2022-2025 Volodya Lombrozo
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/resources/package-info.java
+++ b/src/test/resources/package-info.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2022-2024 Volodya Lombrozo
+ * Copyright (c) 2022-2025 Volodya Lombrozo
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Update license up to 2025 year


<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the copyright year in various files from `2024` to `2025`, reflecting the current year and ensuring proper attribution.

### Detailed summary
- Updated copyright year in `LICENSE.txt`, `pom.xml`, and multiple `.java`, `.groovy`, and `.xml` files from `2024` to `2025`.
- Changes applied across numerous directories, maintaining consistency in copyright information.

> The following files were skipped due to too many changes: `src/test/java/com/github/lombrozo/testnames/javaparser/JavaParserProductionClassTest.java`, `src/main/java/com/github/lombrozo/testnames/bytecode/BytecodeTestClassCharacteristics.java`, `src/test/java/com/github/lombrozo/testnames/rules/RuleAllTestsHaveProductionClassTest.java`, `src/test/java/com/github/lombrozo/testnames/bytecode/BytecodeTestClassCharacteristicsTest.java`, `src/it/empty-project/target/generated-test-sources/com/github/lombrozo/testnames/CorrectNameIT.java`, `src/it/all-have-production-class/target/generated-sources/com/github/lombrozo/testnames/JavaGenerated.java`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->