### PR TITLE
docs(#504): Add rule to avoid 'test' in test names

### DIFF
--- a/docs/rules/rule-not-contains-test-word.md
+++ b/docs/rules/rule-not-contains-test-word.md
@@ -1,0 +1,35 @@
+# Avoid 'test' Word in Test Names
+
+Rule codename: _RuleNotContainsTestWord_
+___
+
+Test names should not contain the word 'test'. This rule ensures that test names
+are descriptive and do not rely on the generic term 'test', which can be
+redundant and uninformative.
+
+Correct:
+
+```java
+@Test
+void calculatesSumCorrectly(){
+    // Test implementation
+}
+```
+
+Incorrect:
+
+```java
+@Test
+void testCalculatesSum(){
+    // Test implementation
+}
+```
+
+The rule checks for the presence of the word 'test' in any case (e.g., 'test', '
+Test', 'TEST') within the test name.
+
+Exceptions:
+`@SuppressedWarnings("JTCOP.RuleNotContainsTestWord")`.
+
+For more information on naming conventions, refer
+to [this guide](https://www.yegor256.com/2023/01/19/layout-of-tests.html#naming).

--- a/src/main/java/com/github/lombrozo/testnames/rules/RuleNotContainsTestWord.java
+++ b/src/main/java/com/github/lombrozo/testnames/rules/RuleNotContainsTestWord.java
@@ -69,7 +69,7 @@ public final class RuleNotContainsTestWord implements Rule {
                 ).message(),
                 "Remove 'test' word from the test name",
                 this.getClass(),
-                "test-word.md"
+                "rule-not-contains-test-word.md"
             )
         ).complaints();
     }


### PR DESCRIPTION
This pull request adds docs for `RuleNotContainsTestWord`, which enforces that test names should not contain the word 'test'. A new documentation file, `rule-not-contains-test-word.md`, has been added to provide guidance on this rule, including examples of correct and incorrect test names, and how to suppress the rule if necessary.

Closes #504

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces a new rule, `RuleNotContainsTestWord`, aimed at improving test name clarity by prohibiting the use of the word 'test'. It updates the documentation and modifies a related file name to reflect this rule.

### Detailed summary
- Renamed file from `test-word.md` to `rule-not-contains-test-word.md`.
- Added documentation for the `RuleNotContainsTestWord` rule.
- Described the rule's purpose and provided examples of correct and incorrect test names.
- Included information on exceptions and a reference link for naming conventions.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->