### PR TITLE
feat(#513): Add suppression support for `RuleProhibitStaticFields` at the field level

### DIFF
--- a/src/it/assertions/src/test/java/AssertionsTest.java
+++ b/src/it/assertions/src/test/java/AssertionsTest.java
@@ -40,21 +40,19 @@ import java.util.function.Consumer;
  * Test class for assertions.
  *
  * @since 0.1
- * @todo #302:30min Allow suppression of the RuleProhibitStaticFields in the field level.
- *  The RuleProhibitStaticFields should be suppressed in the field level.
- *  Currently, the RuleProhibitStaticFields is suppressed in the class level only.
  */
-@SuppressWarnings("JTCOP.RuleProhibitStaticFields")
 class AssertionsTest {
 
     /**
      * Default explanation for assertions.
      */
+    @SuppressWarnings("JTCOP.RuleProhibitStaticFields")
     private final static String CONSTANT = "Message";
 
     /**
      * Default message for assertions.
      */
+    @SuppressWarnings("JTCOP.RuleProhibitStaticFields")
     private static final String MSG = "MESSAGE";
 
     @Test

--- a/src/main/java/com/github/lombrozo/testnames/Field.java
+++ b/src/main/java/com/github/lombrozo/testnames/Field.java
@@ -23,6 +23,10 @@
  */
 package com.github.lombrozo.testnames;
 
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
 /**
  * Field abstraction.
  * @since 1.4
@@ -42,6 +46,12 @@ public interface Field {
     boolean isStatic();
 
     /**
+     * Suppressed rules.
+     * @return Suppressed rules.
+     */
+    List<String> suppressed();
+
+    /**
      * Constant fake field.
      * @since 1.4
      */
@@ -55,6 +65,11 @@ public interface Field {
         @Override
         public boolean isStatic() {
             return false;
+        }
+
+        @Override
+        public List<String> suppressed() {
+            return Collections.emptyList();
         }
     }
 
@@ -101,6 +116,11 @@ public interface Field {
         public boolean isStatic() {
             return this.origin.isStatic();
         }
+
+        @Override
+        public List<String> suppressed() {
+            return Collections.emptyList();
+        }
     }
 
     /**
@@ -137,6 +157,62 @@ public interface Field {
         @Override
         public boolean isStatic() {
             return true;
+        }
+
+        @Override
+        public List<String> suppressed() {
+            return Collections.emptyList();
+        }
+    }
+
+    /**
+     * Field with suppressed rules.
+     * @since 1.4
+     */
+    final class Suppressed implements Field {
+
+        /**
+         * Delegate.
+         */
+        private final Field origin;
+
+        /**
+         * Suppressed rules.
+         */
+        private final List<String> rules;
+
+        /**
+         * Constructor.
+         * @param origin Origin field.
+         * @param suppressed Suppressed rules.
+         */
+        public Suppressed(final Field origin, final String... suppressed) {
+            this(origin, Arrays.asList(suppressed));
+        }
+
+        /**
+         * Constructor.
+         * @param origin Origin field.
+         * @param suppressed Suppressed rules.
+         */
+        Suppressed(final Field origin, final List<String> suppressed) {
+            this.origin = origin;
+            this.rules = suppressed;
+        }
+
+        @Override
+        public String name() {
+            return this.origin.name();
+        }
+
+        @Override
+        public boolean isStatic() {
+            return this.origin.isStatic();
+        }
+
+        @Override
+        public List<String> suppressed() {
+            return Collections.unmodifiableList(this.rules);
         }
     }
 }

--- a/src/main/java/com/github/lombrozo/testnames/bytecode/BytecodeField.java
+++ b/src/main/java/com/github/lombrozo/testnames/bytecode/BytecodeField.java
@@ -24,11 +24,21 @@
 package com.github.lombrozo.testnames.bytecode;
 
 import com.github.lombrozo.testnames.Field;
+import java.lang.annotation.RetentionPolicy;
+import java.util.Collections;
+import java.util.List;
 import javassist.CtField;
 import javassist.Modifier;
 
 /**
  * Class field in bytecode.
+ * <p>
+ * Pay attention, that {@link BytecodeField} returns empty list of suppressed rules
+ * in {@link #suppressed()} method. This is because it is not possible to
+ * determine the suppressed rules in bytecode. Reason is that {@link SuppressWarnings}
+ * has {@link RetentionPolicy#SOURCE} retention policy, so it is not available
+ * in bytecode.
+ * </p>
  * @since 1.4
  */
 public final class BytecodeField implements Field {
@@ -54,5 +64,10 @@ public final class BytecodeField implements Field {
     @Override
     public boolean isStatic() {
         return Modifier.isStatic(this.field.getModifiers());
+    }
+
+    @Override
+    public List<String> suppressed() {
+        return Collections.emptyList();
     }
 }

--- a/src/main/java/com/github/lombrozo/testnames/javaparser/JavaParserField.java
+++ b/src/main/java/com/github/lombrozo/testnames/javaparser/JavaParserField.java
@@ -29,7 +29,9 @@ import com.github.javaparser.ast.body.FieldDeclaration;
 import com.github.javaparser.ast.body.VariableDeclarator;
 import com.github.javaparser.ast.expr.SimpleName;
 import com.github.lombrozo.testnames.Field;
+import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 /**
  * JavaParser field.
@@ -62,6 +64,11 @@ final class JavaParserField implements Field {
     public boolean isStatic() {
         return this.field.getModifiers().stream()
             .anyMatch(modifier -> modifier.getKeyword() == Modifier.Keyword.STATIC);
+    }
+
+    @Override
+    public List<String> suppressed() {
+        return new SuppressedAnnotations(this.field).suppressed().collect(Collectors.toList());
     }
 
     /**

--- a/src/main/java/com/github/lombrozo/testnames/javaparser/SuppressedAnnotations.java
+++ b/src/main/java/com/github/lombrozo/testnames/javaparser/SuppressedAnnotations.java
@@ -33,7 +33,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 /**
- * Parser for test case.
+ * JavaParser suppressed annotations.
  *
  * @since 0.1.14
  */

--- a/src/main/java/com/github/lombrozo/testnames/rules/RuleProhibitStaticFields.java
+++ b/src/main/java/com/github/lombrozo/testnames/rules/RuleProhibitStaticFields.java
@@ -63,6 +63,7 @@ public final class RuleProhibitStaticFields implements Rule {
         final Collection<Complaint> result;
         final List<String> names = this.test.fields().stream()
             .filter(Field::isStatic)
+            .filter(field -> !this.suppressed(field))
             .map(Field::name)
             .collect(Collectors.toList());
         if (names.isEmpty()) {
@@ -87,5 +88,14 @@ public final class RuleProhibitStaticFields implements Rule {
             this.getClass(),
             "prohibit-static-fields.md"
         );
+    }
+
+    /**
+     * Is the rule suppressed for the field?
+     * @param field Field to check.
+     * @return True if the rule is suppressed for the field.
+     */
+    private boolean suppressed(final Field field) {
+        return field.suppressed().stream().anyMatch(name -> this.aliases().contains(name));
     }
 }

--- a/src/test/java/com/github/lombrozo/testnames/javaparser/JavaParserFieldTest.java
+++ b/src/test/java/com/github/lombrozo/testnames/javaparser/JavaParserFieldTest.java
@@ -1,0 +1,83 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2022-2025 Volodya Lombrozo
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.github.lombrozo.testnames.javaparser;
+
+import com.github.lombrozo.testnames.Field;
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.cactoos.list.ListOf;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test case for {@link JavaParserField}.
+ * @since 1.4
+ */
+final class JavaParserFieldTest {
+
+    @Test
+    void parsesStaticFields() {
+        MatcherAssert.assertThat(
+            "Parsed static fields do not match with expected",
+            new ListOf<>(
+                JavaTestClasses.TEST_WITH_JUNIT_ASSERTIONS.toTestClass().fields()
+            ).stream().filter(Field::isStatic).map(Field::name).collect(Collectors.toList()),
+            Matchers.allOf(
+                Matchers.contains("DEFAULT_EXPLANATION", "DEFAULT_SUPPLIER"),
+                Matchers.not(Matchers.contains("number"))
+            )
+        );
+    }
+
+    @Test
+    void parsesInstanceFields() {
+        MatcherAssert.assertThat(
+            "Parsed instance fields do not match with expected",
+            new ListOf<>(
+                JavaTestClasses.TEST_WITH_JUNIT_ASSERTIONS.toTestClass().fields()
+            ).stream().filter(f -> !f.isStatic()).map(Field::name).collect(Collectors.toList()),
+            Matchers.allOf(
+                Matchers.contains("number"),
+                Matchers.not(Matchers.contains("DEFAULT_EXPLANATION", "DEFAULT_SUPPLIER"))
+            )
+        );
+    }
+
+    @Test
+    void parsesSuppressedWarningsAnnotations() {
+        final List<String> suppressed = new ListOf<>(
+            JavaTestClasses.TEST_WITH_JUNIT_ASSERTIONS.toTestClass().fields()
+        ).stream().map(Field::suppressed).flatMap(Collection::stream).collect(Collectors.toList());
+        MatcherAssert.assertThat(
+            String.format(
+                "Parsed suppressed warnings annotations do not match with expected, found: %s",
+                suppressed
+            ),
+            suppressed,
+            Matchers.containsInAnyOrder("Monkey", "Donkey", "Elephant", "Crocodile")
+        );
+    }
+}

--- a/src/test/java/com/github/lombrozo/testnames/javaparser/JavaParserTestCaseTest.java
+++ b/src/test/java/com/github/lombrozo/testnames/javaparser/JavaParserTestCaseTest.java
@@ -24,7 +24,6 @@
 package com.github.lombrozo.testnames.javaparser;
 
 import com.github.lombrozo.testnames.Assertion;
-import com.github.lombrozo.testnames.Field;
 import com.github.lombrozo.testnames.TestCase;
 import com.github.lombrozo.testnames.rules.RuleEveryTestHasProductionClass;
 import com.github.lombrozo.testnames.rules.RuleNotCamelCase;
@@ -34,7 +33,6 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
-import java.util.stream.Collectors;
 import org.cactoos.list.ListOf;
 import org.cactoos.set.SetOf;
 import org.hamcrest.MatcherAssert;
@@ -397,34 +395,6 @@ final class JavaParserTestCaseTest {
             ),
             statements,
             new IsEqual<>(expected)
-        );
-    }
-
-    @Test
-    void parsesStaticFields() {
-        MatcherAssert.assertThat(
-            "Parsed static fields do not match with expected",
-            new ListOf<>(
-                JavaTestClasses.TEST_WITH_JUNIT_ASSERTIONS.toTestClass().fields()
-            ).stream().filter(Field::isStatic).map(Field::name).collect(Collectors.toList()),
-            Matchers.allOf(
-                Matchers.contains("DEFAULT_EXPLANATION", "DEFAULT_SUPPLIER"),
-                Matchers.not(Matchers.contains("number"))
-            )
-        );
-    }
-
-    @Test
-    void parsesInstanceFields() {
-        MatcherAssert.assertThat(
-            "Parsed instance fields do not match with expected",
-            new ListOf<>(
-                JavaTestClasses.TEST_WITH_JUNIT_ASSERTIONS.toTestClass().fields()
-            ).stream().filter(f -> !f.isStatic()).map(Field::name).collect(Collectors.toList()),
-            Matchers.allOf(
-                Matchers.contains("number"),
-                Matchers.not(Matchers.contains("DEFAULT_EXPLANATION", "DEFAULT_SUPPLIER"))
-            )
         );
     }
 }

