### PR TITLE
ci(#738): upgrade Java version to 17 in codecov workflow

### DIFF
--- a/.github/workflows/codecov.yaml
+++ b/.github/workflows/codecov.yaml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
-          java-version: 11
+          java-version: 17
       - uses: actions/cache@v6
         with:
           path: ~/.m2/repository


### PR DESCRIPTION
Upgrade Java version in `codecov` workflow from 11 to 17 to meet the minimum requirement of `qulice-maven-plugin:0.25.0`.

Fixes #738