### PR TITLE
feat(#302): Add `RuleProhibitStaticFields` to enforce no static fields in tests

### DIFF
--- a/docs/rules/prohibit-static-fields.md
+++ b/docs/rules/prohibit-static-fields.md
@@ -1,0 +1,4 @@
+@todo #302:90min Add documentation for the RuleProhibitStaticFields. The
+documentation should be added to the `docs/rules/prohibit-static-fields.md`
+file. The documentation should contain the description of the rule and the
+examples of the correct and incorrect code.

--- a/src/it/assertions/src/test/java/AssertionsTest.java
+++ b/src/it/assertions/src/test/java/AssertionsTest.java
@@ -36,7 +36,15 @@ import java.util.Set;
 import java.util.stream.Stream;
 import java.util.function.Consumer;
 
-
+/**
+ * Test class for assertions.
+ *
+ * @since 0.1
+ * @todo #302:30min Allow suppression of the RuleProhibitStaticFields in the field level.
+ *  The RuleProhibitStaticFields should be suppressed in the field level.
+ *  Currently, the RuleProhibitStaticFields is suppressed in the class level only.
+ */
+@SuppressWarnings("JTCOP.RuleProhibitStaticFields")
 class AssertionsTest {
 
     /**

--- a/src/main/java/com/github/lombrozo/testnames/Cop.java
+++ b/src/main/java/com/github/lombrozo/testnames/Cop.java
@@ -28,6 +28,7 @@ import com.github.lombrozo.testnames.rules.RuleCorrectTestName;
 import com.github.lombrozo.testnames.rules.RuleEveryTestHasProductionClass;
 import com.github.lombrozo.testnames.rules.RuleInheritanceInTests;
 import com.github.lombrozo.testnames.rules.RuleOnlyTestMethods;
+import com.github.lombrozo.testnames.rules.RuleProhibitStaticFields;
 import com.github.lombrozo.testnames.rules.RuleSuppressed;
 import java.util.Collection;
 import java.util.function.Function;
@@ -116,6 +117,7 @@ final class Cop {
                 new RuleEveryTestHasProductionClass(suspect.project(), suspect.test()),
                 suspect.test()
             ),
+            new RuleSuppressed(new RuleProhibitStaticFields(suspect.test()), suspect.test()),
             new RuleSuppressed(new RuleCorrectTestName(suspect.test()), suspect.test()),
             new RuleSuppressed(new RuleInheritanceInTests(suspect.test()), suspect.test()),
             new RuleSuppressed(new RuleCorrectTestCases(suspect.test(), parameters), suspect.test())

--- a/src/main/java/com/github/lombrozo/testnames/Field.java
+++ b/src/main/java/com/github/lombrozo/testnames/Field.java
@@ -1,0 +1,142 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2022-2025 Volodya Lombrozo
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.github.lombrozo.testnames;
+
+/**
+ * Field abstraction.
+ * @since 1.4
+ */
+public interface Field {
+
+    /**
+     * Name of field.
+     * @return Name of field.
+     */
+    String name();
+
+    /**
+     * Is field static.
+     * @return True if field is static.
+     */
+    boolean isStatic();
+
+    /**
+     * Constant fake field.
+     * @since 1.4
+     */
+    final class Fake implements Field {
+
+        @Override
+        public String name() {
+            return "fake";
+        }
+
+        @Override
+        public boolean isStatic() {
+            return false;
+        }
+    }
+
+    /**
+     * Named field.
+     * @since 1.4
+     */
+    final class Named implements Field {
+
+        /**
+         * Name of field.
+         */
+        private final String name;
+
+        /**
+         * Origin field.
+         */
+        private final Field origin;
+
+        /**
+         * Constructor.
+         * @param name Name of field.
+         */
+        public Named(final String name) {
+            this(name, new Field.Fake());
+        }
+
+        /**
+         * Constructor.
+         * @param name Name of field.
+         * @param origin Origin field.
+         */
+        public Named(final String name, final Field origin) {
+            this.name = name;
+            this.origin = origin;
+        }
+
+        @Override
+        public String name() {
+            return this.name;
+        }
+
+        @Override
+        public boolean isStatic() {
+            return this.origin.isStatic();
+        }
+    }
+
+    /**
+     * Static field.
+     * @since 1.4
+     */
+    final class Static implements Field {
+
+        /**
+         * Delegate.
+         */
+        private final Field origin;
+
+        /**
+         * Constructor.
+         */
+        public Static() {
+            this(new Field.Fake());
+        }
+
+        /**
+         * Constructor.
+         * @param origin Origin field.
+         */
+        public Static(final Field origin) {
+            this.origin = origin;
+        }
+
+        @Override
+        public String name() {
+            return this.origin.name();
+        }
+
+        @Override
+        public boolean isStatic() {
+            return true;
+        }
+    }
+}

--- a/src/main/java/com/github/lombrozo/testnames/TestClass.java
+++ b/src/main/java/com/github/lombrozo/testnames/TestClass.java
@@ -39,6 +39,12 @@ import lombok.Data;
 public interface TestClass {
 
     /**
+     * Test class fields.
+     * @return Test class fields.
+     */
+    Collection<Field> fields();
+
+    /**
      * The name of class.
      *
      * @return The name of class as string
@@ -218,6 +224,11 @@ public interface TestClass {
         }
 
         @Override
+        public Collection<Field> fields() {
+            return Collections.emptyList();
+        }
+
+        @Override
         public String name() {
             return this.name;
         }
@@ -240,6 +251,79 @@ public interface TestClass {
         @Override
         public TestClassCharacteristics characteristics() {
             return this.props;
+        }
+    }
+
+    /**
+     * The test class with fields.
+     * @since 1.4
+     */
+    final class WithFields implements TestClass {
+
+        /**
+         * Fields.
+         */
+        private final List<Field> fields;
+
+        /**
+         * Origin test class.
+         */
+        private final TestClass origin;
+
+        /**
+         * Constructor.
+         * @param fields Fields
+         */
+        public WithFields(final Field... fields) {
+            this(Arrays.asList(fields));
+        }
+
+        /**
+         * Constructor.
+         * @param fields Fields.
+         */
+        WithFields(final List<Field> fields) {
+            this(fields, new Fake());
+        }
+
+        /**
+         * Constructor.
+         * @param fields Fields list.
+         * @param origin Origin test class.
+         */
+        WithFields(final List<Field> fields, final TestClass origin) {
+            this.fields = fields;
+            this.origin = origin;
+        }
+
+        @Override
+        public Collection<Field> fields() {
+            return Collections.unmodifiableList(this.fields);
+        }
+
+        @Override
+        public String name() {
+            return this.origin.name();
+        }
+
+        @Override
+        public Collection<TestCase> all() {
+            return this.origin.all();
+        }
+
+        @Override
+        public Path path() {
+            return this.origin.path();
+        }
+
+        @Override
+        public Collection<String> suppressed() {
+            return this.origin.suppressed();
+        }
+
+        @Override
+        public TestClassCharacteristics characteristics() {
+            return this.origin.characteristics();
         }
     }
 }

--- a/src/main/java/com/github/lombrozo/testnames/bytecode/BytecodeField.java
+++ b/src/main/java/com/github/lombrozo/testnames/bytecode/BytecodeField.java
@@ -1,0 +1,58 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2022-2025 Volodya Lombrozo
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.github.lombrozo.testnames.bytecode;
+
+import com.github.lombrozo.testnames.Field;
+import javassist.CtField;
+import javassist.Modifier;
+
+/**
+ * Class field in bytecode.
+ * @since 1.4
+ */
+public final class BytecodeField implements Field {
+
+    /**
+     * Field.
+     */
+    private final CtField field;
+
+    /**
+     * Constructor.
+     * @param field Field
+     */
+    BytecodeField(final CtField field) {
+        this.field = field;
+    }
+
+    @Override
+    public String name() {
+        return this.field.getName();
+    }
+
+    @Override
+    public boolean isStatic() {
+        return Modifier.isStatic(this.field.getModifiers());
+    }
+}

--- a/src/main/java/com/github/lombrozo/testnames/bytecode/BytecodeTestClass.java
+++ b/src/main/java/com/github/lombrozo/testnames/bytecode/BytecodeTestClass.java
@@ -23,12 +23,15 @@
  */
 package com.github.lombrozo.testnames.bytecode;
 
+import com.github.lombrozo.testnames.Field;
 import com.github.lombrozo.testnames.TestCase;
 import com.github.lombrozo.testnames.TestClass;
 import com.github.lombrozo.testnames.TestClassCharacteristics;
 import java.nio.file.Path;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.stream.Collectors;
 import javassist.CtClass;
 
 /**
@@ -59,6 +62,13 @@ final class BytecodeTestClass implements TestClass {
     ) {
         this.file = path;
         this.klass = clazz;
+    }
+
+    @Override
+    public Collection<Field> fields() {
+        return Arrays.stream(this.klass.getDeclaredFields())
+            .map(BytecodeField::new)
+            .collect(Collectors.toList());
     }
 
     @Override

--- a/src/main/java/com/github/lombrozo/testnames/complaints/ComplaintLinked.java
+++ b/src/main/java/com/github/lombrozo/testnames/complaints/ComplaintLinked.java
@@ -26,6 +26,7 @@ package com.github.lombrozo.testnames.complaints;
 import com.github.lombrozo.testnames.Complaint;
 import java.net.MalformedURLException;
 import java.net.URL;
+import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
 /**
@@ -34,6 +35,7 @@ import lombok.ToString;
  * @since 0.1.15
  */
 @ToString
+@EqualsAndHashCode
 public final class ComplaintLinked implements Complaint {
 
     /**

--- a/src/main/java/com/github/lombrozo/testnames/javaparser/JavaParserClass.java
+++ b/src/main/java/com/github/lombrozo/testnames/javaparser/JavaParserClass.java
@@ -30,6 +30,7 @@ import com.github.javaparser.ast.ImportDeclaration;
 import com.github.javaparser.ast.Node;
 import com.github.javaparser.ast.body.AnnotationDeclaration;
 import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
+import com.github.javaparser.ast.body.FieldDeclaration;
 import com.github.javaparser.ast.body.MethodDeclaration;
 import com.github.javaparser.ast.body.TypeDeclaration;
 import com.github.javaparser.ast.nodeTypes.NodeWithImplements;
@@ -37,6 +38,7 @@ import com.github.javaparser.ast.nodeTypes.NodeWithMembers;
 import com.github.javaparser.ast.nodeTypes.NodeWithName;
 import com.github.javaparser.ast.type.ClassOrInterfaceType;
 import com.github.javaparser.resolution.SymbolResolver;
+import com.github.lombrozo.testnames.Field;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
@@ -44,6 +46,7 @@ import java.nio.file.Path;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedList;
+import java.util.List;
 import java.util.Optional;
 import java.util.Queue;
 import java.util.function.Predicate;
@@ -197,6 +200,23 @@ final class JavaParserClass {
             );
         return unit.getPackageDeclaration()
             .map(NodeWithName::getNameAsString);
+    }
+
+    /**
+     * Class fields.
+     * @return Fields of the class.
+     */
+    Iterable<Field> fields() {
+        final Iterable<Field> result;
+        if (this.klass instanceof NodeWithMembers) {
+            final List<FieldDeclaration> fields = ((NodeWithMembers<?>) this.klass).getFields();
+            result = fields.stream()
+                .map(JavaParserField::new)
+                .collect(Collectors.toList());
+        } else {
+            result = Collections.emptyList();
+        }
+        return result;
     }
 
     /**

--- a/src/main/java/com/github/lombrozo/testnames/javaparser/JavaParserField.java
+++ b/src/main/java/com/github/lombrozo/testnames/javaparser/JavaParserField.java
@@ -1,0 +1,86 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2022-2025 Volodya Lombrozo
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.github.lombrozo.testnames.javaparser;
+
+import com.github.javaparser.ast.Modifier;
+import com.github.javaparser.ast.Node;
+import com.github.javaparser.ast.body.FieldDeclaration;
+import com.github.javaparser.ast.body.VariableDeclarator;
+import com.github.javaparser.ast.expr.SimpleName;
+import com.github.lombrozo.testnames.Field;
+import java.util.Optional;
+
+/**
+ * JavaParser field.
+ * @since 1.4
+ */
+final class JavaParserField implements Field {
+
+    /**
+     * Field declaration in the source code.
+     */
+    private final FieldDeclaration field;
+
+    /**
+     * Constructor.
+     * @param field Field declaration in the source code.
+     */
+    JavaParserField(final FieldDeclaration field) {
+        this.field = field;
+    }
+
+    @Override
+    public String name() {
+        return this.declarator(this.field)
+            .map(VariableDeclarator::getName)
+            .map(SimpleName::asString)
+            .orElseThrow(() -> new IllegalStateException("Field name is not found"));
+    }
+
+    @Override
+    public boolean isStatic() {
+        return this.field.getModifiers().stream()
+            .anyMatch(modifier -> modifier.getKeyword() == Modifier.Keyword.STATIC);
+    }
+
+    /**
+     * Find variable declarator.
+     * @param node Node to search in.
+     * @return Variable declarator.
+     */
+    private Optional<VariableDeclarator> declarator(final Node node) {
+        final Optional<VariableDeclarator> result;
+        if (node instanceof VariableDeclarator) {
+            result = Optional.of((VariableDeclarator) node);
+        } else {
+            result = node.getChildNodes()
+                .stream()
+                .map(this::declarator)
+                .filter(Optional::isPresent)
+                .map(Optional::get)
+                .findFirst();
+        }
+        return result;
+    }
+}

--- a/src/main/java/com/github/lombrozo/testnames/javaparser/JavaParserTestClass.java
+++ b/src/main/java/com/github/lombrozo/testnames/javaparser/JavaParserTestClass.java
@@ -26,6 +26,7 @@ package com.github.lombrozo.testnames.javaparser;
 
 import com.github.javaparser.ParseProblemException;
 import com.github.javaparser.resolution.SymbolResolver;
+import com.github.lombrozo.testnames.Field;
 import com.github.lombrozo.testnames.TestCase;
 import com.github.lombrozo.testnames.TestClass;
 import com.github.lombrozo.testnames.TestClassCharacteristics;
@@ -36,6 +37,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import org.cactoos.list.ListOf;
 import org.cactoos.scalar.Sticky;
 import org.cactoos.scalar.Unchecked;
 
@@ -153,6 +155,11 @@ public final class JavaParserTestClass implements TestClass {
         this.path = path;
         this.unit = unit;
         this.exclusions = exclusions;
+    }
+
+    @Override
+    public Collection<Field> fields() {
+        return new ListOf<>(this.unit.value().fields());
     }
 
     @Override

--- a/src/main/java/com/github/lombrozo/testnames/rules/RuleProhibitStaticFields.java
+++ b/src/main/java/com/github/lombrozo/testnames/rules/RuleProhibitStaticFields.java
@@ -1,0 +1,94 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2022-2025 Volodya Lombrozo
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.github.lombrozo.testnames.rules;
+
+import com.github.lombrozo.testnames.Complaint;
+import com.github.lombrozo.testnames.Field;
+import com.github.lombrozo.testnames.Rule;
+import com.github.lombrozo.testnames.TestClass;
+import com.github.lombrozo.testnames.complaints.ComplaintLinked;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * Check that a test class does not contain static literals.
+ * Were suggested <a href="https://github.com/volodya-lombrozo/jtcop/issues/302">here</a>.
+ * @since 1.4
+ * @todo #302:30min Add an integration test for the RuleProhibitStaticFields check.
+ *  The test should check that the RuleProhibitStaticFields check works correctly.
+ *  The test should contain a test class with a static and instance fields.
+ */
+public final class RuleProhibitStaticFields implements Rule {
+
+    /**
+     * The test class.
+     */
+    private final TestClass test;
+
+    /**
+     * Constructor.
+     * @param test The test class.
+     */
+    public RuleProhibitStaticFields(final TestClass test) {
+        this.test = test;
+    }
+
+    @Override
+    public List<String> aliases() {
+        return Collections.singletonList(RuleProhibitStaticFields.class.getSimpleName());
+    }
+
+    @Override
+    public Collection<Complaint> complaints() {
+        final Collection<Complaint> result;
+        final List<String> names = this.test.fields().stream()
+            .filter(Field::isStatic)
+            .map(Field::name)
+            .collect(Collectors.toList());
+        if (names.isEmpty()) {
+            result = Collections.emptyList();
+        } else {
+            result = names.stream().map(this::complaint).collect(Collectors.toList());
+        }
+        return result;
+    }
+
+    /**
+     * Generate a complaint for a static field.
+     * @param name Field name
+     * @return Complaint
+     */
+    private Complaint complaint(final String name) {
+        return new ComplaintLinked(
+            String.format(
+                "The static field '%s' was found in the class '%s'", name, this.test.name()
+            ),
+            "Please don't use static fields in the test class; it's better to use constants directly within the test methods.",
+            this.getClass(),
+            "prohibit-static-fields.md"
+        );
+    }
+}

--- a/src/test/java/com/github/lombrozo/testnames/bytecode/BytecodeTestClassTest.java
+++ b/src/test/java/com/github/lombrozo/testnames/bytecode/BytecodeTestClassTest.java
@@ -23,9 +23,11 @@
  */
 package com.github.lombrozo.testnames.bytecode;
 
+import com.github.lombrozo.testnames.Field;
 import com.github.lombrozo.testnames.TestClass;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.stream.Collectors;
 import org.cactoos.bytes.BytesOf;
 import org.cactoos.io.ResourceOf;
 import org.hamcrest.MatcherAssert;
@@ -39,6 +41,39 @@ import org.junit.jupiter.api.io.TempDir;
  * @since 0.1.17
  */
 final class BytecodeTestClassTest {
+
+    @Test
+    void retrievesFields(@TempDir final Path temp) throws Exception {
+        final ResourceOf resource = new ResourceOf("generated/RuleName.class");
+        Files.write(temp.resolve("RuleName.class"), new BytesOf(resource).asBytes());
+        final TestClass test = new BytecodeProject(temp, temp)
+            .testClasses()
+            .iterator()
+            .next();
+        MatcherAssert.assertThat(
+            "We expected to get fields from the test class",
+            test.fields().stream().map(Field::name).collect(Collectors.toList()),
+            Matchers.containsInAnyOrder("PREFIX", "name")
+        );
+    }
+
+    @Test
+    void retrievesStaticFields(@TempDir final Path temp) throws Exception {
+        final ResourceOf resource = new ResourceOf("generated/RuleName.class");
+        Files.write(temp.resolve("RuleName.class"), new BytesOf(resource).asBytes());
+        final TestClass test = new BytecodeProject(temp, temp)
+            .testClasses()
+            .iterator()
+            .next();
+        MatcherAssert.assertThat(
+            "We expected to get all fields from the test class",
+            test.fields().stream()
+                .filter(Field::isStatic)
+                .map(Field::name)
+                .collect(Collectors.toList()),
+            Matchers.contains("PREFIX")
+        );
+    }
 
     @Test
     void checksIfBytecodeIsJUnitExtension(@TempDir final Path temp) throws Exception {

--- a/src/test/java/com/github/lombrozo/testnames/javaparser/JavaParserTestCaseTest.java
+++ b/src/test/java/com/github/lombrozo/testnames/javaparser/JavaParserTestCaseTest.java
@@ -24,6 +24,7 @@
 package com.github.lombrozo.testnames.javaparser;
 
 import com.github.lombrozo.testnames.Assertion;
+import com.github.lombrozo.testnames.Field;
 import com.github.lombrozo.testnames.TestCase;
 import com.github.lombrozo.testnames.rules.RuleEveryTestHasProductionClass;
 import com.github.lombrozo.testnames.rules.RuleNotCamelCase;
@@ -33,6 +34,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Collectors;
 import org.cactoos.list.ListOf;
 import org.cactoos.set.SetOf;
 import org.hamcrest.MatcherAssert;
@@ -395,6 +397,34 @@ final class JavaParserTestCaseTest {
             ),
             statements,
             new IsEqual<>(expected)
+        );
+    }
+
+    @Test
+    void parsesStaticFields() {
+        MatcherAssert.assertThat(
+            "Parsed static fields do not match with expected",
+            new ListOf<>(
+                JavaTestClasses.TEST_WITH_JUNIT_ASSERTIONS.toTestClass().fields()
+            ).stream().filter(Field::isStatic).map(Field::name).collect(Collectors.toList()),
+            Matchers.allOf(
+                Matchers.contains("DEFAULT_EXPLANATION", "DEFAULT_SUPPLIER"),
+                Matchers.not(Matchers.contains("number"))
+            )
+        );
+    }
+
+    @Test
+    void parsesInstanceFields() {
+        MatcherAssert.assertThat(
+            "Parsed instance fields do not match with expected",
+            new ListOf<>(
+                JavaTestClasses.TEST_WITH_JUNIT_ASSERTIONS.toTestClass().fields()
+            ).stream().filter(f -> !f.isStatic()).map(Field::name).collect(Collectors.toList()),
+            Matchers.allOf(
+                Matchers.contains("number"),
+                Matchers.not(Matchers.contains("DEFAULT_EXPLANATION", "DEFAULT_SUPPLIER"))
+            )
         );
     }
 }

--- a/src/test/java/com/github/lombrozo/testnames/rules/RuleProhibitStaticFieldsTest.java
+++ b/src/test/java/com/github/lombrozo/testnames/rules/RuleProhibitStaticFieldsTest.java
@@ -1,0 +1,95 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2022-2025 Volodya Lombrozo
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.github.lombrozo.testnames.rules;
+
+import com.github.lombrozo.testnames.Complaint;
+import com.github.lombrozo.testnames.Field;
+import com.github.lombrozo.testnames.TestClass;
+import com.github.lombrozo.testnames.complaints.ComplaintLinked;
+import java.util.Collection;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test cases for {@link RuleProhibitStaticFields}.
+ * @since 1.4
+ */
+final class RuleProhibitStaticFieldsTest {
+
+    @Test
+    void retrievesAliases() {
+        MatcherAssert.assertThat(
+            "RuleProhibitStaticLiterals should have only one alias with the same name",
+            new RuleProhibitStaticFields(new TestClass.Fake()).aliases(),
+            Matchers.contains("RuleProhibitStaticFields")
+        );
+    }
+
+    @Test
+    void complaintsOnStaticFields() {
+        MatcherAssert.assertThat(
+            "RuleProhibitStaticLiterals should complain on static fields",
+            new RuleProhibitStaticFields(
+                new TestClass.WithFields(new Field.Named("constant", new Field.Static()))
+            ).complaints(),
+            Matchers.not(Matchers.empty())
+        );
+    }
+
+    @Test
+    void generatesMeaningfulComplaint() {
+        final Collection<Complaint> all = new RuleProhibitStaticFields(
+            new TestClass.WithFields(new Field.Named("meaningful", new Field.Static()))
+        ).complaints();
+        MatcherAssert.assertThat(
+            String.format(
+                "RuleProhibitStaticLiterals should generate meaningful complaint. All complaints: %s",
+                all
+            ),
+            all.stream()
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("No complaints found")),
+            Matchers.equalTo(
+                new ComplaintLinked(
+                    "The static field 'meaningful' was found in the class 'FakeClassTest'",
+                    "Please don't use static fields in the test class; it's better to use constants directly within the test methods.",
+                    RuleProhibitStaticFields.class,
+                    "prohibit-static-fields.md"
+                )
+            )
+        );
+    }
+
+    @Test
+    void doesNotComplainOnNonStaticFields() {
+        MatcherAssert.assertThat(
+            "RuleProhibitStaticLiterals should not complain on non-static fields",
+            new RuleProhibitStaticFields(
+                new TestClass.WithFields(new Field.Named("local"))
+            ).complaints(),
+            Matchers.empty()
+        );
+    }
+}

--- a/src/test/resources/TestWithJUnitAssertions.java
+++ b/src/test/resources/TestWithJUnitAssertions.java
@@ -43,6 +43,11 @@ class TestWithJUnitAssertions {
      */
     private final static Supplier<String> DEFAULT_SUPPLIER = () -> TestWithJUnitAssertions.DEFAULT_EXPLANATION;
 
+    /**
+     * Unnecessary number.
+     */
+    private final int number = 1;
+
     @Test
     void withMessages() {
         Assertions.assertEquals("1", "1", DEFAULT_EXPLANATION);


### PR DESCRIPTION
This pull request introduces the `RuleProhibitStaticFields` to ensure test classes do not contain static fields. It adds the necessary interfaces and implementations to support field detection and rule enforcement. Additionally, it includes unit tests to verify the functionality of the new rule. Related to #302.