### PR TITLE
feat(#592): add Jekyll documentation site and update README for local build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,7 @@ target
 .project
 .settings/
 
+
+# jekyll
+docs/_site/
+_site/

--- a/docs/Gemfile
+++ b/docs/Gemfile
@@ -1,0 +1,3 @@
+source 'https://rubygems.org'
+gem 'jekyll', '~> 4.4.1'
+gem 'just-the-docs'

--- a/docs/Gemfile.lock
+++ b/docs/Gemfile.lock
@@ -1,0 +1,174 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    addressable (2.8.7)
+      public_suffix (>= 2.0.2, < 7.0)
+    base64 (0.3.0)
+    bigdecimal (3.3.1)
+    colorator (1.1.0)
+    concurrent-ruby (1.3.5)
+    csv (3.3.5)
+    em-websocket (0.5.3)
+      eventmachine (>= 0.12.9)
+      http_parser.rb (~> 0)
+    eventmachine (1.2.7)
+    ffi (1.17.2)
+    ffi (1.17.2-aarch64-linux-gnu)
+    ffi (1.17.2-aarch64-linux-musl)
+    ffi (1.17.2-arm-linux-gnu)
+    ffi (1.17.2-arm-linux-musl)
+    ffi (1.17.2-arm64-darwin)
+    ffi (1.17.2-x86-linux-gnu)
+    ffi (1.17.2-x86-linux-musl)
+    ffi (1.17.2-x86_64-darwin)
+    ffi (1.17.2-x86_64-linux-gnu)
+    ffi (1.17.2-x86_64-linux-musl)
+    forwardable-extended (2.6.0)
+    google-protobuf (4.33.1)
+      bigdecimal
+      rake (>= 13)
+    google-protobuf (4.33.1-aarch64-linux-gnu)
+      bigdecimal
+      rake (>= 13)
+    google-protobuf (4.33.1-aarch64-linux-musl)
+      bigdecimal
+      rake (>= 13)
+    google-protobuf (4.33.1-arm64-darwin)
+      bigdecimal
+      rake (>= 13)
+    google-protobuf (4.33.1-x86-linux-gnu)
+      bigdecimal
+      rake (>= 13)
+    google-protobuf (4.33.1-x86-linux-musl)
+      bigdecimal
+      rake (>= 13)
+    google-protobuf (4.33.1-x86_64-darwin)
+      bigdecimal
+      rake (>= 13)
+    google-protobuf (4.33.1-x86_64-linux-gnu)
+      bigdecimal
+      rake (>= 13)
+    google-protobuf (4.33.1-x86_64-linux-musl)
+      bigdecimal
+      rake (>= 13)
+    http_parser.rb (0.8.0)
+    i18n (1.14.7)
+      concurrent-ruby (~> 1.0)
+    jekyll (4.4.1)
+      addressable (~> 2.4)
+      base64 (~> 0.2)
+      colorator (~> 1.0)
+      csv (~> 3.0)
+      em-websocket (~> 0.5)
+      i18n (~> 1.0)
+      jekyll-sass-converter (>= 2.0, < 4.0)
+      jekyll-watch (~> 2.0)
+      json (~> 2.6)
+      kramdown (~> 2.3, >= 2.3.1)
+      kramdown-parser-gfm (~> 1.0)
+      liquid (~> 4.0)
+      mercenary (~> 0.3, >= 0.3.6)
+      pathutil (~> 0.9)
+      rouge (>= 3.0, < 5.0)
+      safe_yaml (~> 1.0)
+      terminal-table (>= 1.8, < 4.0)
+      webrick (~> 1.7)
+    jekyll-include-cache (0.2.1)
+      jekyll (>= 3.7, < 5.0)
+    jekyll-sass-converter (3.1.0)
+      sass-embedded (~> 1.75)
+    jekyll-seo-tag (2.8.0)
+      jekyll (>= 3.8, < 5.0)
+    jekyll-watch (2.2.1)
+      listen (~> 3.0)
+    json (2.16.0)
+    just-the-docs (0.10.1)
+      jekyll (>= 3.8.5)
+      jekyll-include-cache
+      jekyll-seo-tag (>= 2.0)
+      rake (>= 12.3.1)
+    kramdown (2.5.1)
+      rexml (>= 3.3.9)
+    kramdown-parser-gfm (1.1.0)
+      kramdown (~> 2.0)
+    liquid (4.0.4)
+    listen (3.9.0)
+      rb-fsevent (~> 0.10, >= 0.10.3)
+      rb-inotify (~> 0.9, >= 0.9.10)
+    mercenary (0.4.0)
+    pathutil (0.16.2)
+      forwardable-extended (~> 2.6)
+    public_suffix (6.0.2)
+    rake (13.3.1)
+    rb-fsevent (0.11.2)
+    rb-inotify (0.11.1)
+      ffi (~> 1.0)
+    rexml (3.4.4)
+    rouge (4.6.1)
+    safe_yaml (1.0.5)
+    sass-embedded (1.94.2)
+      google-protobuf (~> 4.31)
+      rake (>= 13)
+    sass-embedded (1.94.2-aarch64-linux-android)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.94.2-aarch64-linux-gnu)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.94.2-aarch64-linux-musl)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.94.2-aarch64-mingw-ucrt)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.94.2-arm-linux-androideabi)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.94.2-arm-linux-gnueabihf)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.94.2-arm-linux-musleabihf)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.94.2-arm64-darwin)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.94.2-riscv64-linux-android)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.94.2-riscv64-linux-gnu)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.94.2-riscv64-linux-musl)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.94.2-x86_64-darwin)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.94.2-x86_64-linux-android)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.94.2-x86_64-linux-gnu)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.94.2-x86_64-linux-musl)
+      google-protobuf (~> 4.31)
+    terminal-table (3.0.2)
+      unicode-display_width (>= 1.1.1, < 3)
+    unicode-display_width (2.6.0)
+    webrick (1.9.1)
+
+PLATFORMS
+  aarch64-linux-android
+  aarch64-linux-gnu
+  aarch64-linux-musl
+  aarch64-mingw-ucrt
+  arm-linux-androideabi
+  arm-linux-gnu
+  arm-linux-gnueabihf
+  arm-linux-musl
+  arm-linux-musleabihf
+  arm64-darwin
+  riscv64-linux-android
+  riscv64-linux-gnu
+  riscv64-linux-musl
+  ruby
+  x86-linux-gnu
+  x86-linux-musl
+  x86_64-darwin
+  x86_64-linux-android
+  x86_64-linux-gnu
+  x86_64-linux-musl
+
+DEPENDENCIES
+  jekyll (~> 4.4.1)
+  just-the-docs
+
+BUNDLED WITH
+   2.6.2

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,9 +1,20 @@
 # Documentation
 
 This directory contains the documentation for the project.