--- a/src/test/java/com/github/lombrozo/testnames/rules/RuleProhibitStaticFieldsTest.java
+++ b/src/test/java/com/github/lombrozo/testnames/rules/RuleProhibitStaticFieldsTest.java
@@ -110,7 +110,7 @@ final class RuleProhibitStaticFieldsTest {
     }
 
     @Test
-    void complaintOnStaticFieldsWithDifferentSuppression() {
+    void complaintsOnStaticFieldsWithDifferentSuppression() {
         MatcherAssert.assertThat(
             "RuleProhibitStaticLiterals should complain on static fields with different suppression",
             new RuleProhibitStaticFields(

--- a/src/test/java/com/github/lombrozo/testnames/rules/RuleProhibitStaticFieldsTest.java
+++ b/src/test/java/com/github/lombrozo/testnames/rules/RuleProhibitStaticFieldsTest.java
@@ -92,4 +92,31 @@ final class RuleProhibitStaticFieldsTest {
             Matchers.empty()
         );
     }
+
+    @Test
+    void skipsSuppressedFields() {
+        MatcherAssert.assertThat(
+            "RuleProhibitStaticLiterals should not complain on suppressed fields",
+            new RuleProhibitStaticFields(
+                new TestClass.WithFields(
+                    new Field.Suppressed(
+                        new Field.Static(),
+                        "RuleProhibitStaticFields"
+                    )
+                )
+            ).complaints(),
+            Matchers.empty()
+        );
+    }
+
+    @Test
+    void complaintOnStaticFieldsWithDifferentSuppression() {
+        MatcherAssert.assertThat(
+            "RuleProhibitStaticLiterals should complain on static fields with different suppression",
+            new RuleProhibitStaticFields(
+                new TestClass.WithFields(new Field.Suppressed(new Field.Static(), "RuleUnknown"))
+            ).complaints(),
+            Matchers.not(Matchers.empty())
+        );
+    }
 }

--- a/src/test/resources/TestWithJUnitAssertions.java
+++ b/src/test/resources/TestWithJUnitAssertions.java
@@ -36,16 +36,19 @@ class TestWithJUnitAssertions {
     /**
      * Default explanation for assertions.
      */
+    @SuppressWarnings({"JTCOP.Monkey"})
     private final static String DEFAULT_EXPLANATION = "JUnit explanation";
 
     /**
      * Default supplier for assertions.
      */
+    @SuppressWarnings({"JTCOP.Donkey", "JTCOP.Elephant"})
     private final static Supplier<String> DEFAULT_SUPPLIER = () -> TestWithJUnitAssertions.DEFAULT_EXPLANATION;
 
     /**
      * Unnecessary number.
      */
+    @SuppressWarnings("JTCOP.Crocodile")
     private final int number = 1;
 
     @Test


### PR DESCRIPTION
This pull request introduces the ability to suppress the `RuleProhibitStaticFields` at the field level, enhancing the flexibility of rule application. It also includes the implementation of a new method to retrieve suppressed rules for fields, and updates the test suite to cover these changes.

Closes #513.