### PR TITLE
refactor(#507): Rename `RuleAllTestsHaveProductionClass` and add `aliases` method

### DIFF
--- a/src/main/java/com/github/lombrozo/testnames/Cop.java
+++ b/src/main/java/com/github/lombrozo/testnames/Cop.java
@@ -23,9 +23,9 @@
  */
 package com.github.lombrozo.testnames;
 
-import com.github.lombrozo.testnames.rules.RuleAllTestsHaveProductionClass;
 import com.github.lombrozo.testnames.rules.RuleCorrectTestCases;
 import com.github.lombrozo.testnames.rules.RuleCorrectTestName;
+import com.github.lombrozo.testnames.rules.RuleEveryTestHasProductionClass;
 import com.github.lombrozo.testnames.rules.RuleInheritanceInTests;
 import com.github.lombrozo.testnames.rules.RuleOnlyTestMethods;
 import com.github.lombrozo.testnames.rules.RuleSuppressed;
@@ -113,7 +113,7 @@ final class Cop {
     private static Function<Suspect, Stream<Rule>> regular(final Parameters parameters) {
         return suspect -> Stream.of(
             new RuleSuppressed(
-                new RuleAllTestsHaveProductionClass(suspect.project(), suspect.test()),
+                new RuleEveryTestHasProductionClass(suspect.project(), suspect.test()),
                 suspect.test()
             ),
             new RuleSuppressed(new RuleCorrectTestName(suspect.test()), suspect.test()),

--- a/src/main/java/com/github/lombrozo/testnames/Rule.java
+++ b/src/main/java/com/github/lombrozo/testnames/Rule.java
@@ -25,14 +25,20 @@
 package com.github.lombrozo.testnames;
 
 import java.util.Collection;
+import java.util.List;
 
 /**
  * The rule for naming.
  *
  * @since 0.1.0
  */
-@FunctionalInterface
 public interface Rule {
+
+    /**
+     * Rule aliases.
+     * @return List of aliases
+     */
+    List<String> aliases();
 
     /**
      * Collection of complaints that Rule can produce.

--- a/src/main/java/com/github/lombrozo/testnames/rules/LineHitterRule.java
+++ b/src/main/java/com/github/lombrozo/testnames/rules/LineHitterRule.java
@@ -28,7 +28,9 @@ import com.github.lombrozo.testnames.Complaint;
 import com.github.lombrozo.testnames.Rule;
 import com.github.lombrozo.testnames.TestCase;
 import com.github.lombrozo.testnames.complaints.ComplaintLinked;
+import java.util.Arrays;
 import java.util.Collection;
+import java.util.List;
 
 /**
  * The rule checks if test case contains a "Line Hitter"
@@ -55,6 +57,11 @@ public final class LineHitterRule implements Rule {
      */
     public LineHitterRule(final TestCase test) {
         this.test = test;
+    }
+
+    @Override
+    public List<String> aliases() {
+        return Arrays.asList("LineHitterRule");
     }
 
     @Override

--- a/src/main/java/com/github/lombrozo/testnames/rules/RuleAssertionMessage.java
+++ b/src/main/java/com/github/lombrozo/testnames/rules/RuleAssertionMessage.java
@@ -31,13 +31,14 @@ import com.github.lombrozo.testnames.complaints.ComplaintLinked;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.List;
 
 /**
  * The rule that checks that test method has assertion and the assertion message is not empty.
  *
  * @since 0.1.15
  */
-class RuleAssertionMessage implements Rule {
+final class RuleAssertionMessage implements Rule {
 
     /**
      * The test case.
@@ -50,6 +51,11 @@ class RuleAssertionMessage implements Rule {
      */
     RuleAssertionMessage(final TestCase test) {
         this.method = test;
+    }
+
+    @Override
+    public List<String> aliases() {
+        return Collections.singletonList(RuleAssertionMessage.class.getSimpleName());
     }
 
     @Override

--- a/src/main/java/com/github/lombrozo/testnames/rules/RuleConditional.java
+++ b/src/main/java/com/github/lombrozo/testnames/rules/RuleConditional.java
@@ -27,6 +27,7 @@ import com.github.lombrozo.testnames.Complaint;
 import com.github.lombrozo.testnames.Rule;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.List;
 import java.util.function.Supplier;
 
 /**
@@ -57,6 +58,11 @@ public final class RuleConditional implements Rule {
     ) {
         this.predicate = check;
         this.complaint = warning;
+    }
+
+    @Override
+    public List<String> aliases() {
+        return Collections.singletonList(RuleConditional.class.getSimpleName());
     }
 
     @Override

--- a/src/main/java/com/github/lombrozo/testnames/rules/RuleCorrectTestCase.java
+++ b/src/main/java/com/github/lombrozo/testnames/rules/RuleCorrectTestCase.java
@@ -29,6 +29,8 @@ import com.github.lombrozo.testnames.Parameters;
 import com.github.lombrozo.testnames.Rule;
 import com.github.lombrozo.testnames.TestCase;
 import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -62,6 +64,11 @@ public final class RuleCorrectTestCase implements Rule {
             new LineHitterRule(test),
             new RuleTestCaseContainsMockery(test, parameters)
         ).map(rule -> new RuleSuppressed(rule, test)).collect(Collectors.toList());
+    }
+
+    @Override
+    public List<String> aliases() {
+        return Collections.singletonList(this.getClass().getSimpleName());
     }
 
     @Override

--- a/src/main/java/com/github/lombrozo/testnames/rules/RuleCorrectTestCases.java
+++ b/src/main/java/com/github/lombrozo/testnames/rules/RuleCorrectTestCases.java
@@ -72,6 +72,11 @@ public final class RuleCorrectTestCases implements Rule {
     }
 
     @Override
+    public List<String> aliases() {
+        return Collections.singletonList(this.getClass().getSimpleName());
+    }
+
+    @Override
     public Collection<Complaint> complaints() {
         final List<Complaint> list = this.tests.all().stream()
             .map(

--- a/src/main/java/com/github/lombrozo/testnames/rules/RuleCorrectTestName.java
+++ b/src/main/java/com/github/lombrozo/testnames/rules/RuleCorrectTestName.java
@@ -30,6 +30,7 @@ import com.github.lombrozo.testnames.complaints.ComplaintLinked;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.List;
 
 /**
  * The rule that checks the correct name of an integration test class.
@@ -54,6 +55,11 @@ public final class RuleCorrectTestName implements Rule {
      */
     public RuleCorrectTestName(final TestClass klass) {
         this.test = klass;
+    }
+
+    @Override
+    public List<String> aliases() {
+        return Collections.singletonList(this.getClass().getSimpleName());
     }
 
     @Override

--- a/src/main/java/com/github/lombrozo/testnames/rules/RuleEveryTestHasProductionClass.java
+++ b/src/main/java/com/github/lombrozo/testnames/rules/RuleEveryTestHasProductionClass.java
@@ -30,7 +30,9 @@ import com.github.lombrozo.testnames.Rule;
 import com.github.lombrozo.testnames.TestClass;
 import com.github.lombrozo.testnames.complaints.ComplaintLinked;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
+import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
 import java.util.regex.Pattern;
@@ -41,12 +43,17 @@ import java.util.stream.Collectors;
  *
  * @since 0.2
  */
-public final class RuleAllTestsHaveProductionClass implements Rule {
+public final class RuleEveryTestHasProductionClass implements Rule {
 
     /**
      * The name of the rule.
      */
-    public static final String NAME = "RuleAllTestsHaveProductionClass";
+    public static final String NAME = "RuleEveryTestHasProductionClass";
+
+    /**
+     * The second name of the rule.
+     */
+    public static final String SECOND_NAME = "RuleAllTestsHaveProductionClass";
 
     /**
      * The pattern to replace the underscore sign "_".
@@ -73,28 +80,35 @@ public final class RuleAllTestsHaveProductionClass implements Rule {
      * @param proj The project to check.
      * @param test The test to check.
      */
-    public RuleAllTestsHaveProductionClass(final Project proj, final TestClass test) {
+    public RuleEveryTestHasProductionClass(final Project proj, final TestClass test) {
         this.project = proj;
         this.test = test;
+    }
+
+    @Override
+    public List<String> aliases() {
+        return Arrays.asList(
+            RuleEveryTestHasProductionClass.NAME, RuleEveryTestHasProductionClass.SECOND_NAME
+        );
     }
 
     @Override
     public Collection<Complaint> complaints() {
         final Map<String, ProductionClass> classes = this.project.productionClasses()
             .stream()
-            .filter(clazz -> RuleAllTestsHaveProductionClass.isNotPackageInfo(clazz.name()))
+            .filter(clazz -> RuleEveryTestHasProductionClass.isNotPackageInfo(clazz.name()))
             .collect(
                 Collectors.toMap(
-                    RuleAllTestsHaveProductionClass::correspondingTest,
+                    RuleEveryTestHasProductionClass::correspondingTest,
                     Function.identity(),
                     (first, second) -> first
                 )
             );
         final Collection<Complaint> complaints = new ArrayList<>(0);
-        final String name = RuleAllTestsHaveProductionClass.clean(this.test.name());
+        final String name = RuleEveryTestHasProductionClass.clean(this.test.name());
         if (!classes.containsKey(name)
             && !this.test.characteristics().isIntegrationTest()
-            && RuleAllTestsHaveProductionClass.isNotPackageInfo(this.test.name())) {
+            && RuleEveryTestHasProductionClass.isNotPackageInfo(this.test.name())) {
             complaints.add(
                 new ComplaintLinked(
                     String.format("Test %s doesn't have corresponding production class", name),
@@ -116,7 +130,7 @@ public final class RuleAllTestsHaveProductionClass implements Rule {
      * @return The name of the test class that corresponds to the production class.
      */
     private static String correspondingTest(final ProductionClass clazz) {
-        return String.format("%sTest", RuleAllTestsHaveProductionClass.clean(clazz.name()));
+        return String.format("%sTest", RuleEveryTestHasProductionClass.clean(clazz.name()));
     }
 
     /**
@@ -133,8 +147,8 @@ public final class RuleAllTestsHaveProductionClass implements Rule {
         } else {
             plain = original;
         }
-        return RuleAllTestsHaveProductionClass.DOLLAR.matcher(
-            RuleAllTestsHaveProductionClass.UNDERSCORE.matcher(plain).replaceAll("")
+        return RuleEveryTestHasProductionClass.DOLLAR.matcher(
+            RuleEveryTestHasProductionClass.UNDERSCORE.matcher(plain).replaceAll("")
         ).replaceAll("");
     }
 

--- a/src/main/java/com/github/lombrozo/testnames/rules/RuleInheritanceInTests.java
+++ b/src/main/java/com/github/lombrozo/testnames/rules/RuleInheritanceInTests.java
@@ -29,6 +29,7 @@ import com.github.lombrozo.testnames.TestClass;
 import com.github.lombrozo.testnames.complaints.ComplaintLinked;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.List;
 
 /**
  * The rule that checks a test class doesn't use inheritance.
@@ -48,6 +49,11 @@ public final class RuleInheritanceInTests implements Rule {
      */
     public RuleInheritanceInTests(final TestClass clazz) {
         this.clazz = clazz;
+    }
+
+    @Override
+    public List<String> aliases() {
+        return Collections.singletonList(this.getClass().getSimpleName());
     }
 
     @Override

--- a/src/main/java/com/github/lombrozo/testnames/rules/RuleNotCamelCase.java
+++ b/src/main/java/com/github/lombrozo/testnames/rules/RuleNotCamelCase.java
@@ -30,6 +30,8 @@ import com.github.lombrozo.testnames.TestCase;
 import com.github.lombrozo.testnames.complaints.ComplaintLinked;
 import com.github.lombrozo.testnames.complaints.ComplaintWrongTestName;
 import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
 
 /**
  * Rule to check test case on not camel case name.
@@ -55,6 +57,11 @@ public final class RuleNotCamelCase implements Rule {
      */
     RuleNotCamelCase(final TestCase test) {
         this.test = test;
+    }
+
+    @Override
+    public List<String> aliases() {
+        return Collections.singletonList(this.getClass().getSimpleName());
     }
 
     @Override

--- a/src/main/java/com/github/lombrozo/testnames/rules/RuleNotContainsTestWord.java
+++ b/src/main/java/com/github/lombrozo/testnames/rules/RuleNotContainsTestWord.java
@@ -30,6 +30,8 @@ import com.github.lombrozo.testnames.TestCase;
 import com.github.lombrozo.testnames.complaints.ComplaintLinked;
 import com.github.lombrozo.testnames.complaints.ComplaintWrongTestName;
 import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
 import java.util.stream.Stream;
 
 /**
@@ -56,6 +58,11 @@ public final class RuleNotContainsTestWord implements Rule {
      */
     RuleNotContainsTestWord(final TestCase test) {
         this.test = test;
+    }
+
+    @Override
+    public List<String> aliases() {
+        return Collections.singletonList(RuleNotContainsTestWord.NAME);
     }
 
     @Override

--- a/src/main/java/com/github/lombrozo/testnames/rules/RuleNotSpam.java
+++ b/src/main/java/com/github/lombrozo/testnames/rules/RuleNotSpam.java
@@ -30,6 +30,8 @@ import com.github.lombrozo.testnames.TestCase;
 import com.github.lombrozo.testnames.complaints.ComplaintLinked;
 import com.github.lombrozo.testnames.complaints.ComplaintWrongTestName;
 import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
 
 /**
  * Rule to check test case on not spam.
@@ -50,6 +52,11 @@ public final class RuleNotSpam implements Rule {
      */
     RuleNotSpam(final TestCase test) {
         this.test = test;
+    }
+
+    @Override
+    public List<String> aliases() {
+        return Collections.singletonList(this.getClass().getSimpleName());
     }
 
     @Override

--- a/src/main/java/com/github/lombrozo/testnames/rules/RuleNotUsesSpecialCharacters.java
+++ b/src/main/java/com/github/lombrozo/testnames/rules/RuleNotUsesSpecialCharacters.java
@@ -30,6 +30,8 @@ import com.github.lombrozo.testnames.TestCase;
 import com.github.lombrozo.testnames.complaints.ComplaintLinked;
 import com.github.lombrozo.testnames.complaints.ComplaintWrongTestName;
 import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
 
 /**
  * The rule to check if test name uses special chars.
@@ -50,6 +52,11 @@ public final class RuleNotUsesSpecialCharacters implements Rule {
      */
     RuleNotUsesSpecialCharacters(final TestCase test) {
         this.test = test;
+    }
+
+    @Override
+    public List<String> aliases() {
+        return Collections.singletonList(this.getClass().getSimpleName());
     }
 
     @Override

--- a/src/main/java/com/github/lombrozo/testnames/rules/RuleOnlyTestMethods.java
+++ b/src/main/java/com/github/lombrozo/testnames/rules/RuleOnlyTestMethods.java
@@ -30,6 +30,7 @@ import com.github.lombrozo.testnames.TestClassCharacteristics;
 import com.github.lombrozo.testnames.complaints.ComplaintLinked;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.List;
 
 /**
  * Checks that test class has only methods annotated with @Test annotation.
@@ -52,6 +53,11 @@ public final class RuleOnlyTestMethods implements Rule {
      */
     public RuleOnlyTestMethods(final TestClass klass) {
         this.klass = klass;
+    }
+
+    @Override
+    public List<String> aliases() {
+        return Collections.singletonList(this.getClass().getSimpleName());
     }
 
     @Override

--- a/src/main/java/com/github/lombrozo/testnames/rules/RulePresentTense.java
+++ b/src/main/java/com/github/lombrozo/testnames/rules/RulePresentTense.java
@@ -30,6 +30,8 @@ import com.github.lombrozo.testnames.TestCase;
 import com.github.lombrozo.testnames.complaints.ComplaintLinked;
 import com.github.lombrozo.testnames.complaints.ComplaintWrongTestName;
 import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
 
 /**
  * The rule checks if test case in present tense.
@@ -50,6 +52,11 @@ public final class RulePresentTense implements Rule {
      */
     RulePresentTense(final TestCase tst) {
         this.test = tst;
+    }
+
+    @Override
+    public List<String> aliases() {
+        return Collections.singletonList(this.getClass().getSimpleName());
     }
 
     @Override

--- a/src/main/java/com/github/lombrozo/testnames/rules/RuleSuppressed.java
+++ b/src/main/java/com/github/lombrozo/testnames/rules/RuleSuppressed.java
@@ -29,6 +29,7 @@ import com.github.lombrozo.testnames.TestCase;
 import com.github.lombrozo.testnames.TestClass;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.List;
 
 /**
  * Suppressed rule.
@@ -83,6 +84,11 @@ public final class RuleSuppressed implements Rule {
     }
 
     @Override
+    public List<String> aliases() {
+        return Collections.singletonList(this.getClass().getSimpleName());
+    }
+
+    @Override
     public Collection<Complaint> complaints() {
         final Collection<Complaint> result;
         if (this.isSuppressed()) {
@@ -99,7 +105,7 @@ public final class RuleSuppressed implements Rule {
      */
     private boolean isSuppressed() {
         return this.suppressed.stream().anyMatch(
-            hidden -> hidden.equals(this.delegate.getClass().getSimpleName())
+            hidden -> this.delegate.aliases().contains(hidden)
         );
     }
 }

--- a/src/main/java/com/github/lombrozo/testnames/rules/RuleTestCaseContainsMockery.java
+++ b/src/main/java/com/github/lombrozo/testnames/rules/RuleTestCaseContainsMockery.java
@@ -30,6 +30,8 @@ import com.github.lombrozo.testnames.TestCase;
 import com.github.lombrozo.testnames.complaints.ComplaintLinked;
 import com.github.lombrozo.testnames.javaparser.NumberOfMockitoMocks;
 import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
 
 /**
  * Mockery rule.
@@ -70,6 +72,11 @@ public final class RuleTestCaseContainsMockery implements Rule {
     public RuleTestCaseContainsMockery(final TestCase tst, final int allwd) {
         this.test = tst;
         this.allowed = allwd;
+    }
+
+    @Override
+    public List<String> aliases() {
+        return Collections.singletonList(this.getClass().getSimpleName());
     }
 
     @Override

--- a/src/main/java/com/github/lombrozo/testnames/rules/ml/RulePresentSimpleMl.java
+++ b/src/main/java/com/github/lombrozo/testnames/rules/ml/RulePresentSimpleMl.java
@@ -30,6 +30,7 @@ import com.github.lombrozo.testnames.complaints.ComplaintWrongTestName;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.List;
 import java.util.Locale;
 import java.util.regex.Pattern;
 import java.util.stream.Stream;
@@ -65,6 +66,11 @@ public final class RulePresentSimpleMl implements Rule {
     RulePresentSimpleMl(final POSTaggerME tagger, final TestCase tst) {
         this.model = tagger;
         this.test = tst;
+    }
+
+    @Override
+    public List<String> aliases() {
+        return Collections.singletonList(this.getClass().getSimpleName());
     }
 
     @Override

--- a/src/test/java/com/github/lombrozo/testnames/javaparser/JavaParserTestCaseTest.java
+++ b/src/test/java/com/github/lombrozo/testnames/javaparser/JavaParserTestCaseTest.java
@@ -25,7 +25,7 @@ package com.github.lombrozo.testnames.javaparser;
 
 import com.github.lombrozo.testnames.Assertion;
 import com.github.lombrozo.testnames.TestCase;
-import com.github.lombrozo.testnames.rules.RuleAllTestsHaveProductionClass;
+import com.github.lombrozo.testnames.rules.RuleEveryTestHasProductionClass;
 import com.github.lombrozo.testnames.rules.RuleNotCamelCase;
 import com.github.lombrozo.testnames.rules.RuleNotContainsTestWord;
 import java.util.Arrays;
@@ -139,7 +139,7 @@ final class JavaParserTestCaseTest {
             .testCase(test)
             .suppressed();
         final String[] expected = {
-            RuleAllTestsHaveProductionClass.NAME,
+            RuleEveryTestHasProductionClass.SECOND_NAME,
             RuleNotContainsTestWord.NAME,
             RuleNotCamelCase.NAME,
             "AnotherRule",

--- a/src/test/java/com/github/lombrozo/testnames/javaparser/JavaParserTestClassTest.java
+++ b/src/test/java/com/github/lombrozo/testnames/javaparser/JavaParserTestClassTest.java
@@ -25,7 +25,7 @@
 package com.github.lombrozo.testnames.javaparser;
 
 import com.github.lombrozo.testnames.TestCase;
-import com.github.lombrozo.testnames.rules.RuleAllTestsHaveProductionClass;
+import com.github.lombrozo.testnames.rules.RuleEveryTestHasProductionClass;
 import com.github.lombrozo.testnames.rules.RuleNotCamelCase;
 import com.github.lombrozo.testnames.rules.RuleNotContainsTestWord;
 import java.nio.file.Path;
@@ -151,13 +151,13 @@ final class JavaParserTestClassTest {
         final String msg = String.format(
             "We expected that test class %s will contain only one suppressed rule %s",
             JavaTestClasses.SUPPRESSED_CLASS,
-            RuleAllTestsHaveProductionClass.NAME
+            RuleEveryTestHasProductionClass.SECOND_NAME
         );
         MatcherAssert.assertThat(msg, all, Matchers.hasSize(1));
         MatcherAssert.assertThat(
             msg,
             all.iterator().next(),
-            Matchers.equalTo(RuleAllTestsHaveProductionClass.NAME)
+            Matchers.equalTo(RuleEveryTestHasProductionClass.SECOND_NAME)
         );
     }
 
@@ -167,7 +167,7 @@ final class JavaParserTestClassTest {
             .toTestClass()
             .suppressed();
         final String[] expected = {
-            RuleAllTestsHaveProductionClass.NAME,
+            RuleEveryTestHasProductionClass.SECOND_NAME,
             RuleNotCamelCase.NAME,
             RuleNotContainsTestWord.NAME,
         };
@@ -188,7 +188,7 @@ final class JavaParserTestClassTest {
         final String[] expected = {
             custom,
             project,
-            RuleAllTestsHaveProductionClass.NAME,
+            RuleEveryTestHasProductionClass.SECOND_NAME,
             RuleNotCamelCase.NAME,
             RuleNotContainsTestWord.NAME,
         };
@@ -210,7 +210,7 @@ final class JavaParserTestClassTest {
         final Collection<String> all = JavaTestClasses.SUPPRESSED_ANNOTATION
             .toTestClass()
             .suppressed();
-        final String expected = RuleAllTestsHaveProductionClass.NAME;
+        final String expected = RuleEveryTestHasProductionClass.SECOND_NAME;
         final String msg = String.format("Expected exactly %s rule, but was %s", expected, all);
         MatcherAssert.assertThat(
             msg, all, Matchers.hasSize(1)
@@ -225,7 +225,7 @@ final class JavaParserTestClassTest {
         final Collection<String> all = JavaTestClasses.SUPPRESSED_INTERFACE
             .toTestClass()
             .suppressed();
-        final String expected = RuleAllTestsHaveProductionClass.NAME;
+        final String expected = RuleEveryTestHasProductionClass.SECOND_NAME;
         final String msg = String.format("Expected only %s rule, but was %s", expected, all);
         MatcherAssert.assertThat(msg, all, Matchers.hasSize(1));
         MatcherAssert.assertThat(msg, all, Matchers.hasItem(expected));

--- a/src/test/java/com/github/lombrozo/testnames/rules/RuleEveryTestHasProductionClassTest.java
+++ b/src/test/java/com/github/lombrozo/testnames/rules/RuleEveryTestHasProductionClassTest.java
@@ -37,19 +37,19 @@ import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
 
 /**
- * Test class for {@link RuleAllTestsHaveProductionClass}.
+ * Test class for {@link RuleEveryTestHasProductionClass}.
  *
  * @since 0.2
  */
 @SuppressWarnings("PMD.TooManyMethods")
-final class RuleAllTestsHaveProductionClassTest {
+final class RuleEveryTestHasProductionClassTest {
 
     @Test
     void checksThatAllHaveCorrespondingProductionClass() {
         final TestClass.Fake test = new TestClass.Fake("IdenticalTest", new TestCase.Fake());
         MatcherAssert.assertThat(
             "Should not have complaints, because all tests have corresponding production class",
-            new RuleAllTestsHaveProductionClass(
+            new RuleEveryTestHasProductionClass(
                 new Project.Fake(
                     new ProductionClass.Fake("Identical"),
                     test
@@ -65,7 +65,7 @@ final class RuleAllTestsHaveProductionClassTest {
         final TestClass.Fake test = new TestClass.Fake("HelloTest.java");
         MatcherAssert.assertThat(
             "Should not have complaints, because all tests have corresponding production class, even with .java extension",
-            new RuleAllTestsHaveProductionClass(
+            new RuleEveryTestHasProductionClass(
                 new Project.Fake(
                     new ProductionClass.Fake("Hello.java"),
                     test
@@ -81,7 +81,7 @@ final class RuleAllTestsHaveProductionClassTest {
         final TestClass.Fake test = new TestClass.Fake("HelloTest.class");
         MatcherAssert.assertThat(
             "Should not have complaints, because all tests have corresponding production class, even with .class extension",
-            new RuleAllTestsHaveProductionClass(
+            new RuleEveryTestHasProductionClass(
                 new Project.Fake(
                     new ProductionClass.Fake("Hello.class"),
                     test
@@ -96,7 +96,7 @@ final class RuleAllTestsHaveProductionClassTest {
     void checksThatClassHasCorrespondingProductionClassWithDifferentExtensions() {
         MatcherAssert.assertThat(
             "Should not have complaints, because all tests have corresponding production class, even if they have different extensions",
-            new RuleAllTestsHaveProductionClass(
+            new RuleEveryTestHasProductionClass(
                 new Project.Fake(
                     new ProductionClass.Fake("ComplaintClass.java")
                 ),
@@ -109,7 +109,7 @@ final class RuleAllTestsHaveProductionClassTest {
     @Test
     void checksThatDoesNotHaveCorrespondingProductionClass() {
         final TestClass.Fake test = new TestClass.Fake();
-        final Collection<Complaint> complaints = new RuleAllTestsHaveProductionClass(
+        final Collection<Complaint> complaints = new RuleEveryTestHasProductionClass(
             new Project.Fake(test),
             test
         ).complaints();
@@ -132,10 +132,10 @@ final class RuleAllTestsHaveProductionClassTest {
         MatcherAssert.assertThat(
             "Should not have complaints, because suppressed",
             new RuleSuppressed(
-                new RuleAllTestsHaveProductionClass(
+                new RuleEveryTestHasProductionClass(
                     new Project.Fake(),
                     new TestClass.Fake(
-                        Collections.singletonList(RuleAllTestsHaveProductionClass.NAME)
+                        Collections.singletonList(RuleEveryTestHasProductionClass.NAME)
                     )
                 )
             ).complaints(),
@@ -146,7 +146,7 @@ final class RuleAllTestsHaveProductionClassTest {
     @Test
     void filtersPackageInfoProductionClasses() {
         final String info = "package-info.java";
-        final Collection<Complaint> complaints = new RuleAllTestsHaveProductionClass(
+        final Collection<Complaint> complaints = new RuleEveryTestHasProductionClass(
             new Project.Fake(
                 new ProductionClass.Fake(info),
                 new ProductionClass.Fake(info),
@@ -168,7 +168,7 @@ final class RuleAllTestsHaveProductionClassTest {
     void filtersPackageInfoClasses() {
         final String info = "package-info.java";
         final TestClass.Fake fake = new TestClass.Fake(info);
-        final Collection<Complaint> complaints = new RuleAllTestsHaveProductionClass(
+        final Collection<Complaint> complaints = new RuleEveryTestHasProductionClass(
             new Project.Fake(
                 fake,
                 new TestClass.Fake(info),
@@ -190,7 +190,7 @@ final class RuleAllTestsHaveProductionClassTest {
     void handlesClassesWithTheSameNames() {
         final String name = "Hello";
         final TestClass.Fake test = new TestClass.Fake("HelloTest");
-        final Collection<Complaint> complaints = new RuleAllTestsHaveProductionClass(
+        final Collection<Complaint> complaints = new RuleEveryTestHasProductionClass(
             new Project.Fake(
                 Arrays.asList(new ProductionClass.Fake(name), new ProductionClass.Fake(name)),
                 Collections.singleton(test)
@@ -209,7 +209,7 @@ final class RuleAllTestsHaveProductionClassTest {
         final TestClass.Fake test = new TestClass.Fake("Identical_Name_Test", new TestCase.Fake());
         MatcherAssert.assertThat(
             "Should not have complaints, because all tests have corresponding production class, but with underscores",
-            new RuleAllTestsHaveProductionClass(
+            new RuleEveryTestHasProductionClass(
                 new Project.Fake(
                     new ProductionClass.Fake("IdenticalName"),
                     test
@@ -225,7 +225,7 @@ final class RuleAllTestsHaveProductionClassTest {
         final TestClass.Fake test = new TestClass.Fake("EObool$EOnot$Test", new TestCase.Fake());
         MatcherAssert.assertThat(
             "Should not have complaints, because all tests have corresponding production class, but with dollar sign",
-            new RuleAllTestsHaveProductionClass(
+            new RuleEveryTestHasProductionClass(
                 new Project.Fake(
                     new ProductionClass.Fake("EObool$EOnot"),
                     test
@@ -243,7 +243,7 @@ final class RuleAllTestsHaveProductionClassTest {
         );
         MatcherAssert.assertThat(
             "We expect that test class under 'it' (integration tests) folder is ignored by the rule",
-            new RuleAllTestsHaveProductionClass(
+            new RuleEveryTestHasProductionClass(
                 new Project.Fake(test),
                 test
             ).complaints(),


### PR DESCRIPTION
This pull request refactors the rule naming system by renaming `RuleAllTestsHaveProductionClass` to `RuleEveryTestHasProductionClass` and introduces an `aliases` method to the `Rule` interface. 

Closes #507.