### PR TITLE
build(#498): Update Maven and Mockito versions in pom.xml files

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -174,7 +174,7 @@ SOFTWARE.
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.13.0</version>
+        <version>3.14.0</version>
         <dependencies>
           <dependency>
             <groupId>org.apache.maven.shared</groupId>
@@ -221,7 +221,6 @@ SOFTWARE.
           <streamLogsOnFailures>true</streamLogsOnFailures>
           <showErrors>true</showErrors>
           <skipInvocation>${skipITs}</skipInvocation>
-          <parallelThreads>9</parallelThreads>
         </configuration>
         <executions>
           <execution>

--- a/src/it/all-correct/pom.xml
+++ b/src/it/all-correct/pom.xml
@@ -60,7 +60,7 @@ SOFTWARE.
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
-      <version>5.15.2</version>
+      <version>5.16.1</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/src/it/all-incorrect/pom.xml
+++ b/src/it/all-incorrect/pom.xml
@@ -60,7 +60,7 @@ SOFTWARE.
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
-      <version>5.15.2</version>
+      <version>5.16.1</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/src/it/exclusions/pom.xml
+++ b/src/it/exclusions/pom.xml
@@ -50,7 +50,7 @@ SOFTWARE.
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
-      <version>5.15.2</version>
+      <version>5.16.1</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/src/it/parallel/pom.xml
+++ b/src/it/parallel/pom.xml
@@ -55,7 +55,7 @@ SOFTWARE.
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
-      <version>5.15.2</version>
+      <version>5.16.1</version>
       <scope>test</scope>
     </dependency>
   </dependencies>


### PR DESCRIPTION
This pull request updates the Maven Compiler Plugin to version 3.14.0 and upgrades Mockito dependencies to version 5.16.1 across several integration test modules. Additionally, it removes the parallelThreads configuration from the Maven Surefire Plugin. These changes aim to improve build stability and ensure compatibility with the latest library versions. 

Closes #498.