### PR TITLE
test(#514): Add integration test for static fields detection

### DIFF
--- a/src/it/all-incorrect/src/test/java/StaticFieldsInTest.java
+++ b/src/it/all-incorrect/src/test/java/StaticFieldsInTest.java
@@ -1,0 +1,36 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2022-2025 Volodya Lombrozo
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Assertions;
+
+final class StaticFieldsInTest {
+
+    private final static String MSG = "We can't use static fields in tests";
+
+    @Test
+    void checksCorrectness() {
+        Assertions.assertTrue((true || false) && true, MSG);
+    }
+}

--- a/src/it/all-incorrect/verify.groovy
+++ b/src/it/all-incorrect/verify.groovy
@@ -37,6 +37,7 @@ String log = new File(basedir, 'build.log').text;
   "Test name 'createsWithAnothertest' doesn't follow naming rules, because test name doesn't have to contain the word 'test'",
   "Test name 'testAnother' doesn't follow naming rules, because test name doesn't have to contain the word 'test'",
   "Test name 'testAnother' doesn't follow naming rules, because the test name has to be written using present tense",
+  "The static field 'MSG' was found in the class 'StaticFieldsInTest.java'",
   "Method 'containsLineHitter' contains line hitter anti-pattern",
   "The test class 'UsesInheritenceTest.java' has the parent class 'AbstractTest'. Inheritance in tests is dangerous for maintainability",
   "Method 'testsSomething' contains excessive number of mocks: 3. max allowed: 1.",

--- a/src/main/java/com/github/lombrozo/testnames/rules/RuleProhibitStaticFields.java
+++ b/src/main/java/com/github/lombrozo/testnames/rules/RuleProhibitStaticFields.java
@@ -37,9 +37,6 @@ import java.util.stream.Collectors;
  * Check that a test class does not contain static literals.
  * Were suggested <a href="https://github.com/volodya-lombrozo/jtcop/issues/302">here</a>.
  * @since 1.4
- * @todo #302:30min Add an integration test for the RuleProhibitStaticFields check.
- *  The test should check that the RuleProhibitStaticFields check works correctly.
- *  The test should contain a test class with a static and instance fields.
  */
 public final class RuleProhibitStaticFields implements Rule {
 


### PR DESCRIPTION
This pull request introduces a new test case `StaticFieldsInTest` in the `all-incorrect\' integration test to verify the detection of static fields in test classes. Closes #514.