### PR TITLE
fix(#563): add test to handle unresolved symbol types in assertion messages

### DIFF
--- a/src/test/java/com/github/lombrozo/testnames/javaparser/AssertionOfHamcrestTest.java
+++ b/src/test/java/com/github/lombrozo/testnames/javaparser/AssertionOfHamcrestTest.java
@@ -189,4 +189,21 @@ final class AssertionOfHamcrestTest {
             Matchers.is(false)
         );
     }
+
+    @Test
+    void parsesAbsentAssertionMessageEvenIfArgumentTypeCantBeResolved() {
+        MatcherAssert.assertThat(
+            "We expect that assertion has no explanation message, when argument type can't be resolved",
+            JavaTestClasses.TEST_WITH_HAMCREST_ASSERTIONS
+                .method("checksTheCaseFromThe563issue")
+                .statements()
+                .map(AssertionOfHamcrest::new)
+                .filter(AssertionOfHamcrest::isAssertion)
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("No assertions found"))
+                .explanation()
+                .isPresent(),
+            Matchers.is(false)
+        );
+    }
 }

--- a/src/test/resources/TestWithHamcrestAssertions.java
+++ b/src/test/resources/TestWithHamcrestAssertions.java
@@ -31,6 +31,10 @@ import some.framework.HttpStatus;
 import some.framework.UnirestException;
 import some.framework.HttpResponseBodyMatcher;
 import some.framework.HttpResponseStatusMatcher;
+import some.framework.XtSticky;
+import some.framework.Xtory;
+import some.framework.XtYaml;
+import java.util.Collections;
 import java.util.function.Supplier;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
@@ -135,6 +139,20 @@ class TestWithHamcrestAssertions {
                     "Parameter 'capacity' could not be processed, it should be of type Integer"
                 )
             )
+        );
+    }
+
+    /**
+     * This is test for the issue #563.
+     * You can read more about the issue right here:
+     * https://github.com/volodya-lombrozo/jtcop/issues/563
+     */
+    @Test
+    void checksTheCaseFromThe563issue() {
+        final Xtory story = new XtSticky(new XtYaml("test"));
+        MatcherAssert.assertThat(
+            Collections.singletonList("1"),
+            Matchers.hasItem(story.map().get("line").toString())
         );
     }
 }


### PR DESCRIPTION
Add test that proves that we fixed handling of unresolved symbol types in Hamcrest assertion parsing.

Fixes #563