+All necessary documents can be found in [this](./) directory.
+Additionally, jtcop uses [Jekyll](https://jekyllrb.com/) to generate the site, which is accessible [here](https://volodya.lombrozo.dev/jtcop/).
 
-## Rules
+## Build Site Locally
 
-This directory contains the documentation for the rules.
-- [Present Tense](rules/present-tense.md)
-- [Camel Case](rules/camel-case.md)
+To build the site locally, use the following command:
+
+```bash
+cd docs
+jekyll build
+```
+
+Alternatively, you can use:
+
+```bash
+jekyll build -s docs
+```

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,0 +1,30 @@
+title: jtcop
+email: volodya.lombrozo@gmail.com
+description: Maven Plugin for checking tests in Java projects
+baseurl: "/jtcop"
+url: "https://volodya.lombrozo.dev/jtcop"
+github_username:  volodya-lombrozo
+
+theme: just-the-docs
+
+exclude:
+  - .sass-cache/
+  - .jekyll-cache/
+  - gemfiles/
+  - Gemfile
+  - Gemfile.lock
+  - node_modules/
+  - vendor/bundle/
+  - vendor/cache/
+  - vendor/gems/
+  - vendor/ruby/
+  - articles/
+  - docs/articles/
+
+# just-the-docs configs
+gh_edit_link: true
+gh_edit_link_text: "Edit this page on GitHub."
+gh_edit_repository: "https://github.com/volodya-lombrozo/jtcop"
+gh_edit_source: docs
+gh_edit_branch: "main"
+gh_edit_view_mode: "tree"

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,17 @@
+---
+layout: home
+---
+
+# Welcome to jtcop
+
+A linter for writing clean, readable, and maintainable unit tests in Java.
+
+📘 Explore the rules in the left menu to learn how jtcop can improve your test code quality.
+
+`jtcop` enforces these rules automatically, but you can follow them manually in any Java project.
+
+→ Powered by [GitHub: volodya-lombrozo/jtcop](https://github.com/volodya-lombrozo/jtcop)
+
+→ Report issues or contribute: [GitHub Issues](https://github.com/volodya-lombrozo/jtcop/issues)
+
+→ Inspired by [Yegor256's testing principles](https://www.yegor256.com/2023/01/19/layout-of-tests.html)

--- a/docs/rules/all-have-production-class.md
+++ b/docs/rules/all-have-production-class.md
@@ -1,7 +1,14 @@
-**# All Tests Have Production Class
+---
+title: RuleAllTestsHaveProductionClass
+id: all-have-production-class
+rule: RuleAllTestsHaveProductionClass
+layout: default
+---
+
+# All Tests Have Production Class
 
 Rule codename: _RuleAllTestsHaveProductionClass_
-___
+
 The test class should have the same name as the production class, with the
 suffix `Test`. For instance, if there is a class named `User`, then there should
 be a test class named `UserTest`.
@@ -23,4 +30,4 @@ Annotations, Interfaces,
 ### Rationale
 
 You can read more about that
-rule [here](https://www.yegor256.com/2023/01/19/layout-of-tests.html#test-classes).**
+rule [here](https://www.yegor256.com/2023/01/19/layout-of-tests.html#test-classes).

--- a/docs/rules/camel-case.md
+++ b/docs/rules/camel-case.md
@@ -1,3 +1,9 @@
+---
+title: RuleNotCamelCase
+id: cammel-case
+layout: default
+---
+
 # Camel Case
 
 Each test name has to be written by using [camel case](https://en.wikipedia.org/wiki/Camel_case).

--- a/docs/rules/empty-assertion-message.md
+++ b/docs/rules/empty-assertion-message.md
@@ -1,7 +1,12 @@
+---
+title: RuleAssertionMessage
+id: assertion-message
+layout: default
+---
+
 # Assertion Message: At Least One Assertion is Required
 
 Rule codename: _RuleAssertionMessage_
-___
 
 Each assertion in the test should have the description message.
 The assertion message should be meaningful and provide information

--- a/docs/rules/inheritance-in-tests.md
+++ b/docs/rules/inheritance-in-tests.md
@@ -1,24 +1,32 @@
+---
+title: RuleInheritanceInTests
+id: inheritance-in-tests
+layout: default
+---
+
 # Inheritance in Tests
 
 Rule codename: _RuleInheritanceInTests_
-___
+
 The test class should not extend any other class. Test inheritance can lead to
 increased complexity, making tests harder to understand and maintain. Each test
 class should be self-contained and focused solely on testing the functionality
 of the production code it targets.
 
-* Correct: A test class without a parent:
-  ```java
-  public class UserTest {
-      // test methods
-  }
-  ```
-* Wrong: A test class that extends another class:
-  ```java
-    public class UserTest extends BaseTest {
-        // test methods
-    }
-  ```
+*Correct*: A test class without a parent:
+
+```java
+public class UserTest {
+    // test methods
+}
+```
+*Wrong*: A test class that extends another class:
+
+```java
+public class UserTest extends BaseTest {
+    // test methods
+}
+```
 
 Inheritance in tests can obscure the context of the test by introducing shared
 state or behavior from parent classes, leading to subtle bugs and making it

--- a/docs/rules/line-hitter.md
+++ b/docs/rules/line-hitter.md
@@ -1,28 +1,44 @@
+---
+title: LineHitterRule
+id: line-hitter
+layout: default
+---
+
 # Line hitter
 At first glance, the tests cover everything and code coverage tools confirm it with 100%, but in reality the tests merely hit the code, without doing any output analysis.
 
 ## Example
 Code to test
+
 ```java
-    int sum(a, b) {
-        return a + b;
-    }
+int sum(a, b) {
+    return a + b;
+}
 ```
+
 ### Bad
+
 ```java
-    @Test
-    void someTest() {
-        int a = sum(1, 3);
-        assertThat("msg", true, equalTo(true));
-        assertThat("msg", false, equalTo(false));
-        assertThat("msg", true || false, equalTo(true));
-    }
+@Test
+void someTest() {
+    int a = sum(1, 3);
+    assertThat("msg", true, equalTo(true));
+    assertThat("msg", false, equalTo(false));
+    assertThat("msg", true || false, equalTo(true));
+}
 ```
+
 ### Good
+
 ```java
-    @Test
-    void someTest() {
-        int actual = sum(1, 3);
-        assertThat("1 plus 3 is 4", actual, equalTo(4));
-    }
+@Test
+void someTest() {
+    int actual = sum(1, 3);
+    assertThat("1 plus 3 is 4", actual, equalTo(4));
+}
 ```
+
+### Ignoring the Rule
+
+To ignore this rule, annotate a method or class with `@SuppressWarnings("JTCOP.LineHitterRule")`.
+

--- a/docs/rules/mockery.md
+++ b/docs/rules/mockery.md
@@ -1,3 +1,9 @@
+---
+title: RuleTestCaseContainsMockery
+id: mockery
+layout: default
+---
+
 # Mockery
 
 Sometimes mocking can be good, and handy. But sometimes developers can lose

--- a/docs/rules/no-assertions.md
+++ b/docs/rules/no-assertions.md
@@ -1,13 +1,19 @@
+---
+title: RuleAssertionMessage
+id: no-assertions
+layout: default
+---
+
 # Assertion Message: At Least One Assertion is Required
 
 Rule codename: _RuleAssertionMessage_
-___
 
 Each test case has to contain at least one assertion. The assertion message
 should be meaningful and provide information about the expected and actual
 values or behaviour.
 
 Wrong:
+
 ```java
 @Test
 void checks() {
@@ -27,6 +33,7 @@ void checks() {
 ```
 
 Correct:
+
 ```java
 @Test
 void checks() {
@@ -47,7 +54,7 @@ void checks() {
 
 We support only Hamcrest and JUnit 5 assertions. 
 
-Exceptions:
+In order to suppress this rule, you can use the following annotation:
 `@SuppressedWarnings("JTCOP.RuleAssertionMessage")`.
 
 You can read more about that

--- a/docs/rules/not-spam.md
+++ b/docs/rules/not-spam.md
@@ -1,11 +1,17 @@
+---
+title: RuleNotSpam
+id: not-spam
+layout: default
+---
+
 # Test Name: Do Not Repeat Characters
 
 Rule codename: _RuleNotSpam_
-___
 
 Each test name should be meaningful without any repeating characters.
 
 Wrong:
+
 ```java
 @Test
 void checksSss() {
@@ -19,6 +25,7 @@ void checksUnsuccessfullyYeaaa(){
 ```
 
 Correct:
+
 ```java
 @Test
 void checksSuccessfully() {

--- a/docs/rules/not-special-characters.md
+++ b/docs/rules/not-special-characters.md
@@ -1,11 +1,17 @@
+---
+title: RuleNotUsesSpecialCharacters
+id: not-uses-special-characters
+layout: default
+---
+
 # Test Name: Don't Use Special Characters
 
 Rule codename: _RuleNotUsesSpecialCharacters_
-___
 
 Each test name should not contain special characters like `$` or `_`.
 
 Wrong:
+
 ```java
 @Test
 void checks_successfully() {
@@ -19,6 +25,7 @@ void checks$unsuccessfully(){
 ```
 
 Correct:
+
 ```java
 @Test
 void checksSuccessfully() {

--- a/docs/rules/only-test-methods.md
+++ b/docs/rules/only-test-methods.md
@@ -1,7 +1,12 @@
+---
+title: RuleOnlyTestMethods
+id: only-test-methods
+layout: default
+---
+
 # Only test methods
 
 Rule codename: _RuleOnlyTestMethods_
-___
 
 Each test class has to contain **only** test methods. That is all.
 The _RuleOnlyTestMethods_ rule is rather strict, hence it is considered
@@ -10,7 +15,6 @@ please enable experimental features in your `pom.xml` file by switching the
 flag:
 
 ```xml
-
 <configuration>
   <experimental>true</experimental>
 </configuration>

--- a/docs/rules/present-tense.md
+++ b/docs/rules/present-tense.md
@@ -1,3 +1,9 @@
+---
+title: PresentTense
+id: present-tense
+layout: default
+---
+
 # Present tense
 
 The test method name should be a sentence that describes the test case using

--- a/docs/rules/prohibit-static-fields.md
+++ b/docs/rules/prohibit-static-fields.md
@@ -1,7 +1,13 @@
+---
+title: RuleProhibitStaticFields
+id: prohibit-static-fields
+layout: default
+---
+
 # Prohibit Static Fields in Test Classes
 
 Rule codename: _RuleProhibitStaticFields_
-___
+
 This rule ensures that test classes do not contain static fields. Static fields
 in test classes can lead to shared state between tests, which can cause tests to
 be interdependent and lead to flaky tests. Instead, constants should be used

--- a/docs/rules/rule-not-contains-test-word.md
+++ b/docs/rules/rule-not-contains-test-word.md
@@ -1,7 +1,12 @@
+---
+title: RuleNotContainsTestWord
+id: not-contains-test-word
+layout: default
+---
+
 # Avoid 'test' Word in Test Names
 
 Rule codename: _RuleNotContainsTestWord_
-___
 
 Test names should not contain the word 'test'. This rule ensures that test names
 are descriptive and do not rely on the generic term 'test', which can be

--- a/docs/rules/test-class-name.md
+++ b/docs/rules/test-class-name.md
@@ -1,6 +1,11 @@
+---
+title: RuleCorrectTestName
+id: correct-test-name
+layout: default
+---
+
 # Test Class Name
 Rule codename: _RuleCorrectTestName_
-___
 
 The test class name should start or end with one of the next prefixes:
 - `Test`
@@ -10,6 +15,7 @@ The test class name should start or end with one of the next prefixes:
 - `ITCase`
 
 Examples of valid test class names:
+
 ```java
 public class UserTest {
     // valid


### PR DESCRIPTION
This PR adds Jekyll documentation for `jtcop`.

Related to #592